### PR TITLE
Publish stratos-core to GitHub Packages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish stratos-client to GitHub Packages
+name: Publish stratos packages to GitHub Packages
 
 on:
   push:
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   publish:
-    name: Publish stratos-client
+    name: Publish stratos packages
     runs-on: ubuntu-latest
 
     steps:
@@ -45,24 +45,50 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      # stratos-core is published first: stratos-client declares a runtime
+      # dependency on it, so it must exist in the registry for the client to
+      # be installable by external consumers.
+      - name: Build stratos-core
+        run: pnpm --filter @northskysocial/stratos-core build
+
+      - name: Check if stratos-core version already published
+        id: core-version-check
+        run: |
+          VERSION=$(node -p "require('./stratos-core/package.json').version")
+          if npm view "@northskysocial/stratos-core@${VERSION}" version --registry=https://npm.pkg.github.com 2>/dev/null; then
+            echo "skip=true" >> $GITHUB_OUTPUT
+            echo "stratos-core ${VERSION} already published — skipping"
+          else
+            echo "skip=false" >> $GITHUB_OUTPUT
+            echo "stratos-core ${VERSION} not yet published — proceeding"
+          fi
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish stratos-core to GitHub Packages
+        if: steps.core-version-check.outputs.skip == 'false'
+        run: pnpm --filter @northskysocial/stratos-core publish --no-git-checks
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build stratos-client
         run: pnpm --filter @northskysocial/stratos-client build
 
-      - name: Check if version already published
+      - name: Check if stratos-client version already published
         id: version-check
         run: |
           VERSION=$(node -p "require('./stratos-client/package.json').version")
           if npm view "@northskysocial/stratos-client@${VERSION}" version --registry=https://npm.pkg.github.com 2>/dev/null; then
             echo "skip=true" >> $GITHUB_OUTPUT
-            echo "Version ${VERSION} already published — skipping"
+            echo "stratos-client ${VERSION} already published — skipping"
           else
             echo "skip=false" >> $GITHUB_OUTPUT
-            echo "Version ${VERSION} not yet published — proceeding"
+            echo "stratos-client ${VERSION} not yet published — proceeding"
           fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Publish to GitHub Packages
+      - name: Publish stratos-client to GitHub Packages
         if: steps.version-check.outputs.skip == 'false'
         run: pnpm --filter @northskysocial/stratos-client publish --no-git-checks
         env:

--- a/stratos-core/package.json
+++ b/stratos-core/package.json
@@ -80,5 +80,37 @@
     "dist",
     "src"
   ],
-  "license": "MIT"
+  "license": "MIT",
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/",
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      },
+      "./atproto": {
+        "types": "./dist/atproto/index.d.ts",
+        "import": "./dist/atproto/index.js"
+      },
+      "./validation": {
+        "types": "./dist/validation/index.d.ts",
+        "import": "./dist/validation/index.js"
+      },
+      "./db": {
+        "types": "./dist/db/index.d.ts",
+        "import": "./dist/db/index.js"
+      },
+      "./db/pg": {
+        "types": "./dist/db/pg.d.ts",
+        "import": "./dist/db/pg.js"
+      },
+      "./enrollment": {
+        "types": "./dist/enrollment/index.d.ts",
+        "import": "./dist/enrollment/index.js"
+      }
+    }
+  }
 }


### PR DESCRIPTION
## Summary
`@northskysocial/stratos-client` declares a runtime dependency on `@northskysocial/stratos-core` (pnpm substitutes the concrete `0.1.0` for `workspace:*` at publish time), but **core was never published**, so any external install of the client 404s on the core dependency. This is why the client has never been installable from the registry.

This publishes `stratos-core` alongside `stratos-client`:

- **`stratos-core/package.json`**: add `publishConfig` with the GitHub Packages registry + `access: public`, and dist-based `main`/`types`/`exports` overrides. The top-level `main`/`exports` still point at `src`, so intra-monorepo consumers keep importing the raw TypeScript source via workspace links; the `publishConfig` overrides apply **only to the published tarball**. The published `exports` map covers the six built subpaths (`.`, `./atproto`, `./validation`, `./db`, `./db/pg`, `./enrollment`) and omits `./tests` (excluded from the build).
- **`.github/workflows/publish.yml`**: build + publish `stratos-core` before `stratos-client`, each guarded by its own "already published?" version check.

## Validation
Built `stratos-core` locally (`tsc -p tsconfig.build.json && tsc-alias`) and confirmed `dist/` contains all six export entry points with matching `.js` + `.d.ts`, and that `dist/enrollment/index.js` (the only subpath `stratos-client` imports) re-exports with proper `.js` ESM extensions.

## Note
`stratos-core@0.1.0` will publish fresh; `stratos-client@0.1.2` is already published (its check will skip). No version bumps needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)