### PR TITLE
Admin Endpoints Oauth for Admin interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,13 @@ test-state.json
 docs/*-prompt.md
 .github/*-instructions.md
 
+# Local planning / design work-package artifacts (not committed)
+plans/
+docs/design/service-auth-client.md
+docs/design/service-auth-client-work-packages.md
+docs/design/service-auth-inter-service.md
+docs/design/service-auth-inter-service-work-packages.md
+
 # CDK
 docs/.vitepress/cache
 /webapp/public/client-metadata.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,7 +122,7 @@ stratos-service/src/features/{feature}/
 | --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `api/`          | XRPC handlers: `records.ts` (CRUD), `handlers.ts` (getRecord, getRepo, importRepo)                                                                        |
 | `auth/`         | DPoP verification (`dpop-verifier.ts`), token introspection (`introspection-client.ts`), auth verifier (`verifier.ts`), enrollment auth (`enrollment.ts`) |
-| `oauth/`        | OAuth client (`client.ts`), authorization routes (`routes.ts`)                                                                                            |
+| `oauth/`        | OAuth client (`client.ts`), enrollment authorization routes (`routes.ts`), admin authorization routes (`admin-routes.ts`), admin web-session store (`admin-session-store.ts`), admin flow handlers (`handlers/admin-authorize.ts`, `handlers/admin-callback.ts`) |
 | `subscription/` | WebSocket firehose (`subscribe-records.ts`) for Stratos sync consumers                                                                                    |
 | `blobstore/`    | Blob storage backends: disk (`disk.ts`), S3 (`s3.ts`)                                                                                                     |
 | `adapters/`     | Storage backend implementations: `sqlite/`, `postgres/`                                                                                                   |
@@ -267,7 +267,38 @@ definitions in `stratos-core/src/db/schema/` and Postgres-specific tables in
 Follow the pattern in `stratos-service/src/api/records.ts` for handler structure.
 
 Auth verifier options: `ctx.authVerifier.standard` (OAuth), `.optionalStandard`, `.service` (
-inter-service JWT), `.admin` (basic/bearer).
+inter-service JWT), `.admin` (OAuth-authorized operator via server-side session cookie; see Admin
+Authorization below).
+
+---
+
+## Admin Authorization
+
+Admin access is OAuth-only — there is no shared admin password. An operator logs in through the
+normal ATProto OAuth flow with identity-only scope (`OAUTH_ADMIN_SCOPE = 'atproto'`, no repo
+writes), and their DID must appear on the `STRATOS_ADMIN_DIDS` allowlist (comma-separated env var,
+parsed into `config.adminDids`).
+
+**Flow** (routes in `stratos-service/src/oauth/admin-routes.ts`, mounted at `/admin/oauth`):
+
+| Route                    | Handler                                  | Purpose                                                              |
+| ------------------------ | ---------------------------------------- | ------------------------------------------------------------------- |
+| `GET /admin/oauth/authorize` | `handlers/admin-authorize.ts`        | Starts OAuth; pins `redirect_uri` to the admin callback             |
+| `GET /admin/oauth/callback`  | `handlers/admin-callback.ts`         | Token exchange, allowlist check, establishes web session            |
+| `GET /admin/whoami`          | inline in `admin-routes.ts`          | Returns `{ did, isAdmin }` for the active session, else 401         |
+| `POST /admin/oauth/logout`   | inline in `admin-routes.ts`          | Deletes the session and clears the cookie                           |
+
+**Session model**: the callback enforces the allowlist (revoking the OAuth session and returning
+`403 NotAdmin` on a miss), then mints an opaque server-side session via `AdminSessionStore`
+(`admin-session-store.ts`; `SqliteAdminSessionStore` / `PgAdminSessionStore`). The only value placed
+in the `stratos_admin_session` HttpOnly cookie is a 32-byte random key — the DID and expiry live in
+the `admin_session` table. Sessions expire after `ADMIN_SESSION_TTL_MS` (12 hours) and are deleted on
+read once expired.
+
+**Request-time verification**: the `.admin` XRPC verifier (`createAdminVerifier` in
+`infra/auth/verifiers.ts`) reads the cookie at the raw `IncomingMessage` level, requires a valid
+unexpired session whose DID is still on the allowlist, and applies a CSRF origin check
+(cross-origin requests are rejected). On success it yields `{ type: 'admin', did }`.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,14 +118,14 @@ stratos-service/src/features/{feature}/
 
 **Service infrastructure** (`stratos-service/src/`):
 
-| Module          | Description                                                                                                                                               |
-| --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `api/`          | XRPC handlers: `records.ts` (CRUD), `handlers.ts` (getRecord, getRepo, importRepo)                                                                        |
-| `auth/`         | DPoP verification (`dpop-verifier.ts`), token introspection (`introspection-client.ts`), auth verifier (`verifier.ts`), enrollment auth (`enrollment.ts`) |
+| Module          | Description                                                                                                                                                                                                                                                      |
+| --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `api/`          | XRPC handlers: `records.ts` (CRUD), `handlers.ts` (getRecord, getRepo, importRepo)                                                                                                                                                                               |
+| `auth/`         | DPoP verification (`dpop-verifier.ts`), token introspection (`introspection-client.ts`), auth verifier (`verifier.ts`), enrollment auth (`enrollment.ts`)                                                                                                        |
 | `oauth/`        | OAuth client (`client.ts`), enrollment authorization routes (`routes.ts`), admin authorization routes (`admin-routes.ts`), admin web-session store (`admin-session-store.ts`), admin flow handlers (`handlers/admin-authorize.ts`, `handlers/admin-callback.ts`) |
-| `subscription/` | WebSocket firehose (`subscribe-records.ts`) for Stratos sync consumers                                                                                    |
-| `blobstore/`    | Blob storage backends: disk (`disk.ts`), S3 (`s3.ts`)                                                                                                     |
-| `adapters/`     | Storage backend implementations: `sqlite/`, `postgres/`                                                                                                   |
+| `subscription/` | WebSocket firehose (`subscribe-records.ts`) for Stratos sync consumers                                                                                                                                                                                           |
+| `blobstore/`    | Blob storage backends: disk (`disk.ts`), S3 (`s3.ts`)                                                                                                                                                                                                            |
+| `adapters/`     | Storage backend implementations: `sqlite/`, `postgres/`                                                                                                                                                                                                          |
 
 **Client library** (`stratos-client/src/`):
 
@@ -281,12 +281,12 @@ parsed into `config.adminDids`).
 
 **Flow** (routes in `stratos-service/src/oauth/admin-routes.ts`, mounted at `/admin/oauth`):
 
-| Route                    | Handler                                  | Purpose                                                              |
-| ------------------------ | ---------------------------------------- | ------------------------------------------------------------------- |
-| `GET /admin/oauth/authorize` | `handlers/admin-authorize.ts`        | Starts OAuth; pins `redirect_uri` to the admin callback             |
-| `GET /admin/oauth/callback`  | `handlers/admin-callback.ts`         | Token exchange, allowlist check, establishes web session            |
-| `GET /admin/whoami`          | inline in `admin-routes.ts`          | Returns `{ did, isAdmin }` for the active session, else 401         |
-| `POST /admin/oauth/logout`   | inline in `admin-routes.ts`          | Deletes the session and clears the cookie                           |
+| Route                        | Handler                       | Purpose                                                     |
+| ---------------------------- | ----------------------------- | ----------------------------------------------------------- |
+| `GET /admin/oauth/authorize` | `handlers/admin-authorize.ts` | Starts OAuth; pins `redirect_uri` to the admin callback     |
+| `GET /admin/oauth/callback`  | `handlers/admin-callback.ts`  | Token exchange, allowlist check, establishes web session    |
+| `GET /admin/whoami`          | inline in `admin-routes.ts`   | Returns `{ did, isAdmin }` for the active session, else 401 |
+| `POST /admin/oauth/logout`   | inline in `admin-routes.ts`   | Deletes the session and clears the cookie                   |
 
 **Session model**: the callback enforces the allowlist (revoking the OAuth session and returning
 `403 NotAdmin` on a miss), then mints an opaque server-side session via `AdminSessionStore`

--- a/stratos-core/src/lexicons/atproto.ts
+++ b/stratos-core/src/lexicons/atproto.ts
@@ -56,6 +56,22 @@ export const atprotoLexicons: LexiconDoc[] = [
             },
           },
         },
+        output: {
+          encoding: 'application/json',
+          schema: {
+            type: 'object',
+            properties: {
+              commit: {
+                type: 'object',
+                required: ['cid', 'rev'],
+                properties: {
+                  cid: { type: 'string' },
+                  rev: { type: 'string' },
+                },
+              },
+            },
+          },
+        },
       },
     },
   },

--- a/stratos-service/src/config.ts
+++ b/stratos-service/src/config.ts
@@ -569,6 +569,45 @@ export function isAllowedCredentialedOrigin(
 }
 
 /**
+ * CSRF defense for cookie-authenticated admin requests.
+ *
+ * The primary CSRF gate is the admin session cookie's `SameSite=Strict`
+ * attribute: a forged cross-site request never carries the cookie, so it fails
+ * the downstream session check regardless of this function. This Origin/Referer
+ * screen is defense in depth on top of that — a same-site sub-origin or a
+ * SameSite-relaxing proxy is still rejected here unless it resolves to an
+ * allowlisted credentialed origin.
+ *
+ * Requests with no Origin and no Referer (e.g. same-origin server-to-server
+ * admin tooling) are allowed through: a browser cross-site POST always carries
+ * an `Origin`, so the no-header case cannot be a browser-driven forgery, and the
+ * SameSite cookie remains the gate. Blocking it would break legitimate
+ * non-browser admin callers for no security gain.
+ *
+ * @returns true if the request may proceed past CSRF screening
+ */
+export function passesAdminCsrfCheck(
+  req: import('node:http').IncomingMessage,
+  config: { publicUrl: string; devMode: boolean },
+): boolean {
+  const origin = req.headers?.origin
+  if (origin) {
+    return isAllowedCredentialedOrigin(origin, config)
+  }
+
+  const referer = req.headers?.referer
+  if (referer) {
+    try {
+      return isAllowedCredentialedOrigin(new URL(referer).origin, config)
+    } catch {
+      return false
+    }
+  }
+
+  return true
+}
+
+/**
  * Get the full service DID with fragment for use in source.service field
  * @example "did:plc:abc123#atproto_pns"
  *

--- a/stratos-service/src/config.ts
+++ b/stratos-service/src/config.ts
@@ -119,8 +119,8 @@ const envSchema = z
     // PLC directory
     STRATOS_PLC_URL: z.string().url().default('https://plc.directory'),
 
-    // Admin auth (optional)
-    STRATOS_ADMIN_PASSWORD: z.string().optional(),
+    // Admin auth: comma-separated list of admin DIDs (OAuth-authorized operators)
+    STRATOS_ADMIN_DIDS: z.string().optional(),
     // External allowlist (optional)
     STRATOS_ALLOW_LIST_URI: z.string().url().optional(),
     STRATOS_VALKEY_URL: z.string().url().optional(),
@@ -250,9 +250,7 @@ export interface StratosServiceConfig {
   logging: {
     level: string
   }
-  admin?: {
-    password: string
-  }
+  adminDids: string[]
   dpop: {
     requireNonce: boolean
   }
@@ -512,11 +510,10 @@ export function envToConfig(env: Env): StratosServiceConfig {
     logging: {
       level: env.LOG_LEVEL,
     },
-    admin: env.STRATOS_ADMIN_PASSWORD
-      ? {
-          password: env.STRATOS_ADMIN_PASSWORD,
-        }
-      : undefined,
+    adminDids: (env.STRATOS_ADMIN_DIDS ?? '')
+      .split(',')
+      .map((d) => d.trim())
+      .filter((d) => d.length > 0),
     dpop: {
       requireNonce: env.STRATOS_DPOP_REQUIRE_NONCE,
     },
@@ -525,6 +522,50 @@ export function envToConfig(env: Env): StratosServiceConfig {
       operatorContact: env.STRATOS_OPERATOR_CONTACT,
     },
   }
+}
+
+/**
+ * Determine whether a request Origin may receive credentialed
+ * (cookie-bearing) CORS responses.
+ *
+ * Reflected-origin + credentials is unsafe once an admin session cookie
+ * exists: any site could ride the session. Only the service's own origin
+ * (where the admin UI is served same-origin) and, in dev mode, loopback
+ * origins are trusted with credentials. The DPoP/XRPC surface does not rely
+ * on cookies and is handled separately (non-credentialed, any origin).
+ *
+ * @param origin - The request `Origin` header value (may be undefined)
+ * @param config - Service public URL and dev-mode flag
+ * @returns true if the origin may receive credentialed responses
+ */
+export function isAllowedCredentialedOrigin(
+  origin: string | undefined,
+  config: { publicUrl: string; devMode: boolean },
+): boolean {
+  if (!origin) return false
+
+  let originUrl: URL
+  try {
+    originUrl = new URL(origin)
+  } catch {
+    return false
+  }
+
+  try {
+    const serviceUrl = new URL(config.publicUrl)
+    if (originUrl.origin === serviceUrl.origin) return true
+  } catch {
+    // publicUrl unparseable; fall through to dev check
+  }
+
+  if (config.devMode) {
+    const host = originUrl.hostname
+    if (host === 'localhost' || host === '127.0.0.1' || host === '::1') {
+      return true
+    }
+  }
+
+  return false
 }
 
 /**

--- a/stratos-service/src/context-types.ts
+++ b/stratos-service/src/context-types.ts
@@ -56,6 +56,7 @@ export interface StorageContext {
     sessionStore: import('./oauth/client.js').OAuthSessionStoreBackend
     stateStore: import('./oauth/client.js').OAuthStateStoreBackend
   }
+  adminSessionStore: import('./oauth/admin-session-store.js').AdminSessionStore
 }
 
 /**

--- a/stratos-service/src/context.ts
+++ b/stratos-service/src/context.ts
@@ -218,7 +218,7 @@ async function initCoreServices(
   sequenceEvents: SequenceEventEmitter,
   logger?: Logger,
 ) {
-  const { enrollmentStore, actorStore } = storage
+  const { enrollmentStore, actorStore, adminSessionStore } = storage
   const { idResolver, signingKey, oauthClient } = identity
 
   const enrollmentCtx = await initEnrollment(
@@ -234,9 +234,8 @@ async function initCoreServices(
   const { dpopVerifier, authVerifier, lexiconProvider, xrpcServer } = initAuth(
     cfg,
     idResolver,
-    oauthClient,
     enrollmentStore,
-    enrollmentCtx.enrollmentValidator,
+    adminSessionStore,
     enrollmentCtx.allowListProvider,
     logger,
   )
@@ -321,8 +320,8 @@ async function initIdentity(
  * Initializes authentication components for the application context.
  * @param cfg - Configuration options for the application.
  * @param idResolver - Identity resolver for user authentication.
- * @param oauthClient - OAuth client context for token management.
  * @param enrollmentStore - Store for managing user enrollments.
+ * @param adminSessionStore - Admin web-session store.
  * @param allowListProvider - Optional provider for external allowlists.
  * @param logger - Logger instance for logging application events.
  * @returns Initialized authentication components.
@@ -330,9 +329,8 @@ async function initIdentity(
 function initAuth(
   cfg: AppContextOptions['cfg'],
   idResolver: AppContext['idResolver'],
-  oauthClient: AppContext['oauthClient'],
   enrollmentStore: AppContext['enrollmentStore'],
-  enrollmentValidator: AppContext['enrollmentValidator'],
+  adminSessionStore: AppContext['adminSessionStore'],
   allowListProvider?: ExternalAllowListProvider,
   logger?: AppContext['logger'],
 ) {
@@ -349,10 +347,10 @@ function initAuth(
   const authVerifier = createAuthVerifiers(
     cfg.service.did,
     idResolver,
-    oauthClient,
     cfg,
     enrollmentStore,
-    cfg.admin?.password,
+    adminSessionStore,
+    cfg.adminDids,
     dpopVerifier,
     allowListProvider,
     cfg.stratos.devMode === true,

--- a/stratos-service/src/db/index.ts
+++ b/stratos-service/src/db/index.ts
@@ -6,6 +6,7 @@ import * as schema from './schema.js'
 export {
   oauthSession,
   oauthState,
+  adminSession,
   enrollment,
   enrollmentBoundary,
 } from './schema.js'
@@ -14,6 +15,8 @@ export type {
   NewOAuthSession,
   OAuthState,
   NewOAuthState,
+  AdminSession,
+  NewAdminSession,
   Enrollment,
   NewEnrollment,
   EnrollmentBoundary,
@@ -60,6 +63,15 @@ export async function migrateServiceDb(db: ServiceDb): Promise<void> {
       key TEXT PRIMARY KEY,
       state TEXT NOT NULL,
       createdAt TEXT NOT NULL
+    )
+  `)
+
+  await db.run(sql`
+    CREATE TABLE IF NOT EXISTS admin_session (
+      key TEXT PRIMARY KEY,
+      did TEXT NOT NULL,
+      createdAt TEXT NOT NULL,
+      expiresAt TEXT NOT NULL
     )
   `)
 

--- a/stratos-service/src/db/pg-schema.ts
+++ b/stratos-service/src/db/pg-schema.ts
@@ -13,6 +13,13 @@ export const pgOauthState = pgTable('oauth_state', {
   createdAt: text('createdAt').notNull(),
 })
 
+export const pgAdminSession = pgTable('admin_session', {
+  key: text('key').primaryKey(),
+  did: text('did').notNull(),
+  createdAt: text('createdAt').notNull(),
+  expiresAt: text('expiresAt').notNull(),
+})
+
 export const pgEnrollment = pgTable('enrollment', {
   did: text('did').primaryKey(),
   enrolledAt: text('enrolledAt').notNull(),
@@ -39,6 +46,8 @@ export type PgOAuthSession = typeof pgOauthSession.$inferSelect
 export type PgNewOAuthSession = typeof pgOauthSession.$inferInsert
 export type PgOAuthState = typeof pgOauthState.$inferSelect
 export type PgNewOAuthState = typeof pgOauthState.$inferInsert
+export type PgAdminSession = typeof pgAdminSession.$inferSelect
+export type PgNewAdminSession = typeof pgAdminSession.$inferInsert
 export type PgEnrollment = typeof pgEnrollment.$inferSelect
 export type PgNewEnrollment = typeof pgEnrollment.$inferInsert
 export type PgEnrollmentBoundary = typeof pgEnrollmentBoundary.$inferSelect

--- a/stratos-service/src/db/pg.ts
+++ b/stratos-service/src/db/pg.ts
@@ -226,6 +226,19 @@ export async function migrateServicePgDb(db: ServicePgDb): Promise<void> {
 
   await executeMigrationStep(
     db,
+    'admin_session',
+    sql`
+      CREATE TABLE IF NOT EXISTS "admin_session" (
+        "key" TEXT PRIMARY KEY,
+        "did" TEXT NOT NULL,
+        "createdAt" TEXT NOT NULL,
+        "expiresAt" TEXT NOT NULL
+      )
+    `,
+  )
+
+  await executeMigrationStep(
+    db,
     'enrollment',
     sql`
       CREATE TABLE IF NOT EXISTS "enrollment" (

--- a/stratos-service/src/db/schema.ts
+++ b/stratos-service/src/db/schema.ts
@@ -26,6 +26,17 @@ export const oauthState = sqliteTable('oauth_state', {
 })
 
 /**
+ * Admin session storage - server-side sessions for OAuth-authorized admins.
+ * The cookie holds only the opaque `key`; the OAuth token never leaves the DB.
+ */
+export const adminSession = sqliteTable('admin_session', {
+  key: text('key').primaryKey(),
+  did: text('did').notNull(),
+  createdAt: text('createdAt').notNull(),
+  expiresAt: text('expiresAt').notNull(),
+})
+
+/**
  * Enrollment storage - tracks enrolled users
  */
 export const enrollment = sqliteTable('enrollment', {
@@ -57,6 +68,8 @@ export type OAuthSession = typeof oauthSession.$inferSelect
 export type NewOAuthSession = typeof oauthSession.$inferInsert
 export type OAuthState = typeof oauthState.$inferSelect
 export type NewOAuthState = typeof oauthState.$inferInsert
+export type AdminSession = typeof adminSession.$inferSelect
+export type NewAdminSession = typeof adminSession.$inferInsert
 export type Enrollment = typeof enrollment.$inferSelect
 export type NewEnrollment = typeof enrollment.$inferInsert
 export type EnrollmentBoundary = typeof enrollmentBoundary.$inferSelect

--- a/stratos-service/src/features/enrollment/handler.ts
+++ b/stratos-service/src/features/enrollment/handler.ts
@@ -1,4 +1,4 @@
-import { type Request, type Response } from 'express'
+import express, { type Request, type Response } from 'express'
 import { Agent } from '@atproto/api'
 import { InvalidRequestError, Server as XrpcServer } from '@atproto/xrpc-server'
 import { type Enrollment } from '@northskysocial/stratos-core'
@@ -266,15 +266,26 @@ function registerAdminBoundaryHandlers(ctx: AppContext): void {
 }
 
 /**
+ * JSON body parser for the admin boundary routes. The global parser in
+ * index.ts skips every `/xrpc/` path (xrpc-server parses those), but these
+ * admin routes are raw express handlers registered under `/xrpc/`, so they
+ * must parse their own JSON body or `req.body` is undefined.
+ */
+const adminJsonParser = express.json({ limit: '100kb' })
+
+/**
  * Register handler for adding a boundary
  * @param ctx - Application context
  */
 function registerAddBoundaryHandler(ctx: AppContext): void {
   ctx.app.post(
     '/xrpc/zone.stratos.admin.addBoundary',
+    adminJsonParser,
     async (req: Request, res: Response) => {
+      let adminDid: string
       try {
-        await ctx.authVerifier.admin({ req, res })
+        const auth = await ctx.authVerifier.admin({ req, res })
+        adminDid = auth.credentials.did
       } catch {
         return res
           .status(401)
@@ -322,7 +333,10 @@ function registerAddBoundaryHandler(ctx: AppContext): void {
           )
         }
 
-        ctx.logger?.info({ did, boundary }, 'admin added boundary')
+        ctx.logger?.info(
+          { adminDid, targetDid: did, boundary },
+          'admin added boundary',
+        )
         res.json({ did, boundaries })
       } catch (err) {
         ctx.logger?.error(
@@ -346,9 +360,12 @@ function registerRemoveBoundaryHandler(ctx: AppContext): void {
   // POST /xrpc/zone.stratos.admin.removeBoundary
   ctx.app.post(
     '/xrpc/zone.stratos.admin.removeBoundary',
+    adminJsonParser,
     async (req: Request, res: Response) => {
+      let adminDid: string
       try {
-        await ctx.authVerifier.admin({ req, res })
+        const auth = await ctx.authVerifier.admin({ req, res })
+        adminDid = auth.credentials.did
       } catch {
         return res
           .status(401)
@@ -388,7 +405,10 @@ function registerRemoveBoundaryHandler(ctx: AppContext): void {
           )
         }
 
-        ctx.logger?.info({ did, boundary }, 'admin removed boundary')
+        ctx.logger?.info(
+          { adminDid, targetDid: did, boundary },
+          'admin removed boundary',
+        )
         res.json({ did, boundaries })
       } catch (err) {
         ctx.logger?.error(
@@ -411,9 +431,12 @@ function registerRemoveBoundaryHandler(ctx: AppContext): void {
 function registerSetBoundariesHandler(ctx: AppContext): void {
   ctx.app.post(
     '/xrpc/zone.stratos.admin.setBoundaries',
+    adminJsonParser,
     async (req: Request, res: Response) => {
+      let adminDid: string
       try {
-        await ctx.authVerifier.admin({ req, res })
+        const auth = await ctx.authVerifier.admin({ req, res })
+        adminDid = auth.credentials.did
       } catch {
         return res
           .status(401)
@@ -462,7 +485,7 @@ function registerSetBoundariesHandler(ctx: AppContext): void {
         }
 
         ctx.logger?.info(
-          { did, boundaryCount: boundaries.length },
+          { adminDid, targetDid: did, boundaryCount: boundaries.length },
           'admin set boundaries',
         )
         res.json({ did, boundaries })

--- a/stratos-service/src/features/enrollment/handler.ts
+++ b/stratos-service/src/features/enrollment/handler.ts
@@ -324,9 +324,11 @@ function registerAddBoundaryHandler(ctx: AppContext): void {
         await ctx.enrollmentStore.addBoundary(did, boundary)
         const boundaries = await ctx.enrollmentStore.getBoundaries(did)
 
+        let pdsSync: 'ok' | 'failed' = 'ok'
         try {
           await updatePdsEnrollmentRecord(ctx, did, boundaries)
         } catch (err) {
+          pdsSync = 'failed'
           ctx.logger?.warn(
             { err: err instanceof Error ? err.message : String(err), did },
             'failed to update PDS enrollment record after addBoundary',
@@ -334,10 +336,10 @@ function registerAddBoundaryHandler(ctx: AppContext): void {
         }
 
         ctx.logger?.info(
-          { adminDid, targetDid: did, boundary },
+          { adminDid, targetDid: did, boundary, pdsSync },
           'admin added boundary',
         )
-        res.json({ did, boundaries })
+        res.json({ did, boundaries, pdsSync })
       } catch (err) {
         ctx.logger?.error(
           { err: err instanceof Error ? err.message : String(err) },
@@ -396,9 +398,11 @@ function registerRemoveBoundaryHandler(ctx: AppContext): void {
         await ctx.enrollmentStore.removeBoundary(did, boundary)
         const boundaries = await ctx.enrollmentStore.getBoundaries(did)
 
+        let pdsSync: 'ok' | 'failed' = 'ok'
         try {
           await updatePdsEnrollmentRecord(ctx, did, boundaries)
         } catch (err) {
+          pdsSync = 'failed'
           ctx.logger?.warn(
             { err: err instanceof Error ? err.message : String(err), did },
             'failed to update PDS enrollment record after removeBoundary',
@@ -406,10 +410,10 @@ function registerRemoveBoundaryHandler(ctx: AppContext): void {
         }
 
         ctx.logger?.info(
-          { adminDid, targetDid: did, boundary },
+          { adminDid, targetDid: did, boundary, pdsSync },
           'admin removed boundary',
         )
-        res.json({ did, boundaries })
+        res.json({ did, boundaries, pdsSync })
       } catch (err) {
         ctx.logger?.error(
           { err: err instanceof Error ? err.message : String(err) },
@@ -475,9 +479,11 @@ function registerSetBoundariesHandler(ctx: AppContext): void {
 
         await ctx.enrollmentStore.setBoundaries(did, boundaries)
 
+        let pdsSync: 'ok' | 'failed' = 'ok'
         try {
           await updatePdsEnrollmentRecord(ctx, did, boundaries)
         } catch (err) {
+          pdsSync = 'failed'
           ctx.logger?.warn(
             { err: err instanceof Error ? err.message : String(err), did },
             'failed to update PDS enrollment record after setBoundaries',
@@ -485,10 +491,15 @@ function registerSetBoundariesHandler(ctx: AppContext): void {
         }
 
         ctx.logger?.info(
-          { adminDid, targetDid: did, boundaryCount: boundaries.length },
+          {
+            adminDid,
+            targetDid: did,
+            boundaryCount: boundaries.length,
+            pdsSync,
+          },
           'admin set boundaries',
         )
-        res.json({ did, boundaries })
+        res.json({ did, boundaries, pdsSync })
       } catch (err) {
         ctx.logger?.error(
           { err: err instanceof Error ? err.message : String(err) },

--- a/stratos-service/src/index.ts
+++ b/stratos-service/src/index.ts
@@ -16,10 +16,15 @@ import {
   destroyAppContext,
 } from './context.js'
 import { createLogger } from './logger.js'
-import { envToConfig, parseEnv, type StratosServiceConfig } from './config.js'
+import {
+  envToConfig,
+  isAllowedCredentialedOrigin,
+  parseEnv,
+  type StratosServiceConfig,
+} from './config.js'
 import { registerHandlers } from './api'
 import { registerSubscribeRecords } from './subscription'
-import { createOAuthRoutes } from './oauth'
+import { createAdminAuthRoutes, createOAuthRoutes } from './oauth'
 import { DiskBlobStore, S3BlobStoreAdapter } from './infra/blobstore'
 import { signAndPersistCommit, StratosBlockStoreReader } from './features'
 import { reconcileServiceEnrollments } from './features/enrollment'
@@ -96,24 +101,35 @@ export class StratosServer {
     })
 
     app.use(
-      cors({
-        origin: true,
-        methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS', 'HEAD'],
-        allowedHeaders: [
-          'Authorization',
-          'Content-Type',
-          'DPoP',
-          'DPoP-Nonce',
-          'x-trace-id',
-          'atproto-accept-labelers',
-          'atproto-proxy-type',
-          'ngrok-skip-browser-warning',
-        ],
-        exposedHeaders: ['DPoP-Nonce', 'WWW-Authenticate', 'x-trace-id'],
-        credentials: true,
-        maxAge: 86400,
-        preflightContinue: false,
-        optionsSuccessStatus: 204,
+      cors((req: express.Request, callback) => {
+        const origin = req.headers.origin
+        const credentialed = isAllowedCredentialedOrigin(origin, {
+          publicUrl: ctx.cfg.service.publicUrl,
+          devMode: ctx.cfg.stratos.devMode === true,
+        })
+        callback(null, {
+          // Reflect the request origin for the non-credentialed DPoP/XRPC
+          // surface; only allowlisted origins additionally receive
+          // `Access-Control-Allow-Credentials`, so no untrusted site can ride
+          // the admin session cookie.
+          origin: true,
+          methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS', 'HEAD'],
+          allowedHeaders: [
+            'Authorization',
+            'Content-Type',
+            'DPoP',
+            'DPoP-Nonce',
+            'x-trace-id',
+            'atproto-accept-labelers',
+            'atproto-proxy-type',
+            'ngrok-skip-browser-warning',
+          ],
+          exposedHeaders: ['DPoP-Nonce', 'WWW-Authenticate', 'x-trace-id'],
+          credentials: credentialed,
+          maxAge: 86400,
+          preflightContinue: false,
+          optionsSuccessStatus: 204,
+        })
       }),
     )
     app.use(cookieParser())
@@ -163,6 +179,7 @@ export class StratosServer {
     this.registerWellKnownRoutes(app, ctx, cfg)
     this.registerStaticRoutes(app, cfg)
     this.registerOAuthRoutes(app, ctx, cfg)
+    this.registerAdminAuthRoutes(app, ctx, cfg)
     this.registerFeatureHandlers(app, ctx)
     this.registerErrorMiddleware(app, ctx, cfg)
   }
@@ -355,6 +372,29 @@ export class StratosServer {
       createAttestation: ctx.createAttestation,
     })
     app.use('/oauth', oauthRoutes)
+  }
+
+  /**
+   * Register admin OAuth authorization routes for the Stratos service.
+   * @param app - Express application instance
+   * @param ctx - Application context
+   * @param cfg - Stratos service configuration
+   * @private
+   */
+  private static registerAdminAuthRoutes(
+    app: express.Application,
+    ctx: AppContext,
+    cfg: StratosServiceConfig,
+  ) {
+    const adminRoutes = createAdminAuthRoutes({
+      oauthClient: ctx.oauthClient,
+      adminSessionStore: ctx.adminSessionStore,
+      adminDids: cfg.adminDids,
+      baseUrl: cfg.service.publicUrl,
+      devMode: cfg.stratos.devMode === true,
+      logger: ctx.logger,
+    })
+    app.use('/admin', adminRoutes)
   }
 
   /**

--- a/stratos-service/src/infra/auth/verifiers.ts
+++ b/stratos-service/src/infra/auth/verifiers.ts
@@ -1,6 +1,4 @@
-import { timingSafeEqual } from 'node:crypto'
 import { IdResolver } from '@atproto/identity'
-import { NodeOAuthClient } from '@atproto/oauth-client-node'
 import {
   AuthRequiredError,
   InvalidRequestError,
@@ -12,9 +10,14 @@ import {
   EnrollmentDeniedError,
   type Logger,
 } from '@northskysocial/stratos-core'
-import { StratosServiceConfig } from '../../config.js'
+import {
+  isAllowedCredentialedOrigin,
+  StratosServiceConfig,
+} from '../../config.js'
 import { ExternalAllowListProvider } from '../../features/enrollment/internal/allow-list.js'
 import { verifyEnrolled } from '../../features'
+import { ADMIN_SESSION_COOKIE } from '../../oauth/admin-routes.js'
+import type { AdminSessionStore } from '../../oauth/admin-session-store.js'
 
 /**
  * Auth verifier collection for different auth scenarios
@@ -32,37 +35,23 @@ export interface AuthVerifiers {
   optionalStandard: (
     ctx: import('@atproto/xrpc-server').MethodAuthContext,
   ) => Promise<{ credentials: { type: string; did?: string } }>
-  /** Admin auth (basic auth or bearer token with admin password) */
+  /** Admin auth (OAuth-authorized operator via server-side session cookie) */
   admin: (ctx: {
     req: import('node:http').IncomingMessage
     res: import('node:http').ServerResponse
-  }) => Promise<{ credentials: { type: string } }>
+  }) => Promise<{ credentials: { type: string; did: string } }>
   /** Stream auth for zone.stratos.sync.subscribeRecords */
   subscribeAuth: StreamAuthVerifier
-}
-
-/**
- * Timing-safe string comparison to prevent timing attacks on credentials
- */
-function safeEqual(a: string, b: string): boolean {
-  const bufA = Buffer.from(a, 'utf8')
-  const bufB = Buffer.from(b, 'utf8')
-  if (bufA.length !== bufB.length) {
-    // Compare against self to consume constant time, then return false
-    timingSafeEqual(bufA, bufA)
-    return false
-  }
-  return timingSafeEqual(bufA, bufB)
 }
 
 /**
  * Create auth verifiers for the application
  * @param serviceDid - Service DID
  * @param idResolver - Identity resolver
- * @param _oauthClient - OAuth client
  * @param cfg
  * @param enrollmentStore - Enrollment store
- * @param adminPassword - Admin password
+ * @param adminSessionStore - Admin web-session store
+ * @param adminDids - Allowlisted admin DIDs
  * @param dpopVerifier - DPoP verifier
  * @param allowListProvider - External allowlist provider
  * @param devMode - Development mode flag
@@ -72,10 +61,10 @@ function safeEqual(a: string, b: string): boolean {
 export function createAuthVerifiers(
   serviceDid: string,
   idResolver: IdResolver,
-  _oauthClient: NodeOAuthClient,
   cfg: StratosServiceConfig,
   enrollmentStore: import('@northskysocial/stratos-core').EnrollmentStoreReader,
-  adminPassword: string | undefined,
+  adminSessionStore: AdminSessionStore,
+  adminDids: string[],
   dpopVerifier: DpopVerifier,
   allowListProvider: ExternalAllowListProvider | undefined,
   devMode: boolean,
@@ -101,7 +90,13 @@ export function createAuthVerifiers(
       dpopVerifier,
       logger,
     }),
-    admin: createAdminVerifier(adminPassword),
+    admin: createAdminVerifier({
+      adminSessionStore,
+      adminDids,
+      publicUrl: cfg.service.publicUrl,
+      devMode,
+      logger,
+    }),
     subscribeAuth: createSubscribeAuthVerifier(idResolver, serviceDid),
   }
 }
@@ -372,37 +367,118 @@ async function verifyDpop(
 }
 
 /**
- * Creates the admin auth verifier (basic auth or bearer token)
+ * Reads the opaque admin session id from the request's Cookie header.
  *
- * @param adminPassword - Admin password for basic auth
- * @returns Auth verifier function
- * @throws AuthRequiredError if admin authorization fails
+ * The admin verifier runs at the raw `IncomingMessage` level (no Express
+ * cookie parsing), so the cookie is parsed directly here.
  */
-function createAdminVerifier(
-  adminPassword: string | undefined,
-): AuthVerifiers['admin'] {
+function readAdminSessionCookie(
+  req: import('node:http').IncomingMessage,
+): string | undefined {
+  const cookieHeader = req.headers?.cookie
+  if (!cookieHeader) return undefined
+  for (const part of cookieHeader.split(';')) {
+    const eq = part.indexOf('=')
+    if (eq === -1) continue
+    const name = part.slice(0, eq).trim()
+    if (name === ADMIN_SESSION_COOKIE) {
+      return decodeURIComponent(part.slice(eq + 1).trim())
+    }
+  }
+  return undefined
+}
+
+/**
+ * CSRF defense for cookie-authenticated admin requests.
+ *
+ * Cookie sessions are CSRF-susceptible in a way Bearer tokens were not, and
+ * `SameSite=Lax` does not cover same-site sub-origins or all request shapes.
+ * As defense in depth, the request's `Origin` (falling back to `Referer`)
+ * must resolve to an allowlisted credentialed origin. Same-origin admin UI
+ * requests (plan 004) pass; cross-site forged POSTs do not.
+ *
+ * Requests with no Origin/Referer at all (e.g. server-to-server tooling that
+ * also lacks a browser session cookie) are not blocked here — they simply
+ * won't carry the cookie and fail the session check instead.
+ *
+ * @returns true if the request may proceed past CSRF screening
+ */
+function passesAdminCsrfCheck(
+  req: import('node:http').IncomingMessage,
+  deps: { publicUrl: string; devMode: boolean },
+): boolean {
+  const origin = req.headers?.origin
+  if (origin) {
+    return isAllowedCredentialedOrigin(origin, deps)
+  }
+
+  const referer = req.headers?.referer
+  if (referer) {
+    try {
+      return isAllowedCredentialedOrigin(new URL(referer).origin, deps)
+    } catch {
+      return false
+    }
+  }
+
+  // No Origin and no Referer: nothing to forge against. The session-cookie
+  // check downstream is the real gate.
+  return true
+}
+
+/**
+ * Creates the admin auth verifier.
+ *
+ * Admin auth is OAuth-only: the operator must have an established server-side
+ * web session (set by the admin OAuth callback) whose DID is on the configured
+ * allowlist. There is no password and no `Bearer did:` dev bypass — the cookie
+ * is the only accepted credential. A CSRF Origin/Referer check guards the
+ * cookie-authenticated mutation path.
+ *
+ * @param deps - Admin session store, allowlist, origin config, and logger
+ * @returns Auth verifier function
+ * @throws AuthRequiredError if no valid admin session is present or CSRF fails
+ */
+function createAdminVerifier(deps: {
+  adminSessionStore: AdminSessionStore
+  adminDids: string[]
+  publicUrl: string
+  devMode: boolean
+  logger?: Logger
+}): AuthVerifiers['admin'] {
   return async (ctx) => {
-    const authHeader = ctx.req?.headers?.authorization
-    if (!authHeader || !adminPassword) {
+    if (
+      !passesAdminCsrfCheck(ctx.req, {
+        publicUrl: deps.publicUrl,
+        devMode: deps.devMode,
+      })
+    ) {
+      deps.logger?.warn(
+        { origin: ctx.req.headers?.origin },
+        'admin auth rejected: cross-origin request blocked (CSRF)',
+      )
+      throw new AuthRequiredError('Cross-origin admin request rejected')
+    }
+
+    const sessionKey = readAdminSessionCookie(ctx.req)
+    if (!sessionKey) {
       throw new AuthRequiredError('Admin authorization required')
     }
 
-    let passwordAttempt: string | undefined
-    if (authHeader.startsWith('Basic ')) {
-      const credentials = Buffer.from(authHeader.slice(6), 'base64').toString(
-        'utf8',
+    const session = await deps.adminSessionStore.get(sessionKey)
+    if (!session) {
+      throw new AuthRequiredError('Admin session invalid or expired')
+    }
+
+    if (!deps.adminDids.includes(session.did)) {
+      deps.logger?.warn(
+        { did: session.did },
+        'admin auth rejected: DID not in allowlist',
       )
-      const parts = credentials.split(':')
-      passwordAttempt = parts[1]
-    } else if (authHeader.startsWith('Bearer ')) {
-      passwordAttempt = authHeader.slice(7).trim()
+      throw new AuthRequiredError('Not an authorized admin')
     }
 
-    if (passwordAttempt && safeEqual(passwordAttempt, adminPassword)) {
-      return { credentials: { type: 'admin' } }
-    }
-
-    throw new AuthRequiredError('Invalid admin credentials')
+    return { credentials: { type: 'admin', did: session.did } }
   }
 }
 

--- a/stratos-service/src/infra/auth/verifiers.ts
+++ b/stratos-service/src/infra/auth/verifiers.ts
@@ -10,10 +10,7 @@ import {
   EnrollmentDeniedError,
   type Logger,
 } from '@northskysocial/stratos-core'
-import {
-  isAllowedCredentialedOrigin,
-  StratosServiceConfig,
-} from '../../config.js'
+import { passesAdminCsrfCheck, StratosServiceConfig } from '../../config.js'
 import { ExternalAllowListProvider } from '../../features/enrollment/internal/allow-list.js'
 import { verifyEnrolled } from '../../features'
 import { ADMIN_SESSION_COOKIE } from '../../oauth/admin-routes.js'
@@ -386,44 +383,6 @@ function readAdminSessionCookie(
     }
   }
   return undefined
-}
-
-/**
- * CSRF defense for cookie-authenticated admin requests.
- *
- * Cookie sessions are CSRF-susceptible in a way Bearer tokens were not, and
- * `SameSite=Lax` does not cover same-site sub-origins or all request shapes.
- * As defense in depth, the request's `Origin` (falling back to `Referer`)
- * must resolve to an allowlisted credentialed origin. Same-origin admin UI
- * requests (plan 004) pass; cross-site forged POSTs do not.
- *
- * Requests with no Origin/Referer at all (e.g. server-to-server tooling that
- * also lacks a browser session cookie) are not blocked here — they simply
- * won't carry the cookie and fail the session check instead.
- *
- * @returns true if the request may proceed past CSRF screening
- */
-function passesAdminCsrfCheck(
-  req: import('node:http').IncomingMessage,
-  deps: { publicUrl: string; devMode: boolean },
-): boolean {
-  const origin = req.headers?.origin
-  if (origin) {
-    return isAllowedCredentialedOrigin(origin, deps)
-  }
-
-  const referer = req.headers?.referer
-  if (referer) {
-    try {
-      return isAllowedCredentialedOrigin(new URL(referer).origin, deps)
-    } catch {
-      return false
-    }
-  }
-
-  // No Origin and no Referer: nothing to forge against. The session-cookie
-  // check downstream is the real gate.
-  return true
 }
 
 /**

--- a/stratos-service/src/infra/auth/verifiers.ts
+++ b/stratos-service/src/infra/auth/verifiers.ts
@@ -13,7 +13,7 @@ import {
 import { passesAdminCsrfCheck, StratosServiceConfig } from '../../config.js'
 import { ExternalAllowListProvider } from '../../features/enrollment/internal/allow-list.js'
 import { verifyEnrolled } from '../../features'
-import { ADMIN_SESSION_COOKIE } from '../../oauth/admin-routes.js'
+import { readAdminSessionCookie } from '../../oauth/admin-routes.js'
 import type { AdminSessionStore } from '../../oauth/admin-session-store.js'
 
 /**
@@ -361,28 +361,6 @@ async function verifyDpop(
     }
     return { credentials: { type: 'anonymous' } }
   }
-}
-
-/**
- * Reads the opaque admin session id from the request's Cookie header.
- *
- * The admin verifier runs at the raw `IncomingMessage` level (no Express
- * cookie parsing), so the cookie is parsed directly here.
- */
-function readAdminSessionCookie(
-  req: import('node:http').IncomingMessage,
-): string | undefined {
-  const cookieHeader = req.headers?.cookie
-  if (!cookieHeader) return undefined
-  for (const part of cookieHeader.split(';')) {
-    const eq = part.indexOf('=')
-    if (eq === -1) continue
-    const name = part.slice(0, eq).trim()
-    if (name === ADMIN_SESSION_COOKIE) {
-      return decodeURIComponent(part.slice(eq + 1).trim())
-    }
-  }
-  return undefined
 }
 
 /**

--- a/stratos-service/src/oauth/admin-routes.ts
+++ b/stratos-service/src/oauth/admin-routes.ts
@@ -2,6 +2,7 @@ import express from 'express'
 import type { NodeOAuthClient } from '@atproto/oauth-client-node'
 import type { Logger } from '@northskysocial/stratos-core'
 import type { AdminSessionStore } from './admin-session-store.js'
+import { passesAdminCsrfCheck } from '../config.js'
 import { handleAdminAuthorize } from './handlers/admin-authorize.js'
 import { handleAdminCallback } from './handlers/admin-callback.js'
 
@@ -59,6 +60,7 @@ export function createAdminAuthRoutes(
   const router = express.Router()
   const { adminSessionStore, baseUrl } = config
   const isSecure = baseUrl.startsWith('https://')
+  const csrfDeps = { publicUrl: baseUrl, devMode: config.devMode ?? false }
 
   router.get('/oauth/authorize', handleAdminAuthorize(config))
   router.get('/oauth/callback', handleAdminCallback(config))
@@ -75,6 +77,13 @@ export function createAdminAuthRoutes(
   })
 
   router.post('/oauth/logout', async (req, res) => {
+    if (!passesAdminCsrfCheck(req, csrfDeps)) {
+      return res.status(403).json({
+        error: 'Forbidden',
+        message: 'Cross-origin admin request rejected',
+      })
+    }
+
     const cookies = (req as unknown as { cookies?: Record<string, string> })
       .cookies
     const sessionKey = cookies?.[ADMIN_SESSION_COOKIE]
@@ -84,7 +93,7 @@ export function createAdminAuthRoutes(
     res.clearCookie(ADMIN_SESSION_COOKIE, {
       httpOnly: true,
       secure: isSecure,
-      sameSite: 'lax',
+      sameSite: 'strict',
       path: '/',
     })
     res.json({ success: true })

--- a/stratos-service/src/oauth/admin-routes.ts
+++ b/stratos-service/src/oauth/admin-routes.ts
@@ -13,6 +13,33 @@ import { handleAdminCallback } from './handlers/admin-callback.js'
 export const ADMIN_SESSION_COOKIE = 'stratos_admin_session'
 
 /**
+ * Read the opaque admin session id straight from the request's `Cookie`
+ * header.
+ *
+ * This deliberately parses the raw header rather than reading `req.cookies`.
+ * The latter only exists after the `cookie-parser` middleware has run; a
+ * reordering would make `req.cookies` `undefined` and silently log every admin
+ * out (the failure the type cast masked). Reading the header directly has no
+ * such ordering dependency, and the same accessor serves both the Express
+ * routes here and the raw `IncomingMessage` admin auth verifier.
+ */
+export function readAdminSessionCookie(
+  req: import('node:http').IncomingMessage,
+): string | undefined {
+  const cookieHeader = req.headers?.cookie
+  if (!cookieHeader) return undefined
+  for (const part of cookieHeader.split(';')) {
+    const eq = part.indexOf('=')
+    if (eq === -1) continue
+    const name = part.slice(0, eq).trim()
+    if (name === ADMIN_SESSION_COOKIE) {
+      return decodeURIComponent(part.slice(eq + 1).trim())
+    }
+  }
+  return undefined
+}
+
+/**
  * Lifetime of an admin web session.
  */
 export const ADMIN_SESSION_TTL_MS = 12 * 60 * 60 * 1000
@@ -37,9 +64,7 @@ export async function resolveAdminSession(
   req: express.Request,
   config: Pick<AdminAuthRoutesConfig, 'adminSessionStore' | 'adminDids'>,
 ): Promise<string | null> {
-  const cookies = (req as unknown as { cookies?: Record<string, string> })
-    .cookies
-  const sessionKey = cookies?.[ADMIN_SESSION_COOKIE]
+  const sessionKey = readAdminSessionCookie(req)
   if (!sessionKey) return null
 
   const session = await config.adminSessionStore.get(sessionKey)
@@ -66,6 +91,13 @@ export function createAdminAuthRoutes(
   router.get('/oauth/callback', handleAdminCallback(config))
 
   router.get('/whoami', async (req, res) => {
+    if (!passesAdminCsrfCheck(req, csrfDeps)) {
+      return res.status(403).json({
+        error: 'Forbidden',
+        message: 'Cross-origin admin request rejected',
+      })
+    }
+
     const did = await resolveAdminSession(req, config)
     if (!did) {
       return res.status(401).json({
@@ -84,9 +116,7 @@ export function createAdminAuthRoutes(
       })
     }
 
-    const cookies = (req as unknown as { cookies?: Record<string, string> })
-      .cookies
-    const sessionKey = cookies?.[ADMIN_SESSION_COOKIE]
+    const sessionKey = readAdminSessionCookie(req)
     if (sessionKey) {
       await adminSessionStore.del(sessionKey)
     }

--- a/stratos-service/src/oauth/admin-routes.ts
+++ b/stratos-service/src/oauth/admin-routes.ts
@@ -1,0 +1,94 @@
+import express from 'express'
+import type { NodeOAuthClient } from '@atproto/oauth-client-node'
+import type { Logger } from '@northskysocial/stratos-core'
+import type { AdminSessionStore } from './admin-session-store.js'
+import { handleAdminAuthorize } from './handlers/admin-authorize.js'
+import { handleAdminCallback } from './handlers/admin-callback.js'
+
+/**
+ * Name of the cookie holding the opaque admin web-session id. The cookie never
+ * carries the OAuth token — only the server-side session lookup key.
+ */
+export const ADMIN_SESSION_COOKIE = 'stratos_admin_session'
+
+/**
+ * Lifetime of an admin web session.
+ */
+export const ADMIN_SESSION_TTL_MS = 12 * 60 * 60 * 1000
+
+/**
+ * Configuration for the admin OAuth authorization routes.
+ */
+export interface AdminAuthRoutesConfig {
+  oauthClient: NodeOAuthClient
+  adminSessionStore: AdminSessionStore
+  adminDids: string[]
+  baseUrl: string
+  devMode?: boolean
+  logger?: Logger
+}
+
+/**
+ * Resolve the admin DID from the request's session cookie, or null if there is
+ * no valid, unexpired session whose DID is still on the allowlist.
+ */
+export async function resolveAdminSession(
+  req: express.Request,
+  config: Pick<AdminAuthRoutesConfig, 'adminSessionStore' | 'adminDids'>,
+): Promise<string | null> {
+  const cookies = (req as unknown as { cookies?: Record<string, string> })
+    .cookies
+  const sessionKey = cookies?.[ADMIN_SESSION_COOKIE]
+  if (!sessionKey) return null
+
+  const session = await config.adminSessionStore.get(sessionKey)
+  if (!session) return null
+  if (!config.adminDids.includes(session.did)) return null
+
+  return session.did
+}
+
+/**
+ * Create the Express router for admin OAuth authorization.
+ *
+ * Mounted at `/admin/oauth` (plus the `/admin/whoami` convenience route).
+ */
+export function createAdminAuthRoutes(
+  config: AdminAuthRoutesConfig,
+): express.Router {
+  const router = express.Router()
+  const { adminSessionStore, baseUrl } = config
+  const isSecure = baseUrl.startsWith('https://')
+
+  router.get('/oauth/authorize', handleAdminAuthorize(config))
+  router.get('/oauth/callback', handleAdminCallback(config))
+
+  router.get('/whoami', async (req, res) => {
+    const did = await resolveAdminSession(req, config)
+    if (!did) {
+      return res.status(401).json({
+        error: 'Unauthorized',
+        message: 'No active admin session',
+      })
+    }
+    res.json({ did, isAdmin: true })
+  })
+
+  router.post('/oauth/logout', async (req, res) => {
+    const cookies = (req as unknown as { cookies?: Record<string, string> })
+      .cookies
+    const sessionKey = cookies?.[ADMIN_SESSION_COOKIE]
+    if (sessionKey) {
+      await adminSessionStore.del(sessionKey)
+    }
+    res.clearCookie(ADMIN_SESSION_COOKIE, {
+      httpOnly: true,
+      secure: isSecure,
+      sameSite: 'lax',
+      path: '/',
+    })
+    res.json({ success: true })
+  })
+
+  return router
+}

--- a/stratos-service/src/oauth/admin-session-store.ts
+++ b/stratos-service/src/oauth/admin-session-store.ts
@@ -1,0 +1,126 @@
+import { randomBytes } from 'node:crypto'
+import { eq } from 'drizzle-orm'
+import { adminSession, type ServiceDb } from '../db'
+import { pgAdminSession } from '../db/pg-schema.js'
+import type { ServicePgDb } from '../db/pg.js'
+
+/**
+ * A server-side admin session. The opaque `key` is the only value placed in the
+ * cookie; the DID and lifetime live exclusively in the database.
+ */
+export interface AdminSessionRecord {
+  did: string
+  createdAt: string
+  expiresAt: string
+}
+
+/**
+ * Persistence for admin web sessions. Sessions are keyed by a cryptographically
+ * random, opaque id and carry only the authenticated admin DID plus expiry.
+ */
+export interface AdminSessionStore {
+  create(did: string, ttlMs: number): Promise<string>
+  get(key: string): Promise<AdminSessionRecord | undefined>
+  del(key: string): Promise<void>
+}
+
+const SESSION_KEY_BYTES = 32
+
+function newSessionKey(): string {
+  return randomBytes(SESSION_KEY_BYTES).toString('base64url')
+}
+
+function sessionTimestamps(ttlMs: number): {
+  createdAt: string
+  expiresAt: string
+} {
+  const now = Date.now()
+  return {
+    createdAt: new Date(now).toISOString(),
+    expiresAt: new Date(now + ttlMs).toISOString(),
+  }
+}
+
+function isExpired(record: AdminSessionRecord): boolean {
+  return Date.parse(record.expiresAt) <= Date.now()
+}
+
+/**
+ * SQLite-backed admin session store.
+ */
+export class SqliteAdminSessionStore implements AdminSessionStore {
+  constructor(private db: ServiceDb) {}
+
+  async create(did: string, ttlMs: number): Promise<string> {
+    const key = newSessionKey()
+    const { createdAt, expiresAt } = sessionTimestamps(ttlMs)
+    await this.db.insert(adminSession).values({ key, did, createdAt, expiresAt })
+    return key
+  }
+
+  async get(key: string): Promise<AdminSessionRecord | undefined> {
+    const rows = await this.db
+      .select()
+      .from(adminSession)
+      .where(eq(adminSession.key, key))
+      .limit(1)
+
+    const row = rows[0]
+    if (!row) return undefined
+    const record: AdminSessionRecord = {
+      did: row.did,
+      createdAt: row.createdAt,
+      expiresAt: row.expiresAt,
+    }
+    if (isExpired(record)) {
+      await this.del(key)
+      return undefined
+    }
+    return record
+  }
+
+  async del(key: string): Promise<void> {
+    await this.db.delete(adminSession).where(eq(adminSession.key, key))
+  }
+}
+
+/**
+ * PostgreSQL-backed admin session store.
+ */
+export class PgAdminSessionStore implements AdminSessionStore {
+  constructor(private db: ServicePgDb) {}
+
+  async create(did: string, ttlMs: number): Promise<string> {
+    const key = newSessionKey()
+    const { createdAt, expiresAt } = sessionTimestamps(ttlMs)
+    await this.db
+      .insert(pgAdminSession)
+      .values({ key, did, createdAt, expiresAt })
+    return key
+  }
+
+  async get(key: string): Promise<AdminSessionRecord | undefined> {
+    const rows = await this.db
+      .select()
+      .from(pgAdminSession)
+      .where(eq(pgAdminSession.key, key))
+      .limit(1)
+
+    const row = rows[0]
+    if (!row) return undefined
+    const record: AdminSessionRecord = {
+      did: row.did,
+      createdAt: row.createdAt,
+      expiresAt: row.expiresAt,
+    }
+    if (isExpired(record)) {
+      await this.del(key)
+      return undefined
+    }
+    return record
+  }
+
+  async del(key: string): Promise<void> {
+    await this.db.delete(pgAdminSession).where(eq(pgAdminSession.key, key))
+  }
+}

--- a/stratos-service/src/oauth/admin-session-store.ts
+++ b/stratos-service/src/oauth/admin-session-store.ts
@@ -54,7 +54,9 @@ export class SqliteAdminSessionStore implements AdminSessionStore {
   async create(did: string, ttlMs: number): Promise<string> {
     const key = newSessionKey()
     const { createdAt, expiresAt } = sessionTimestamps(ttlMs)
-    await this.db.insert(adminSession).values({ key, did, createdAt, expiresAt })
+    await this.db
+      .insert(adminSession)
+      .values({ key, did, createdAt, expiresAt })
     return key
   }
 

--- a/stratos-service/src/oauth/admin-session-store.ts
+++ b/stratos-service/src/oauth/admin-session-store.ts
@@ -1,5 +1,6 @@
 import { randomBytes } from 'node:crypto'
-import { eq } from 'drizzle-orm'
+import { eq, lt } from 'drizzle-orm'
+import type { Logger } from '@northskysocial/stratos-core'
 import { adminSession, type ServiceDb } from '../db'
 import { pgAdminSession } from '../db/pg-schema.js'
 import type { ServicePgDb } from '../db/pg.js'
@@ -22,6 +23,12 @@ export interface AdminSessionStore {
   create(did: string, ttlMs: number): Promise<string>
   get(key: string): Promise<AdminSessionRecord | undefined>
   del(key: string): Promise<void>
+  /**
+   * Delete every session whose expiry has passed. Returns the number of rows
+   * removed. Intended for a periodic sweep so expired rows don't accumulate
+   * between the lazy, on-read cleanups in {@link AdminSessionStore.get}.
+   */
+  deleteExpired(): Promise<number>
 }
 
 const SESSION_KEY_BYTES = 32
@@ -49,7 +56,10 @@ function isExpired(record: AdminSessionRecord): boolean {
  * SQLite-backed admin session store.
  */
 export class SqliteAdminSessionStore implements AdminSessionStore {
-  constructor(private db: ServiceDb) {}
+  constructor(
+    private db: ServiceDb,
+    private logger?: Logger,
+  ) {}
 
   async create(did: string, ttlMs: number): Promise<string> {
     const key = newSessionKey()
@@ -75,7 +85,18 @@ export class SqliteAdminSessionStore implements AdminSessionStore {
       expiresAt: row.expiresAt,
     }
     if (isExpired(record)) {
-      await this.del(key)
+      try {
+        await this.del(key)
+      } catch (err) {
+        // The session is gone as far as the caller is concerned (expiry was
+        // checked in-memory above); a failed delete only means the stale row
+        // lingers for the periodic sweep. Surface it so a recurring storage
+        // fault isn't silently masked.
+        this.logger?.warn(
+          { err },
+          'admin session: failed to purge expired session on read',
+        )
+      }
       return undefined
     }
     return record
@@ -84,13 +105,25 @@ export class SqliteAdminSessionStore implements AdminSessionStore {
   async del(key: string): Promise<void> {
     await this.db.delete(adminSession).where(eq(adminSession.key, key))
   }
+
+  async deleteExpired(): Promise<number> {
+    const now = new Date().toISOString()
+    const deleted = await this.db
+      .delete(adminSession)
+      .where(lt(adminSession.expiresAt, now))
+      .returning({ key: adminSession.key })
+    return deleted.length
+  }
 }
 
 /**
  * PostgreSQL-backed admin session store.
  */
 export class PgAdminSessionStore implements AdminSessionStore {
-  constructor(private db: ServicePgDb) {}
+  constructor(
+    private db: ServicePgDb,
+    private logger?: Logger,
+  ) {}
 
   async create(did: string, ttlMs: number): Promise<string> {
     const key = newSessionKey()
@@ -116,7 +149,14 @@ export class PgAdminSessionStore implements AdminSessionStore {
       expiresAt: row.expiresAt,
     }
     if (isExpired(record)) {
-      await this.del(key)
+      try {
+        await this.del(key)
+      } catch (err) {
+        this.logger?.warn(
+          { err },
+          'admin session: failed to purge expired session on read',
+        )
+      }
       return undefined
     }
     return record
@@ -124,5 +164,14 @@ export class PgAdminSessionStore implements AdminSessionStore {
 
   async del(key: string): Promise<void> {
     await this.db.delete(pgAdminSession).where(eq(pgAdminSession.key, key))
+  }
+
+  async deleteExpired(): Promise<number> {
+    const now = new Date().toISOString()
+    const deleted = await this.db
+      .delete(pgAdminSession)
+      .where(lt(pgAdminSession.expiresAt, now))
+      .returning({ key: pgAdminSession.key })
+    return deleted.length
   }
 }

--- a/stratos-service/src/oauth/client-factory.ts
+++ b/stratos-service/src/oauth/client-factory.ts
@@ -32,6 +32,7 @@ export async function createOAuthClientContext(
         cfg.oauth.clientId ?? `${cfg.service.publicUrl}/client-metadata.json`,
       clientUri: cfg.service.publicUrl,
       redirectUri: `${cfg.service.publicUrl}/oauth/callback`,
+      adminRedirectUri: `${cfg.service.publicUrl}/admin/oauth/callback`,
       privateKeyPem: cfg.oauth.clientSecret,
       scope: OAUTH_SCOPE,
       clientName: cfg.oauth.clientName,

--- a/stratos-service/src/oauth/client.ts
+++ b/stratos-service/src/oauth/client.ts
@@ -21,6 +21,12 @@ export const OAUTH_SCOPE = [
 ].join(' ')
 
 /**
+ * OAuth scope for admin login. Admins only prove identity; they get no repo
+ * write grants. Identity-only `atproto` scope is deliberate.
+ */
+export const OAUTH_ADMIN_SCOPE = 'atproto'
+
+/**
  * Database schema for OAuth session storage
  */
 export interface OAuthSessionTable {
@@ -175,6 +181,7 @@ export interface OAuthClientConfig {
   clientId: string
   clientUri: string
   redirectUri: string
+  adminRedirectUri?: string
   privateKeyPem?: string
   scope?: string
   clientName?: string
@@ -329,7 +336,9 @@ export async function createOAuthClient(
       ...(config.logoUri && { logo_uri: config.logoUri }),
       ...(config.tosUri && { tos_uri: config.tosUri }),
       ...(config.policyUri && { policy_uri: config.policyUri }),
-      redirect_uris: [config.redirectUri],
+      redirect_uris: (config.adminRedirectUri
+        ? [config.redirectUri, config.adminRedirectUri]
+        : [config.redirectUri]) as [string, ...string[]],
       grant_types: ['authorization_code', 'refresh_token'],
       response_types: ['code'],
       scope: config.scope ?? OAUTH_SCOPE,

--- a/stratos-service/src/oauth/handlers/admin-authorize.ts
+++ b/stratos-service/src/oauth/handlers/admin-authorize.ts
@@ -1,0 +1,57 @@
+import express from 'express'
+import { OAUTH_ADMIN_SCOPE } from '../client.js'
+import type { AdminAuthRoutesConfig } from '../admin-routes.js'
+
+/**
+ * Starts the admin OAuth authorization flow.
+ *
+ * Requests identity-only `atproto` scope (no repo writes) and pins the
+ * authorization to the admin callback redirect URI so the enrollment callback
+ * is never reached. Allowlist enforcement happens in the callback, not here.
+ */
+export const handleAdminAuthorize = (config: AdminAuthRoutesConfig) => {
+  const { oauthClient, baseUrl, logger } = config
+  const adminRedirectUri = `${baseUrl}/admin/oauth/callback`
+
+  return async (req: express.Request, res: express.Response) => {
+    try {
+      const handle = req.query.handle as string | undefined
+      if (!handle) {
+        return res.status(400).json({
+          error: 'InvalidRequest',
+          message: 'Handle parameter required',
+        })
+      }
+
+      logger?.debug({ handle }, 'starting admin OAuth authorization')
+      type AuthorizeOptions = NonNullable<
+        Parameters<typeof oauthClient.authorize>[1]
+      >
+      const authUrl = await oauthClient.authorize(handle, {
+        scope: OAUTH_ADMIN_SCOPE,
+        redirect_uri: adminRedirectUri as AuthorizeOptions['redirect_uri'],
+      })
+
+      res.redirect(authUrl.toString())
+    } catch (err) {
+      const errorMsg = err instanceof Error ? err.message : String(err)
+      logger?.error(
+        { err: errorMsg, handle: req.query.handle },
+        'admin OAuth authorize failed',
+      )
+
+      const isResolutionError =
+        errorMsg.toLowerCase().includes('resolve') ||
+        errorMsg.toLowerCase().includes('handle') ||
+        errorMsg.toLowerCase().includes('did') ||
+        errorMsg.toLowerCase().includes('discovery')
+
+      res.status(isResolutionError ? 400 : 500).json({
+        error: 'AuthorizationError',
+        message: config.devMode
+          ? `Failed to start admin authorization: ${errorMsg}`
+          : 'Failed to start admin authorization',
+      })
+    }
+  }
+}

--- a/stratos-service/src/oauth/handlers/admin-callback.ts
+++ b/stratos-service/src/oauth/handlers/admin-callback.ts
@@ -1,0 +1,68 @@
+import express from 'express'
+import type { AdminAuthRoutesConfig } from '../admin-routes.js'
+import { ADMIN_SESSION_COOKIE, ADMIN_SESSION_TTL_MS } from '../admin-routes.js'
+
+/**
+ * Completes the admin OAuth flow.
+ *
+ * Unlike the enrollment callback, this performs no repo init, signing-key
+ * creation, attestation, or PDS record write. It only:
+ *  1. completes the token exchange and reads the authenticated DID,
+ *  2. enforces the admin DID allowlist (revoking the OAuth session on miss),
+ *  3. establishes an opaque server-side web session via an HttpOnly cookie.
+ */
+export const handleAdminCallback = (config: AdminAuthRoutesConfig) => {
+  const { oauthClient, adminSessionStore, adminDids, baseUrl, logger } = config
+  const isSecure = baseUrl.startsWith('https://')
+  const adminRedirectUri = `${baseUrl}/admin/oauth/callback`
+
+  return async (req: express.Request, res: express.Response) => {
+    try {
+      const params = new URLSearchParams(req.url.split('?')[1] || '')
+
+      // The authorize step pinned this same redirect_uri; the token exchange
+      // must echo it or the AS rejects the grant (invalid_grant). Without it
+      // the client falls back to the first registered redirect_uri (the
+      // enrollment callback), which never matches.
+      type CallbackOptions = NonNullable<
+        Parameters<typeof oauthClient.callback>[1]
+      >
+      const { session } = await oauthClient.callback(params, {
+        redirect_uri: adminRedirectUri as CallbackOptions['redirect_uri'],
+      })
+      const did = session.sub
+
+      if (!adminDids.includes(did)) {
+        await oauthClient.revoke(did)
+        logger?.warn({ did }, 'admin login rejected: DID not in allowlist')
+        return res.status(403).json({
+          error: 'NotAdmin',
+          message: 'This account is not authorized for admin access',
+        })
+      }
+
+      const sessionKey = await adminSessionStore.create(
+        did,
+        ADMIN_SESSION_TTL_MS,
+      )
+
+      res.cookie(ADMIN_SESSION_COOKIE, sessionKey, {
+        httpOnly: true,
+        secure: isSecure,
+        sameSite: 'lax',
+        maxAge: ADMIN_SESSION_TTL_MS,
+        path: '/',
+      })
+
+      logger?.info({ adminDid: did }, 'admin session established')
+      res.redirect('/admin')
+    } catch (err) {
+      const errMsg = err instanceof Error ? err.message : String(err)
+      logger?.error({ err: errMsg }, 'admin OAuth callback failed')
+      res.status(500).json({
+        error: 'CallbackError',
+        message: config.devMode ? errMsg : 'Failed to complete admin login',
+      })
+    }
+  }
+}

--- a/stratos-service/src/oauth/handlers/admin-callback.ts
+++ b/stratos-service/src/oauth/handlers/admin-callback.ts
@@ -49,7 +49,7 @@ export const handleAdminCallback = (config: AdminAuthRoutesConfig) => {
       res.cookie(ADMIN_SESSION_COOKIE, sessionKey, {
         httpOnly: true,
         secure: isSecure,
-        sameSite: 'lax',
+        sameSite: 'strict',
         maxAge: ADMIN_SESSION_TTL_MS,
         path: '/',
       })

--- a/stratos-service/src/oauth/index.ts
+++ b/stratos-service/src/oauth/index.ts
@@ -1,2 +1,4 @@
 export * from './client.js'
+export * from './admin-session-store.js'
+export * from './admin-routes.js'
 export * from './routes.js'

--- a/stratos-service/src/storage-context.ts
+++ b/stratos-service/src/storage-context.ts
@@ -17,6 +17,9 @@ import { CachedEnrollmentStore } from './infra/storage/cached-enrollment-store.j
 import {
   createPgOAuthStores,
   createSqliteOAuthStores,
+  PgAdminSessionStore,
+  SqliteAdminSessionStore,
+  type AdminSessionStore,
   type EnrollmentStore,
   type OAuthSessionStoreBackend,
   type OAuthStateStoreBackend,
@@ -39,6 +42,7 @@ export interface StorageContext {
     sessionStore: OAuthSessionStoreBackend
     stateStore: OAuthStateStoreBackend
   }
+  adminSessionStore: AdminSessionStore
   checkDbHealth: () => Promise<'ok' | 'error'>
   destroy: () => Promise<void>
 }
@@ -63,6 +67,7 @@ export async function createStorageContext(
     sessionStore: OAuthSessionStoreBackend
     stateStore: OAuthStateStoreBackend
   }
+  let adminSessionStore: AdminSessionStore
   let actorStore: ActorStore
   let checkDbHealth: () => Promise<'ok' | 'error'>
   let destroy: () => Promise<void>
@@ -95,6 +100,7 @@ export async function createStorageContext(
     await cachedEnrollmentStore.warm()
     enrollmentStore = cachedEnrollmentStore
     oauthStores = createPgOAuthStores(pgDb)
+    adminSessionStore = new PgAdminSessionStore(pgDb)
     actorStore = new PostgresActorStore({
       connectionString: cfg.storage.postgresUrl,
       blobstore,
@@ -117,6 +123,7 @@ export async function createStorageContext(
     await migrateServiceDb(db)
     enrollmentStore = new SqliteEnrollmentStore(db)
     oauthStores = createSqliteOAuthStores(db)
+    adminSessionStore = new SqliteAdminSessionStore(db)
     actorStore = new StratosActorStore({
       dataDir: path.join(cfg.storage.dataDir, 'actors'),
       blobstore,
@@ -137,6 +144,7 @@ export async function createStorageContext(
     db,
     enrollmentStore,
     oauthStores,
+    adminSessionStore,
     actorStore,
     checkDbHealth,
     destroy,

--- a/stratos-service/src/storage-context.ts
+++ b/stratos-service/src/storage-context.ts
@@ -26,7 +26,10 @@ import {
 } from './oauth'
 import { SqliteEnrollmentStore } from './storage/sqlite/enrollment-store.js'
 import { StratosActorStore } from './storage/sqlite/actor-store.js'
-import type { EnrollmentStoreReader } from '@northskysocial/stratos-core'
+import type {
+  EnrollmentStoreReader,
+  Logger,
+} from '@northskysocial/stratos-core'
 import type { ActorStore } from './actor-store-types.js'
 import type { AppContextOptions } from './context-types.js'
 import {
@@ -100,7 +103,7 @@ export async function createStorageContext(
     await cachedEnrollmentStore.warm()
     enrollmentStore = cachedEnrollmentStore
     oauthStores = createPgOAuthStores(pgDb)
-    adminSessionStore = new PgAdminSessionStore(pgDb)
+    adminSessionStore = new PgAdminSessionStore(pgDb, logger)
     actorStore = new PostgresActorStore({
       connectionString: cfg.storage.postgresUrl,
       blobstore,
@@ -123,7 +126,7 @@ export async function createStorageContext(
     await migrateServiceDb(db)
     enrollmentStore = new SqliteEnrollmentStore(db)
     oauthStores = createSqliteOAuthStores(db)
-    adminSessionStore = new SqliteAdminSessionStore(db)
+    adminSessionStore = new SqliteAdminSessionStore(db, logger)
     actorStore = new StratosActorStore({
       dataDir: path.join(cfg.storage.dataDir, 'actors'),
       blobstore,
@@ -140,6 +143,13 @@ export async function createStorageContext(
     }
   }
 
+  const sweep = scheduleExpiredSessionSweep(adminSessionStore, logger)
+  const closeBackend = destroy
+  destroy = async () => {
+    sweep.stop()
+    await closeBackend()
+  }
+
   return {
     db,
     enrollmentStore,
@@ -149,4 +159,40 @@ export async function createStorageContext(
     checkDbHealth,
     destroy,
   }
+}
+
+/**
+ * Interval between periodic expired-admin-session sweeps. Sessions are also
+ * purged lazily on read; this bound keeps the table from growing without limit
+ * when expired sessions are never read again.
+ */
+const ADMIN_SESSION_SWEEP_INTERVAL_MS = 60 * 60 * 1000
+
+/**
+ * Start a periodic sweep that deletes expired admin sessions. The timer is
+ * `unref`'d so it never keeps the process alive, and {@link ScheduledSweep.stop}
+ * clears it during shutdown.
+ */
+function scheduleExpiredSessionSweep(
+  store: AdminSessionStore,
+  logger?: Logger,
+): ScheduledSweep {
+  const timer = setInterval(() => {
+    store
+      .deleteExpired()
+      .then((removed) => {
+        if (removed > 0) {
+          logger?.info({ removed }, 'admin session: swept expired sessions')
+        }
+      })
+      .catch((err) => {
+        logger?.warn({ err }, 'admin session: expired sweep failed')
+      })
+  }, ADMIN_SESSION_SWEEP_INTERVAL_MS)
+  timer.unref()
+  return { stop: () => clearInterval(timer) }
+}
+
+interface ScheduledSweep {
+  stop: () => void
 }

--- a/stratos-service/tests/admin-auth.integration.test.ts
+++ b/stratos-service/tests/admin-auth.integration.test.ts
@@ -91,6 +91,31 @@ describe('SqliteAdminSessionStore', () => {
     await store.del(key)
     expect(await store.get(key)).toBeUndefined()
   })
+
+  it('sweeps only expired sessions, leaving live ones intact', async () => {
+    const expired = await store.create(ADMIN_DID, -1_000)
+    const live = await store.create(ADMIN_DID, 60_000)
+
+    const removed = await store.deleteExpired()
+
+    expect(removed).toBe(1)
+    expect(await store.get(live)).toBeDefined()
+    // The expired row is gone; a direct del would have been a no-op.
+    const req: any = {
+      headers: { cookie: `${ADMIN_SESSION_COOKIE}=${expired}` },
+    }
+    const did = await resolveAdminSession(req, {
+      adminSessionStore: store,
+      adminDids: [ADMIN_DID],
+    })
+    expect(did).toBeNull()
+  })
+
+  it('sweeps nothing when all sessions are live', async () => {
+    await store.create(ADMIN_DID, 60_000)
+    await store.create(ADMIN_DID, 60_000)
+    expect(await store.deleteExpired()).toBe(0)
+  })
 })
 
 describe('isAllowedCredentialedOrigin', () => {
@@ -393,7 +418,7 @@ describe('resolveAdminSession (whoami / logout)', () => {
 
   it('returns the DID for a live, allowlisted session', async () => {
     const key = await store.create(ADMIN_DID, 60_000)
-    const req: any = { cookies: { [ADMIN_SESSION_COOKIE]: key } }
+    const req: any = { headers: { cookie: `${ADMIN_SESSION_COOKIE}=${key}` } }
     const did = await resolveAdminSession(req, {
       adminSessionStore: store,
       adminDids: [ADMIN_DID],
@@ -404,7 +429,7 @@ describe('resolveAdminSession (whoami / logout)', () => {
   it('returns null once the session is deleted (logout)', async () => {
     const key = await store.create(ADMIN_DID, 60_000)
     await store.del(key)
-    const req: any = { cookies: { [ADMIN_SESSION_COOKIE]: key } }
+    const req: any = { headers: { cookie: `${ADMIN_SESSION_COOKIE}=${key}` } }
     const did = await resolveAdminSession(req, {
       adminSessionStore: store,
       adminDids: [ADMIN_DID],
@@ -413,7 +438,7 @@ describe('resolveAdminSession (whoami / logout)', () => {
   })
 
   it('returns null when there is no session cookie', async () => {
-    const req: any = { cookies: {} }
+    const req: any = { headers: {} }
     const did = await resolveAdminSession(req, {
       adminSessionStore: store,
       adminDids: [ADMIN_DID],

--- a/stratos-service/tests/admin-auth.integration.test.ts
+++ b/stratos-service/tests/admin-auth.integration.test.ts
@@ -17,7 +17,10 @@ import {
 } from '../src/oauth/admin-routes.js'
 import { handleAdminCallback } from '../src/oauth/handlers/admin-callback.js'
 import { createAuthVerifiers } from '../src/infra/auth/verifiers.js'
-import { isAllowedCredentialedOrigin } from '../src/config.js'
+import {
+  isAllowedCredentialedOrigin,
+  passesAdminCsrfCheck,
+} from '../src/config.js'
 import { createTestConfig } from './utils'
 
 const ADMIN_DID = 'did:plc:usagi'
@@ -30,7 +33,9 @@ function makeAdminCtx(headers: Record<string, string | undefined>): {
 } {
   return {
     req: { headers } as unknown as import('node:http').IncomingMessage,
-    res: { setHeader: vi.fn() } as unknown as import('node:http').ServerResponse,
+    res: {
+      setHeader: vi.fn(),
+    } as unknown as import('node:http').ServerResponse,
   }
 }
 
@@ -129,6 +134,48 @@ describe('isAllowedCredentialedOrigin', () => {
         devMode: false,
       }),
     ).toBe(false)
+  })
+})
+
+describe('passesAdminCsrfCheck', () => {
+  const deps = { publicUrl: PUBLIC_URL, devMode: false }
+  const makeReq = (headers: Record<string, string>) =>
+    ({ headers }) as unknown as import('node:http').IncomingMessage
+
+  it('admits a request whose Origin is the service origin', () => {
+    expect(passesAdminCsrfCheck(makeReq({ origin: PUBLIC_URL }), deps)).toBe(
+      true,
+    )
+  })
+
+  it('rejects a request with a foreign Origin', () => {
+    expect(
+      passesAdminCsrfCheck(
+        makeReq({ origin: 'https://gehirn.tokyo.jp' }),
+        deps,
+      ),
+    ).toBe(false)
+  })
+
+  it('falls back to Referer when no Origin is present', () => {
+    expect(
+      passesAdminCsrfCheck(makeReq({ referer: `${PUBLIC_URL}/admin` }), deps),
+    ).toBe(true)
+    expect(
+      passesAdminCsrfCheck(
+        makeReq({ referer: 'https://gehirn.tokyo.jp/admin' }),
+        deps,
+      ),
+    ).toBe(false)
+  })
+
+  // A browser cross-site POST always carries an Origin, so the no-header case
+  // cannot be a browser-driven forgery; the SameSite=Strict cookie is the gate.
+  // This passes through intentionally so same-origin server-to-server admin
+  // tooling (the E2E suite) is not blocked — guarding against a regression to
+  // fail-closed behavior.
+  it('admits a request with neither Origin nor Referer', () => {
+    expect(passesAdminCsrfCheck(makeReq({}), deps)).toBe(true)
   })
 })
 
@@ -236,7 +283,10 @@ describe('admin OAuth callback', () => {
   let dataDir: string
   let db: ServiceDb
   let store: SqliteAdminSessionStore
-  let oauthClient: { callback: ReturnType<typeof vi.fn>; revoke: ReturnType<typeof vi.fn> }
+  let oauthClient: {
+    callback: ReturnType<typeof vi.fn>
+    revoke: ReturnType<typeof vi.fn>
+  }
 
   beforeEach(async () => {
     dataDir = join(
@@ -285,7 +335,11 @@ describe('admin OAuth callback', () => {
     expect(res.cookie).toHaveBeenCalledWith(
       ADMIN_SESSION_COOKIE,
       expect.any(String),
-      expect.objectContaining({ httpOnly: true, secure: true, sameSite: 'lax' }),
+      expect.objectContaining({
+        httpOnly: true,
+        secure: true,
+        sameSite: 'strict',
+      }),
     )
     expect(res.redirect).toHaveBeenCalledWith('/admin')
 

--- a/stratos-service/tests/admin-auth.integration.test.ts
+++ b/stratos-service/tests/admin-auth.integration.test.ts
@@ -1,0 +1,369 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mkdir, rm } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { randomBytes } from 'node:crypto'
+
+import {
+  closeServiceDb,
+  createServiceDb,
+  migrateServiceDb,
+  type ServiceDb,
+} from '../src/db'
+import { SqliteAdminSessionStore } from '../src/oauth/admin-session-store.js'
+import {
+  ADMIN_SESSION_COOKIE,
+  resolveAdminSession,
+} from '../src/oauth/admin-routes.js'
+import { handleAdminCallback } from '../src/oauth/handlers/admin-callback.js'
+import { createAuthVerifiers } from '../src/infra/auth/verifiers.js'
+import { isAllowedCredentialedOrigin } from '../src/config.js'
+import { createTestConfig } from './utils'
+
+const ADMIN_DID = 'did:plc:usagi'
+const INTRUDER_DID = 'did:plc:mamoru'
+const PUBLIC_URL = 'https://stratos.test'
+
+function makeAdminCtx(headers: Record<string, string | undefined>): {
+  req: import('node:http').IncomingMessage
+  res: import('node:http').ServerResponse
+} {
+  return {
+    req: { headers } as unknown as import('node:http').IncomingMessage,
+    res: { setHeader: vi.fn() } as unknown as import('node:http').ServerResponse,
+  }
+}
+
+describe('SqliteAdminSessionStore', () => {
+  let dataDir: string
+  let db: ServiceDb
+  let store: SqliteAdminSessionStore
+
+  beforeEach(async () => {
+    dataDir = join(
+      tmpdir(),
+      `stratos-admin-session-${randomBytes(8).toString('hex')}`,
+    )
+    await mkdir(dataDir, { recursive: true })
+    db = createServiceDb(join(dataDir, 'service.sqlite'))
+    await migrateServiceDb(db)
+    store = new SqliteAdminSessionStore(db)
+  })
+
+  afterEach(async () => {
+    await closeServiceDb(db)
+    await rm(dataDir, { recursive: true, force: true })
+  })
+
+  it('issues an opaque key and reads the session back', async () => {
+    const key = await store.create(ADMIN_DID, 60_000)
+    expect(key).toMatch(/^[A-Za-z0-9_-]+$/)
+
+    const session = await store.get(key)
+    expect(session?.did).toBe(ADMIN_DID)
+    expect(Date.parse(session!.expiresAt)).toBeGreaterThan(Date.now())
+  })
+
+  it('mints a distinct key per session', async () => {
+    const a = await store.create(ADMIN_DID, 60_000)
+    const b = await store.create(ADMIN_DID, 60_000)
+    expect(a).not.toBe(b)
+  })
+
+  it('returns undefined for an unknown key', async () => {
+    expect(await store.get('does-not-exist')).toBeUndefined()
+  })
+
+  it('treats an expired session as absent and purges it', async () => {
+    const key = await store.create(ADMIN_DID, -1_000)
+    expect(await store.get(key)).toBeUndefined()
+    // A second read confirms the expired row was deleted, not just filtered.
+    expect(await store.get(key)).toBeUndefined()
+  })
+
+  it('deletes a session on logout', async () => {
+    const key = await store.create(ADMIN_DID, 60_000)
+    await store.del(key)
+    expect(await store.get(key)).toBeUndefined()
+  })
+})
+
+describe('isAllowedCredentialedOrigin', () => {
+  it('admits the service origin', () => {
+    expect(
+      isAllowedCredentialedOrigin(PUBLIC_URL, {
+        publicUrl: PUBLIC_URL,
+        devMode: false,
+      }),
+    ).toBe(true)
+  })
+
+  it('rejects a foreign origin', () => {
+    expect(
+      isAllowedCredentialedOrigin('https://gehirn.tokyo.jp', {
+        publicUrl: PUBLIC_URL,
+        devMode: false,
+      }),
+    ).toBe(false)
+  })
+
+  it('rejects a missing origin', () => {
+    expect(
+      isAllowedCredentialedOrigin(undefined, {
+        publicUrl: PUBLIC_URL,
+        devMode: false,
+      }),
+    ).toBe(false)
+  })
+
+  it('admits localhost only in dev mode', () => {
+    expect(
+      isAllowedCredentialedOrigin('http://localhost:5173', {
+        publicUrl: PUBLIC_URL,
+        devMode: true,
+      }),
+    ).toBe(true)
+    expect(
+      isAllowedCredentialedOrigin('http://localhost:5173', {
+        publicUrl: PUBLIC_URL,
+        devMode: false,
+      }),
+    ).toBe(false)
+  })
+})
+
+describe('admin auth verifier', () => {
+  let dataDir: string
+  let db: ServiceDb
+  let store: SqliteAdminSessionStore
+  let verifiers: ReturnType<typeof createAuthVerifiers>
+
+  beforeEach(async () => {
+    dataDir = join(
+      tmpdir(),
+      `stratos-admin-verifier-${randomBytes(8).toString('hex')}`,
+    )
+    await mkdir(dataDir, { recursive: true })
+    db = createServiceDb(join(dataDir, 'service.sqlite'))
+    await migrateServiceDb(db)
+    store = new SqliteAdminSessionStore(db)
+
+    const cfg = createTestConfig(dataDir)
+    cfg.service.publicUrl = PUBLIC_URL
+
+    verifiers = createAuthVerifiers(
+      cfg.service.did,
+      {} as never,
+      cfg,
+      {} as never,
+      store,
+      [ADMIN_DID],
+      {} as never,
+      undefined,
+      false,
+      undefined,
+    )
+  })
+
+  afterEach(async () => {
+    await closeServiceDb(db)
+    await rm(dataDir, { recursive: true, force: true })
+  })
+
+  it('accepts a valid session from the service origin', async () => {
+    const key = await store.create(ADMIN_DID, 60_000)
+    const result = await verifiers.admin(
+      makeAdminCtx({
+        origin: PUBLIC_URL,
+        cookie: `${ADMIN_SESSION_COOKIE}=${key}`,
+      }),
+    )
+    expect(result.credentials).toEqual({ type: 'admin', did: ADMIN_DID })
+  })
+
+  it('accepts a session when no Origin or Referer is present', async () => {
+    const key = await store.create(ADMIN_DID, 60_000)
+    const result = await verifiers.admin(
+      makeAdminCtx({ cookie: `${ADMIN_SESSION_COOKIE}=${key}` }),
+    )
+    expect(result.credentials.did).toBe(ADMIN_DID)
+  })
+
+  it('rejects a cross-origin request before consulting the session', async () => {
+    const key = await store.create(ADMIN_DID, 60_000)
+    await expect(
+      verifiers.admin(
+        makeAdminCtx({
+          origin: 'https://gehirn.tokyo.jp',
+          cookie: `${ADMIN_SESSION_COOKIE}=${key}`,
+        }),
+      ),
+    ).rejects.toThrow(/Cross-origin/)
+  })
+
+  it('rejects a request with no session cookie', async () => {
+    await expect(
+      verifiers.admin(makeAdminCtx({ origin: PUBLIC_URL })),
+    ).rejects.toThrow(/Admin authorization required/)
+  })
+
+  it('rejects an expired session', async () => {
+    const key = await store.create(ADMIN_DID, -1_000)
+    await expect(
+      verifiers.admin(
+        makeAdminCtx({
+          origin: PUBLIC_URL,
+          cookie: `${ADMIN_SESSION_COOKIE}=${key}`,
+        }),
+      ),
+    ).rejects.toThrow(/invalid or expired/)
+  })
+
+  it('rejects a session whose DID has fallen off the allowlist', async () => {
+    const key = await store.create(INTRUDER_DID, 60_000)
+    await expect(
+      verifiers.admin(
+        makeAdminCtx({
+          origin: PUBLIC_URL,
+          cookie: `${ADMIN_SESSION_COOKIE}=${key}`,
+        }),
+      ),
+    ).rejects.toThrow(/Not an authorized admin/)
+  })
+})
+
+describe('admin OAuth callback', () => {
+  let dataDir: string
+  let db: ServiceDb
+  let store: SqliteAdminSessionStore
+  let oauthClient: { callback: ReturnType<typeof vi.fn>; revoke: ReturnType<typeof vi.fn> }
+
+  beforeEach(async () => {
+    dataDir = join(
+      tmpdir(),
+      `stratos-admin-callback-${randomBytes(8).toString('hex')}`,
+    )
+    await mkdir(dataDir, { recursive: true })
+    db = createServiceDb(join(dataDir, 'service.sqlite'))
+    await migrateServiceDb(db)
+    store = new SqliteAdminSessionStore(db)
+    oauthClient = {
+      callback: vi.fn(),
+      revoke: vi.fn().mockResolvedValue(undefined),
+    }
+  })
+
+  afterEach(async () => {
+    await closeServiceDb(db)
+    await rm(dataDir, { recursive: true, force: true })
+  })
+
+  function makeConfig() {
+    return {
+      // The handler only touches callback/revoke from the OAuth client.
+      oauthClient: oauthClient as never,
+      adminSessionStore: store,
+      adminDids: [ADMIN_DID],
+      baseUrl: PUBLIC_URL,
+    }
+  }
+
+  it('establishes a session cookie for an allowlisted DID', async () => {
+    oauthClient.callback.mockResolvedValue({ session: { sub: ADMIN_DID } })
+    const handler = handleAdminCallback(makeConfig())
+
+    const req: any = { url: '/admin/oauth/callback?code=foo&state=bar' }
+    const res: any = {
+      cookie: vi.fn(),
+      redirect: vi.fn(),
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn(),
+    }
+
+    await handler(req, res)
+
+    expect(res.cookie).toHaveBeenCalledWith(
+      ADMIN_SESSION_COOKIE,
+      expect.any(String),
+      expect.objectContaining({ httpOnly: true, secure: true, sameSite: 'lax' }),
+    )
+    expect(res.redirect).toHaveBeenCalledWith('/admin')
+
+    const issuedKey = res.cookie.mock.calls[0][1]
+    const session = await store.get(issuedKey)
+    expect(session?.did).toBe(ADMIN_DID)
+  })
+
+  it('refuses a non-allowlisted DID and revokes its OAuth session', async () => {
+    oauthClient.callback.mockResolvedValue({ session: { sub: INTRUDER_DID } })
+    const createSpy = vi.spyOn(store, 'create')
+    const handler = handleAdminCallback(makeConfig())
+
+    const req: any = { url: '/admin/oauth/callback?code=foo&state=bar' }
+    const res: any = {
+      cookie: vi.fn(),
+      redirect: vi.fn(),
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn(),
+    }
+
+    await handler(req, res)
+
+    expect(oauthClient.revoke).toHaveBeenCalledWith(INTRUDER_DID)
+    expect(res.status).toHaveBeenCalledWith(403)
+    expect(res.cookie).not.toHaveBeenCalled()
+    expect(createSpy).not.toHaveBeenCalled()
+  })
+})
+
+describe('resolveAdminSession (whoami / logout)', () => {
+  let dataDir: string
+  let db: ServiceDb
+  let store: SqliteAdminSessionStore
+
+  beforeEach(async () => {
+    dataDir = join(
+      tmpdir(),
+      `stratos-admin-resolve-${randomBytes(8).toString('hex')}`,
+    )
+    await mkdir(dataDir, { recursive: true })
+    db = createServiceDb(join(dataDir, 'service.sqlite'))
+    await migrateServiceDb(db)
+    store = new SqliteAdminSessionStore(db)
+  })
+
+  afterEach(async () => {
+    await closeServiceDb(db)
+    await rm(dataDir, { recursive: true, force: true })
+  })
+
+  it('returns the DID for a live, allowlisted session', async () => {
+    const key = await store.create(ADMIN_DID, 60_000)
+    const req: any = { cookies: { [ADMIN_SESSION_COOKIE]: key } }
+    const did = await resolveAdminSession(req, {
+      adminSessionStore: store,
+      adminDids: [ADMIN_DID],
+    })
+    expect(did).toBe(ADMIN_DID)
+  })
+
+  it('returns null once the session is deleted (logout)', async () => {
+    const key = await store.create(ADMIN_DID, 60_000)
+    await store.del(key)
+    const req: any = { cookies: { [ADMIN_SESSION_COOKIE]: key } }
+    const did = await resolveAdminSession(req, {
+      adminSessionStore: store,
+      adminDids: [ADMIN_DID],
+    })
+    expect(did).toBeNull()
+  })
+
+  it('returns null when there is no session cookie', async () => {
+    const req: any = { cookies: {} }
+    const did = await resolveAdminSession(req, {
+      adminSessionStore: store,
+      adminDids: [ADMIN_DID],
+    })
+    expect(did).toBeNull()
+  })
+})

--- a/stratos-service/tests/admin-boundaries.test.ts
+++ b/stratos-service/tests/admin-boundaries.test.ts
@@ -4,6 +4,25 @@ import type { AppContext } from '../src'
 import type { EnrollmentStore } from '../src/oauth'
 import { registerEnrollmentHandlers } from '../src/features'
 
+// The boundary handlers write the user's PDS enrollment record through an
+// `Agent` constructed inside `updatePdsEnrollmentRecord`. Stub it so the PDS
+// write is deterministic: by default it succeeds (pdsSync: 'ok'); a failure is
+// injected per-test by making `oauthClient.restore` throw before the Agent is
+// ever built. The mock must be a real constructor (class), not an arrow
+// function — `new Agent(...)` would otherwise throw "not a constructor".
+vi.mock('@atproto/api', () => ({
+  Agent: class {
+    com = {
+      atproto: {
+        repo: {
+          putRecord: async () => ({}),
+        },
+      },
+    }
+    constructor(_session: unknown) {}
+  },
+}))
+
 interface MockResponse {
   statusCode: number
   body: unknown
@@ -74,6 +93,7 @@ function createMockStore(
 function createCtx(opts: {
   enrollmentStore?: Partial<EnrollmentStore>
   adminAuthFails?: boolean
+  pdsWriteFails?: boolean
 }): {
   ctx: AppContext
   enrollmentStore: EnrollmentStore
@@ -101,7 +121,13 @@ function createCtx(opts: {
         credentials: { did: null },
       })),
     },
-    oauthClient: { restore: vi.fn(async () => ({})) },
+    oauthClient: {
+      restore: opts.pdsWriteFails
+        ? vi.fn(async () => {
+            throw new Error('oauth session expired')
+          })
+        : vi.fn(async () => ({})),
+    },
     serviceDid: 'did:web:stratos.example.com',
     createAttestation: vi.fn(async () => ({
       sig: new Uint8Array([1, 2, 3]),
@@ -147,13 +173,32 @@ describe('admin boundary endpoints', () => {
         { did: 'did:plc:usagi', boundary: 'did:web:nerv.tokyo.jp/bees' },
       )
       expect(res.statusCode).toBe(200)
-      const body = res.body as { did: string; boundaries: string[] }
+      const body = res.body as {
+        did: string
+        boundaries: string[]
+        pdsSync: string
+      }
       expect(body.did).toBe('did:plc:usagi')
       expect(body.boundaries).toBeDefined()
+      expect(body.pdsSync).toBe('ok')
       expect(enrollmentStore.addBoundary).toHaveBeenCalledWith(
         'did:plc:usagi',
         'did:web:nerv.tokyo.jp/bees',
       )
+    })
+
+    it('reports pdsSync failed but still applies the local change on PDS write failure', async () => {
+      const { app, enrollmentStore } = createCtx({ pdsWriteFails: true })
+      const res = await invokePostRoute(
+        app,
+        '/xrpc/zone.stratos.admin.addBoundary',
+        { did: 'did:plc:usagi', boundary: 'did:web:nerv.tokyo.jp/bees' },
+      )
+      expect(res.statusCode).toBe(200)
+      const body = res.body as { boundaries: string[]; pdsSync: string }
+      expect(body.pdsSync).toBe('failed')
+      // The local store mutation is still applied; only PDS propagation failed.
+      expect(enrollmentStore.addBoundary).toHaveBeenCalled()
     })
 
     it('rejects unauthenticated requests', async () => {
@@ -218,12 +263,32 @@ describe('admin boundary endpoints', () => {
         },
       )
       expect(res.statusCode).toBe(200)
-      const body = res.body as { did: string; boundaries: string[] }
+      const body = res.body as {
+        did: string
+        boundaries: string[]
+        pdsSync: string
+      }
       expect(body.did).toBe('did:plc:usagi')
+      expect(body.pdsSync).toBe('ok')
       expect(enrollmentStore.removeBoundary).toHaveBeenCalledWith(
         'did:plc:usagi',
         'did:web:nerv.tokyo.jp/posters-madness',
       )
+    })
+
+    it('reports pdsSync failed on PDS write failure', async () => {
+      const { app, enrollmentStore } = createCtx({ pdsWriteFails: true })
+      const res = await invokePostRoute(
+        app,
+        '/xrpc/zone.stratos.admin.removeBoundary',
+        {
+          did: 'did:plc:usagi',
+          boundary: 'did:web:nerv.tokyo.jp/posters-madness',
+        },
+      )
+      expect(res.statusCode).toBe(200)
+      expect((res.body as { pdsSync: string }).pdsSync).toBe('failed')
+      expect(enrollmentStore.removeBoundary).toHaveBeenCalled()
     })
 
     it('rejects unauthenticated requests', async () => {
@@ -270,12 +335,32 @@ describe('admin boundary endpoints', () => {
         },
       )
       expect(res.statusCode).toBe(200)
-      const body = res.body as { did: string; boundaries: string[] }
+      const body = res.body as {
+        did: string
+        boundaries: string[]
+        pdsSync: string
+      }
       expect(body.did).toBe('did:plc:usagi')
+      expect(body.pdsSync).toBe('ok')
       expect(enrollmentStore.setBoundaries).toHaveBeenCalledWith(
         'did:plc:usagi',
         ['did:web:nerv.tokyo.jp/bees', 'did:web:nerv.tokyo.jp/plants'],
       )
+    })
+
+    it('reports pdsSync failed on PDS write failure', async () => {
+      const { app, enrollmentStore } = createCtx({ pdsWriteFails: true })
+      const res = await invokePostRoute(
+        app,
+        '/xrpc/zone.stratos.admin.setBoundaries',
+        {
+          did: 'did:plc:usagi',
+          boundaries: ['did:web:nerv.tokyo.jp/bees'],
+        },
+      )
+      expect(res.statusCode).toBe(200)
+      expect((res.body as { pdsSync: string }).pdsSync).toBe('failed')
+      expect(enrollmentStore.setBoundaries).toHaveBeenCalled()
     })
 
     it('allows setting empty boundaries', async () => {

--- a/stratos-service/tests/integration.test.ts
+++ b/stratos-service/tests/integration.test.ts
@@ -189,6 +189,7 @@ describe('Integration: Full Stratos Flow', () => {
         mode: ENROLLMENT_MODE.OPEN,
         allowedDids: [],
         allowedPdsEndpoints: [],
+        serviceEnrollments: [],
       }
 
       const mockResolver = createMockIdResolver(null)
@@ -206,6 +207,7 @@ describe('Integration: Full Stratos Flow', () => {
         mode: ENROLLMENT_MODE.ALLOWLIST,
         allowedDids: [testDid],
         allowedPdsEndpoints: [],
+        serviceEnrollments: [],
       }
 
       const mockResolver = createMockIdResolver(null)
@@ -223,6 +225,7 @@ describe('Integration: Full Stratos Flow', () => {
         mode: ENROLLMENT_MODE.ALLOWLIST,
         allowedDids: [],
         allowedPdsEndpoints: [testPds],
+        serviceEnrollments: [],
       }
 
       const didDoc = {
@@ -252,6 +255,7 @@ describe('Integration: Full Stratos Flow', () => {
         mode: ENROLLMENT_MODE.ALLOWLIST,
         allowedDids: [],
         allowedPdsEndpoints: [testPds],
+        serviceEnrollments: [],
       }
 
       const mockResolver = createMockIdResolver(null)

--- a/stratos-service/tests/subscription-auth.test.ts
+++ b/stratos-service/tests/subscription-auth.test.ts
@@ -211,9 +211,21 @@ describe('createSubscribeAuthVerifier (stream auth gate)', () => {
 
     const result = await verifier(makeCtx(`Bearer ${token}`))
 
-    expect(result.credentials.type).toBe('service')
-    expect(result.credentials.did).toBe(keypair.did())
-    expect(result.credentials.iss).toBe(keypair.did())
+    if ('status' in result) {
+      throw new Error(
+        `expected an authenticated result, got ${JSON.stringify(result)}`,
+      )
+    }
+    // The xrpc-server StreamAuthVerifier types `credentials` as `unknown`; the
+    // subscribe verifier always returns the service-credential shape on success.
+    const credentials = result.credentials as {
+      type: string
+      did: string
+      iss: string
+    }
+    expect(credentials.type).toBe('service')
+    expect(credentials.did).toBe(keypair.did())
+    expect(credentials.iss).toBe(keypair.did())
   })
 
   it('rejects a request with no authorization header', async () => {

--- a/stratos-service/tests/utils/test-context.ts
+++ b/stratos-service/tests/utils/test-context.ts
@@ -67,6 +67,7 @@ export function createTestConfig(dataDir: string): StratosServiceConfig {
     logging: {
       level: 'info',
     },
+    adminDids: [],
     dpop: {
       requireNonce: false,
     },

--- a/test/docker-compose.test.yml
+++ b/test/docker-compose.test.yml
@@ -65,6 +65,7 @@ services:
       STRATOS_OAUTH_CLIENT_ID: ${STRATOS_OAUTH_CLIENT_ID:-http://127.0.0.1:3100/client-metadata.json}
       STRATOS_OAUTH_CLIENT_URI: ${STRATOS_OAUTH_CLIENT_URI:-http://127.0.0.1:3100}
       STRATOS_OAUTH_REDIRECT_URI: ${STRATOS_OAUTH_REDIRECT_URI:-http://127.0.0.1:3100/oauth/callback}
+      STRATOS_ADMIN_DIDS: ${STRATOS_ADMIN_DIDS:-}
     depends_on:
       ssl-init:
         condition: service_completed_successfully

--- a/test/scripts/lib/admin.ts
+++ b/test/scripts/lib/admin.ts
@@ -1,0 +1,5 @@
+// Admin auth constants shared across E2E phases. Mirrors
+// `ADMIN_SESSION_COOKIE` in stratos-service/src/oauth/admin-routes.ts; kept in
+// sync manually since the Deno suite does not import the service package.
+
+export const ADMIN_SESSION_COOKIE = 'stratos_admin_session'

--- a/test/scripts/lib/config.ts
+++ b/test/scripts/lib/config.ts
@@ -10,6 +10,13 @@ export { loadState }
 const envPath = new URL('../../../.env', import.meta.url).pathname
 await load({ envPath, export: true })
 
+// Defined before the loadState() call below: state.ts imports STATE_FILE from
+// this module (circular), so it must be initialized before loadState reads it,
+// or the read hits the temporal dead zone, throws, and loadState silently
+// falls back to empty state — baking the wrong SERVICE_DID into DOMAINS.
+export const STATE_FILE = new URL('../../test-state.json', import.meta.url)
+  .pathname
+
 const state = await loadState()
 
 // Use the ngrok URL from state if available, otherwise fall back to environment or default.
@@ -98,7 +105,19 @@ export const TEST_USERS: Record<string, TestUser> = {
 }
 
 export const TEST_ROOT = new URL('../..', import.meta.url).pathname
-export const STATE_FILE = new URL('../../test-state.json', import.meta.url)
-  .pathname
 export const TEST_DATA_DIR = new URL('../../test-data', import.meta.url)
   .pathname
+
+/**
+ * E2E user dedicated as the admin operator for the admin-API phase. Chosen so it
+ * is *not* mutated by the posts phase, keeping the admin phase decoupled. Its DID
+ * is injected into `STRATOS_ADMIN_DIDS` at setup so the service trusts it.
+ */
+export const ADMIN_OPERATOR_KEY = 'haruki'
+
+/**
+ * E2E user whose boundaries the admin-API phase mutates. Also untouched by the
+ * posts phase, so boundary churn here cannot perturb the post access-control
+ * assertions.
+ */
+export const ADMIN_TARGET_KEY = 'fuyuko'

--- a/test/scripts/lib/pds.ts
+++ b/test/scripts/lib/pds.ts
@@ -120,27 +120,26 @@ export async function deleteAccount(did: string): Promise<void> {
 /** Check for enrollment record on PDS */
 export async function getEnrollmentRecord(
   did: string,
-  accessJwt: string,
 ): Promise<{ exists: boolean; value?: Record<string, unknown> }> {
   const collection = 'zone.stratos.actor.enrollment'
+  // Enrollment records are keyed by the Stratos service DID, not a fixed
+  // "self" rkey, so list the collection instead of guessing the rkey.
+  const params = new URLSearchParams({ repo: did, collection })
   const res = await fetch(
-    `${PDS_URL}/xrpc/com.atproto.repo.getRecord?repo=${did}&collection=${collection}&rkey=self`,
-    {
-      headers: {
-        Authorization: `Bearer ${accessJwt}`,
-      },
-    },
+    `${PDS_URL}/xrpc/com.atproto.repo.listRecords?${params}`,
   )
-
-  if (res.status === 404) {
-    return { exists: false }
-  }
 
   if (!res.ok) {
     const body = await res.text()
-    throw new Error(`Failed to get enrollment record: ${res.status} ${body}`)
+    throw new Error(`Failed to list enrollment records: ${res.status} ${body}`)
   }
 
-  const data = await res.json()
-  return { exists: true, value: data.value }
+  const data = (await res.json()) as {
+    records?: Array<{ value?: Record<string, unknown> }>
+  }
+  const record = data.records?.[0]
+  if (!record) {
+    return { exists: false }
+  }
+  return { exists: true, value: record.value }
 }

--- a/test/scripts/lib/stratos.ts
+++ b/test/scripts/lib/stratos.ts
@@ -266,8 +266,10 @@ export async function unenroll(callerDid: string): Promise<void> {
   const res = await fetch(`${baseUrl}/xrpc/zone.stratos.enrollment.unenroll`, {
     method: 'POST',
     headers: {
+      'Content-Type': 'application/json',
       Authorization: `Bearer ${callerDid}`,
     },
+    body: JSON.stringify({}),
   })
 
   if (!res.ok) {

--- a/test/scripts/run-all.ts
+++ b/test/scripts/run-all.ts
@@ -31,6 +31,12 @@ if (postgresMode) {
 if (appviewMode) {
   Deno.env.set('STRATOS_E2E_APPVIEW', 'true')
 }
+if (directMode) {
+  // The admin-API phase needs a real OAuth login + a target with a live OAuth
+  // session (for the PDS enrollment-record rewrite). Direct enrollment provides
+  // neither, so the phase reads this flag and skips cleanly.
+  Deno.env.set('STRATOS_E2E_DIRECT', 'true')
+}
 
 interface Phase {
   name: string
@@ -52,6 +58,7 @@ const phases: Phase[] = [
   ...(appviewMode
     ? [{ name: 'AppView Service-Auth Feed', script: 'test-appview-feed.ts' }]
     : []),
+  { name: 'Admin API: Boundary Management', script: 'test-admin-api.ts' },
   { name: 'Unenrollment', script: 'test-unenrollment.ts' },
   { name: 'Teardown', script: 'teardown.ts', always: true },
 ]

--- a/test/scripts/setup.ts
+++ b/test/scripts/setup.ts
@@ -2,6 +2,7 @@
 // Setup script — creates PDS accounts, starts Stratos via Docker Compose, waits for health.
 
 import { TEST_DATA_DIR, TEST_ROOT, TEST_USERS } from './lib/config.ts'
+import { ADMIN_OPERATOR_KEY } from './lib/config.ts'
 import { accountExists, createAccount, createInviteCode } from './lib/pds.ts'
 import { waitForHealthy } from './lib/stratos.ts'
 import { loadState, saveState, type TestState } from './lib/state.ts'
@@ -92,6 +93,17 @@ function getEnvVars(state: TestState): Record<string, string> {
     envVars['STRATOS_OAUTH_REDIRECT_URI'] =
       'http://127.0.0.1:3100/oauth/callback'
   }
+
+  const operatorDid = state.users[ADMIN_OPERATOR_KEY]?.did
+  if (operatorDid) {
+    info(`Designating admin operator: ${operatorDid}`)
+    envVars['STRATOS_ADMIN_DIDS'] = operatorDid
+  } else {
+    warn(
+      `Admin operator "${ADMIN_OPERATOR_KEY}" has no DID in state — admin-API phase will be unable to authorize`,
+    )
+  }
+
   return envVars
 }
 

--- a/test/scripts/test-admin-api.ts
+++ b/test/scripts/test-admin-api.ts
@@ -50,7 +50,10 @@ async function getBaseUrl(): Promise<string> {
 async function screenshot(page: Page, name: string): Promise<void> {
   try {
     await Deno.mkdir(SCREENSHOT_DIR, { recursive: true })
-    await page.screenshot({ path: `${SCREENSHOT_DIR}/${name}.png`, fullPage: true })
+    await page.screenshot({
+      path: `${SCREENSHOT_DIR}/${name}.png`,
+      fullPage: true,
+    })
     dim(`Screenshot saved: test-data/screenshots/${name}.png`)
   } catch {
     dim(`Failed to save screenshot: ${name}.png`)
@@ -79,11 +82,16 @@ async function adminLogin(
     await page.goto(authorizeUrl, { waitUntil: 'load', timeout: 30_000 })
     await handleNgrokInterstitial(page)
 
-    await page.waitForSelector('input[type="password"], input[name="password"]', {
-      timeout: 15_000,
-    })
+    await page.waitForSelector(
+      'input[type="password"], input[name="password"]',
+      {
+        timeout: 15_000,
+      },
+    )
     const usernameInput =
-      (await page.$('input[name="username"]:not([readonly]):not([disabled])')) ??
+      (await page.$(
+        'input[name="username"]:not([readonly]):not([disabled])',
+      )) ??
       (await page.$('input[name="identifier"]:not([readonly]):not([disabled])'))
     if (usernameInput && !(await usernameInput.inputValue())) {
       await usernameInput.fill(handle)
@@ -95,7 +103,11 @@ async function adminLogin(
     await page.waitForURL(
       (url: URL) => {
         const s = url.toString()
-        return s.includes('/admin') || s.includes('authorize') || s.includes('consent')
+        return (
+          s.includes('/admin') ||
+          s.includes('authorize') ||
+          s.includes('consent')
+        )
       },
       { timeout: 15_000 },
     )
@@ -127,7 +139,10 @@ async function adminLogin(
     return sessionCookie?.value ?? null
   } catch (err) {
     await screenshot(page, 'admin-login-error')
-    fail('Admin OAuth login threw', err instanceof Error ? err.message : String(err))
+    fail(
+      'Admin OAuth login threw',
+      err instanceof Error ? err.message : String(err),
+    )
     return null
   } finally {
     await context.close()
@@ -202,11 +217,7 @@ async function waitForPdsBoundaries(
   let last: string[] | null = null
   while (Date.now() < deadline) {
     last = await readPdsBoundaries(did)
-    if (
-      last &&
-      last.length === want.size &&
-      last.every((b) => want.has(b))
-    ) {
+    if (last && last.length === want.size && last.every((b) => want.has(b))) {
       return last
     }
     await new Promise((r) => setTimeout(r, 1_000))
@@ -264,7 +275,11 @@ async function run(): Promise<void> {
   })
   let sessionCookie: string | null = null
   try {
-    sessionCookie = await adminLogin(browser, operator.handle, operator.password)
+    sessionCookie = await adminLogin(
+      browser,
+      operator.handle,
+      operator.password,
+    )
   } finally {
     await browser.close()
   }
@@ -325,7 +340,8 @@ async function run(): Promise<void> {
   )
   const setBody = set.body as BoundaryResponse
   assert(
-    set.status === 200 && sameSet(setBody?.boundaries ?? [], [DOMAINS.swordsmith]),
+    set.status === 200 &&
+      sameSet(setBody?.boundaries ?? [], [DOMAINS.swordsmith]),
     'setBoundaries replaces the boundary set',
     `status=${set.status}, boundaries=[${setBody?.boundaries?.join(', ') ?? ''}]`,
   )
@@ -336,7 +352,9 @@ async function run(): Promise<void> {
     'DB reflects setBoundaries',
     `[${dbAfterSet.join(', ')}]`,
   )
-  const pdsAfterSet = await waitForPdsBoundaries(target.did, [DOMAINS.swordsmith])
+  const pdsAfterSet = await waitForPdsBoundaries(target.did, [
+    DOMAINS.swordsmith,
+  ])
   assert(
     pdsAfterSet !== null && sameSet(pdsAfterSet, [DOMAINS.swordsmith]),
     'PDS enrollment record reflects setBoundaries',
@@ -351,7 +369,8 @@ async function run(): Promise<void> {
   )
   const removeBody = remove.body as BoundaryResponse
   assert(
-    remove.status === 200 && !removeBody?.boundaries?.includes(DOMAINS.swordsmith),
+    remove.status === 200 &&
+      !removeBody?.boundaries?.includes(DOMAINS.swordsmith),
     'removeBoundary drops the boundary',
     `status=${remove.status}, boundaries=[${removeBody?.boundaries?.join(', ') ?? ''}]`,
   )

--- a/test/scripts/test-admin-api.ts
+++ b/test/scripts/test-admin-api.ts
@@ -1,0 +1,378 @@
+#!/usr/bin/env -S deno run -A
+// Admin API phase — proves boundary management through the *admin API* (real
+// OAuth login, not a dev Bearer shortcut, which the verifier rejects by design).
+//
+// Unlike configure-boundaries.ts (direct DB writes), this exercises:
+//   1. a genuine admin OAuth login via Playwright → captures the session cookie
+//   2. boundary mutations via zone.stratos.admin.* using that cookie
+//   3. a two-way cross-check: the DB reflects the change AND the user's PDS
+//      enrollment record was rewritten (the part the direct-DB phase cannot cover)
+//   4. a negative case: the same mutation without the cookie → 401
+//
+// Skips cleanly under --direct (no real OAuth session, no PDS-record sync).
+
+import { type Browser, chromium, type Page } from 'npm:playwright@1.58.2'
+import {
+  ADMIN_OPERATOR_KEY,
+  ADMIN_TARGET_KEY,
+  DOMAINS,
+  PDS_URL,
+  STRATOS_URL,
+} from './lib/config.ts'
+import { ADMIN_SESSION_COOKIE } from './lib/admin.ts'
+import { getBoundaries } from './lib/backend.ts'
+import { enrollmentStatus, listPdsRecords } from './lib/stratos.ts'
+import { loadState, type UserState } from './lib/state.ts'
+import { dim, fail, info, pass, section, summary } from './lib/log.ts'
+
+const ENROLLMENT_COLLECTION = 'zone.stratos.actor.enrollment'
+const SCREENSHOT_DIR = new URL('../test-data/screenshots', import.meta.url)
+  .pathname
+
+let passed = 0
+let failed = 0
+
+function assert(condition: unknown, name: string, detail?: string): void {
+  if (condition) {
+    pass(name, detail)
+    passed++
+  } else {
+    fail(name, detail)
+    failed++
+  }
+}
+
+async function getBaseUrl(): Promise<string> {
+  const state = await loadState()
+  return state.ngrokUrl || STRATOS_URL
+}
+
+async function screenshot(page: Page, name: string): Promise<void> {
+  try {
+    await Deno.mkdir(SCREENSHOT_DIR, { recursive: true })
+    await page.screenshot({ path: `${SCREENSHOT_DIR}/${name}.png`, fullPage: true })
+    dim(`Screenshot saved: test-data/screenshots/${name}.png`)
+  } catch {
+    dim(`Failed to save screenshot: ${name}.png`)
+  }
+}
+
+/**
+ * Drive the admin OAuth flow for the operator and return the opaque admin
+ * session cookie value. Mirrors the enrollment OAuth flow but targets the admin
+ * authorize/callback routes; the cookie is set on the callback response, so it
+ * is present in the browser context even though /admin itself has no page yet.
+ */
+async function adminLogin(
+  browser: Browser,
+  handle: string,
+  password: string,
+): Promise<string | null> {
+  const baseUrl = await getBaseUrl()
+  const context = await browser.newContext({ ignoreHTTPSErrors: true })
+  await context.setExtraHTTPHeaders({ 'ngrok-skip-browser-warning': 'true' })
+  const page = await context.newPage()
+
+  try {
+    const authorizeUrl = `${baseUrl}/admin/oauth/authorize?handle=${encodeURIComponent(handle)}`
+    info(`Operator: starting admin OAuth at ${authorizeUrl}`)
+    await page.goto(authorizeUrl, { waitUntil: 'load', timeout: 30_000 })
+    await handleNgrokInterstitial(page)
+
+    await page.waitForSelector('input[type="password"], input[name="password"]', {
+      timeout: 15_000,
+    })
+    const usernameInput =
+      (await page.$('input[name="username"]:not([readonly]):not([disabled])')) ??
+      (await page.$('input[name="identifier"]:not([readonly]):not([disabled])'))
+    if (usernameInput && !(await usernameInput.inputValue())) {
+      await usernameInput.fill(handle)
+    }
+    await page.fill('input[type="password"], input[name="password"]', password)
+    await page.keyboard.press('Enter')
+
+    // Either we land back on the service (callback) or hit a consent screen.
+    await page.waitForURL(
+      (url: URL) => {
+        const s = url.toString()
+        return s.includes('/admin') || s.includes('authorize') || s.includes('consent')
+      },
+      { timeout: 15_000 },
+    )
+
+    if (!page.url().includes('/admin')) {
+      await page.waitForTimeout(1_000)
+      const acceptButton =
+        (await page.$('button:has-text("Accept")')) ??
+        (await page.$('button:has-text("Authorize")')) ??
+        (await page.$('button:has-text("Allow")')) ??
+        (await page.$('button[type="submit"]'))
+      if (acceptButton) {
+        await acceptButton.click()
+      } else {
+        await page.keyboard.press('Enter')
+      }
+      await page
+        .waitForURL((url: URL) => url.toString().includes(baseUrl), {
+          timeout: 15_000,
+        })
+        .catch(() => {
+          // /admin has no page yet (plan 004); the cookie is already set.
+        })
+    }
+
+    await page.waitForTimeout(500)
+    const cookies = await context.cookies()
+    const sessionCookie = cookies.find((c) => c.name === ADMIN_SESSION_COOKIE)
+    return sessionCookie?.value ?? null
+  } catch (err) {
+    await screenshot(page, 'admin-login-error')
+    fail('Admin OAuth login threw', err instanceof Error ? err.message : String(err))
+    return null
+  } finally {
+    await context.close()
+  }
+}
+
+async function handleNgrokInterstitial(page: Page): Promise<void> {
+  const ngrokButton = await page.$(
+    'button:has-text("Visit Site"), button:has-text("Visit the site")',
+  )
+  if (!ngrokButton && !page.url().includes('ngrok-free.app')) return
+  if (ngrokButton) {
+    await ngrokButton.click()
+    await page
+      .waitForNavigation({ waitUntil: 'networkidle', timeout: 30_000 })
+      .catch(() => {})
+  }
+}
+
+interface BoundaryResponse {
+  did: string
+  boundaries: string[]
+}
+
+async function adminFetch(
+  path: string,
+  body: Record<string, unknown>,
+  sessionCookie: string | null,
+): Promise<{ status: number; body: unknown }> {
+  const baseUrl = await getBaseUrl()
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    'ngrok-skip-browser-warning': 'true',
+  }
+  if (sessionCookie) {
+    headers['Cookie'] = `${ADMIN_SESSION_COOKIE}=${sessionCookie}`
+  }
+  const res = await fetch(`${baseUrl}/xrpc/${path}`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body),
+  })
+  let parsed: unknown
+  try {
+    parsed = await res.json()
+  } catch {
+    parsed = undefined
+  }
+  return { status: res.status, body: parsed }
+}
+
+/** Read the boundaries recorded on the user's PDS enrollment record. */
+async function readPdsBoundaries(did: string): Promise<string[] | null> {
+  const result = await listPdsRecords(PDS_URL, did, ENROLLMENT_COLLECTION)
+  const record = result.records[0]
+  if (!record) return null
+  const value = record.value as { boundaries?: Array<{ value?: string }> }
+  if (!Array.isArray(value.boundaries)) return []
+  return value.boundaries
+    .map((b) => b.value)
+    .filter((v): v is string => typeof v === 'string')
+}
+
+/** Poll the PDS until its enrollment record matches the expected boundary set. */
+async function waitForPdsBoundaries(
+  did: string,
+  expected: string[],
+  timeoutMs = 10_000,
+): Promise<string[] | null> {
+  const want = new Set(expected)
+  const deadline = Date.now() + timeoutMs
+  let last: string[] | null = null
+  while (Date.now() < deadline) {
+    last = await readPdsBoundaries(did)
+    if (
+      last &&
+      last.length === want.size &&
+      last.every((b) => want.has(b))
+    ) {
+      return last
+    }
+    await new Promise((r) => setTimeout(r, 1_000))
+  }
+  return last
+}
+
+function sameSet(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false
+  const set = new Set(a)
+  return b.every((v) => set.has(v))
+}
+
+async function run(): Promise<void> {
+  section('Admin API: Boundary Management')
+
+  if (Deno.env.get('STRATOS_E2E_DIRECT') === 'true') {
+    info(
+      'Direct mode: admin API phase requires a real OAuth login + live target session — skipping.',
+    )
+    return
+  }
+
+  const state = await loadState()
+  const operator = state.users[ADMIN_OPERATOR_KEY]
+  const target = state.users[ADMIN_TARGET_KEY]
+
+  if (!operator || !target) {
+    fail(
+      'Missing operator/target user state',
+      `operator=${ADMIN_OPERATOR_KEY}, target=${ADMIN_TARGET_KEY} — run setup.ts first`,
+    )
+    Deno.exit(1)
+  }
+
+  // Precondition: both users must be enrolled from the earlier phase.
+  for (const [label, user] of [
+    ['operator', operator],
+    ['target', target],
+  ] as Array<[string, UserState]>) {
+    const status = await enrollmentStatus(user.did).catch(() => null)
+    if (!status?.enrolled) {
+      fail(
+        `${label} not enrolled`,
+        `${user.handle} (${user.did}) must be enrolled before the admin phase`,
+      )
+      Deno.exit(1)
+    }
+  }
+
+  info('Performing real admin OAuth login (no dev bypass)...')
+  const browser = await chromium.launch({
+    headless: true,
+    args: ['--no-sandbox', '--disable-setuid-sandbox'],
+  })
+  let sessionCookie: string | null = null
+  try {
+    sessionCookie = await adminLogin(browser, operator.handle, operator.password)
+  } finally {
+    await browser.close()
+  }
+
+  assert(
+    sessionCookie,
+    'Captured admin session cookie from OAuth login',
+    sessionCookie ? 'cookie present' : 'no cookie — STOP-worthy per plan 003',
+  )
+  if (!sessionCookie) {
+    // Per plan 003 STOP condition: do not fall back to a Bearer shortcut.
+    summary(passed, failed)
+    Deno.exit(1)
+  }
+
+  // 1. "User appears in the admin panel" — lookup the enrolled target by DID.
+  const lookup = await enrollmentStatus(target.did)
+  assert(
+    lookup.enrolled,
+    'Admin lookup: target user appears as enrolled',
+    `${target.handle} (${target.did})`,
+  )
+
+  // 2. addBoundary via the admin API.
+  const add = await adminFetch(
+    'zone.stratos.admin.addBoundary',
+    { did: target.did, boundary: DOMAINS.aekea },
+    sessionCookie,
+  )
+  const addBody = add.body as BoundaryResponse
+  assert(
+    add.status === 200 && addBody?.boundaries?.includes(DOMAINS.aekea),
+    'addBoundary returns the added boundary',
+    `status=${add.status}, boundaries=[${addBody?.boundaries?.join(', ') ?? ''}]`,
+  )
+
+  // 3a. DB cross-check.
+  const dbAfterAdd = await getBoundaries(target.did)
+  assert(
+    dbAfterAdd.includes(DOMAINS.aekea),
+    'DB reflects the added boundary',
+    `[${dbAfterAdd.join(', ')}]`,
+  )
+
+  // 3b. PDS cross-check — the part the direct-DB phase cannot cover.
+  const pdsAfterAdd = await waitForPdsBoundaries(target.did, dbAfterAdd)
+  assert(
+    pdsAfterAdd !== null && pdsAfterAdd.includes(DOMAINS.aekea),
+    'PDS enrollment record rewritten with the added boundary',
+    pdsAfterAdd ? `[${pdsAfterAdd.join(', ')}]` : 'no PDS record found',
+  )
+
+  // 4. setBoundaries via the admin API to a single known boundary.
+  const set = await adminFetch(
+    'zone.stratos.admin.setBoundaries',
+    { did: target.did, boundaries: [DOMAINS.swordsmith] },
+    sessionCookie,
+  )
+  const setBody = set.body as BoundaryResponse
+  assert(
+    set.status === 200 && sameSet(setBody?.boundaries ?? [], [DOMAINS.swordsmith]),
+    'setBoundaries replaces the boundary set',
+    `status=${set.status}, boundaries=[${setBody?.boundaries?.join(', ') ?? ''}]`,
+  )
+
+  const dbAfterSet = await getBoundaries(target.did)
+  assert(
+    sameSet(dbAfterSet, [DOMAINS.swordsmith]),
+    'DB reflects setBoundaries',
+    `[${dbAfterSet.join(', ')}]`,
+  )
+  const pdsAfterSet = await waitForPdsBoundaries(target.did, [DOMAINS.swordsmith])
+  assert(
+    pdsAfterSet !== null && sameSet(pdsAfterSet, [DOMAINS.swordsmith]),
+    'PDS enrollment record reflects setBoundaries',
+    pdsAfterSet ? `[${pdsAfterSet.join(', ')}]` : 'no PDS record found',
+  )
+
+  // 5. removeBoundary via the admin API.
+  const remove = await adminFetch(
+    'zone.stratos.admin.removeBoundary',
+    { did: target.did, boundary: DOMAINS.swordsmith },
+    sessionCookie,
+  )
+  const removeBody = remove.body as BoundaryResponse
+  assert(
+    remove.status === 200 && !removeBody?.boundaries?.includes(DOMAINS.swordsmith),
+    'removeBoundary drops the boundary',
+    `status=${remove.status}, boundaries=[${removeBody?.boundaries?.join(', ') ?? ''}]`,
+  )
+
+  // 6. Negative case: same mutation with no session cookie → 401.
+  const unauth = await adminFetch(
+    'zone.stratos.admin.addBoundary',
+    { did: target.did, boundary: DOMAINS.aekea },
+    null,
+  )
+  assert(
+    unauth.status === 401,
+    'addBoundary without session cookie is rejected (401)',
+    `status=${unauth.status}`,
+  )
+
+  summary(passed, failed)
+  if (failed > 0) Deno.exit(1)
+}
+
+run().catch((err) => {
+  console.error('\nAdmin API phase failed:', err)
+  Deno.exit(1)
+})

--- a/test/scripts/test-auth-failures.ts
+++ b/test/scripts/test-auth-failures.ts
@@ -65,7 +65,7 @@ async function fillPdsLoginForm(page: Page, handle: string) {
 
 async function verifyPdsError(page: Page) {
   const errorSelector =
-    'text=/Invalid username or password|Authentication failed|Invalid identifier or password/i'
+    'text=/Invalid username or password|Authentication failed|Invalid identifier or password|Wrong identifier or password/i'
   try {
     await page.waitForSelector(errorSelector, {
       timeout: 10_000,

--- a/test/scripts/test-enrollment.ts
+++ b/test/scripts/test-enrollment.ts
@@ -294,7 +294,11 @@ async function run() {
       }
 
       const status = await checkEnrollmentStatus(userState.did)
-      if (status?.enrolled) {
+      // `enrolled: true` alone is ambiguous — the status endpoint reports
+      // eligible-but-not-yet-enrolled DIDs the same way (active: false, no
+      // rkey). Only an existing enrollment record (enrollmentRkey present)
+      // means OAuth has actually run and we can safely skip it.
+      if (status?.enrolled && status.enrollmentRkey) {
         warn(`${userDef.name} (${userState.did}) already enrolled — skipping`)
         userState.enrolled = true
         passed++

--- a/test/scripts/test-posts.ts
+++ b/test/scripts/test-posts.ts
@@ -240,7 +240,17 @@ async function testDeniedAccess(
       "Kaoruko cannot read Rei's post (swordsmith vs aekea)",
     )
     if (!result.ok) {
-      assertTrue(result.status === 403, 'Denied with 403 Forbidden')
+      // The service hides cross-boundary records behind RecordNotFound (400)
+      // rather than 403, so a denied viewer can't even confirm the record
+      // exists. Test 7 relies on the same semantics.
+      assertTrue(
+        result.status === 400 ||
+          result.status === 403 ||
+          result.status === 404 ||
+          result.error.includes('RecordNotFound'),
+        'Cross-boundary read denied (not found)',
+        `status=${result.status}`,
+      )
     }
   }
 
@@ -258,7 +268,17 @@ async function testDeniedAccess(
 
     assertFalse(result.ok, 'Unauthenticated caller cannot read private post')
     if (!result.ok) {
-      assertTrue(result.status === 401, 'Denied with 401 Unauthorized')
+      // Anonymous reads of a boundary-scoped record resolve to RecordNotFound
+      // (400) too: with no caller DID there are no shared boundaries, and the
+      // service hides the record rather than returning a bare 401.
+      assertTrue(
+        result.status === 400 ||
+          result.status === 401 ||
+          result.status === 404 ||
+          result.error.includes('RecordNotFound'),
+        'Unauthenticated read denied (not found)',
+        `status=${result.status}`,
+      )
     }
   }
 }

--- a/test/scripts/test-unenrollment.ts
+++ b/test/scripts/test-unenrollment.ts
@@ -2,7 +2,7 @@
 import { loadState, saveState } from './lib/state.ts'
 import { error, fail, info, pass, section } from './lib/log.ts'
 import { enrollmentStatus, unenroll } from './lib/stratos.ts'
-import { createSession, getEnrollmentRecord } from './lib/pds.ts'
+import { getEnrollmentRecord } from './lib/pds.ts'
 import { STRATOS_URL } from './lib/config.ts'
 
 async function run() {
@@ -43,11 +43,7 @@ async function run() {
     }
     pass(`User ${testUserKey} is active in Stratos`)
 
-    const session = await createSession(userState.handle, userState.password)
-    const recordBefore = await getEnrollmentRecord(
-      userState.did,
-      session.accessJwt,
-    )
+    const recordBefore = await getEnrollmentRecord(userState.did)
     if (!recordBefore.exists) {
       throw new Error('Enrollment record not found on PDS before unenrollment')
     }
@@ -65,10 +61,7 @@ async function run() {
     pass('User is inactive in Stratos')
 
     // 4. Verify PDS record deletion
-    const recordAfter = await getEnrollmentRecord(
-      userState.did,
-      session.accessJwt,
-    )
+    const recordAfter = await getEnrollmentRecord(userState.did)
     if (recordAfter.exists) {
       throw new Error(
         'Enrollment record still exists on PDS after unenrollment',
@@ -102,7 +95,7 @@ async function run() {
     userState.enrolled = false
     passed++
   } catch (err) {
-    error(`Unenrollment test failed for ${testUserKey}`, err)
+    error(`Unenrollment test failed for ${testUserKey}`, { error: String(err) })
     failed++
   }
 


### PR DESCRIPTION
## Description

Remove the admin password used to hit the admin endpoints and introduce oauth authorization with proper auditing:

Changes included:

* Admins sign in with their own accounts. Access is gated by an
  approved-DID allowlist (STRATOS_ADMIN_DIDS).
* Oauth Sessions stored server-side.
* Every boundary change is attributed via audit log.

* Tightened up the edges.
  - CORS is scoped to a known allowlist of origins instead of being wide open.
  - CSRF protection screens admin requests by Origin/Referer, backed by Strict same-site cookies — so another site can't
  quietly act on an admin's behalf.

## Related Issues

<!-- Link to related issues using keywords like "Closes #123" or "Fixes #456" -->

## Testing

<!-- Describe the tests you ran to verify your changes -->

## Type of Change

<!-- Mark relevant options with an "x" -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Build/CI changes
- [ ] Test improvements
