### PR TITLE
Bump stratos-client to 0.1.2

### DIFF
--- a/stratos-client/package.json
+++ b/stratos-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@northskysocial/stratos-client",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Client library for Stratos private namespace service",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Summary
- Bump `@northskysocial/stratos-client` version 0.1.1 -> 0.1.2 to publish a fresh version to GitHub Packages (needed to unblock the `northsky-social-app` install, which is pinned to a non-existent `0.1.2-ripperoni`).
