### PR TITLE
Adjust how docs ci does the checks, also include checks in PRs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,8 +17,7 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
+
 
 concurrency:
   group: pages-${{ github.ref }}
@@ -31,6 +30,7 @@ jobs:
 
     steps:
       - name: Checkout
+        persist-credentials: false
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup pnpm
@@ -89,6 +89,9 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
+    permissions:
+      pages: write
+      id-token: write
 
     steps:
       - name: Deploy to GitHub Pages

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,12 @@ on:
       - main
     paths:
       - 'docs/**'
+      - '.github/workflows/docs.yml'
+
+  pull_request:
+    paths:
+      - 'docs/**'
+      - '.github/workflows/docs.yml'
 
   workflow_dispatch:
 
@@ -15,7 +21,7 @@ permissions:
   id-token: write
 
 concurrency:
-  group: pages
+  group: pages-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
@@ -25,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v5
@@ -38,6 +44,7 @@ jobs:
           node-version: '24'
 
       - name: Setup Pages
+        if: github.event_name != 'pull_request'
         uses: actions/configure-pages@v6
 
       - name: Install dependencies
@@ -49,19 +56,27 @@ jobs:
         run: npm run docs:build
 
       - name: Markdown Lint
-        uses: DavidAnson/markdownlint-cli2-action@v19
+        uses: DavidAnson/markdownlint-cli2-action@6bf21b07787794f89a243495939cd651942aeabe # v24.1.0
         with:
           config: 'docs/.markdownlint-cli2.jsonc'
           globs: 'docs/**/*.md'
 
+      # Docs links are root-relative to the VitePress site root (docs/) and are
+      # written without a file extension, so lychee needs both to resolve them.
       - name: Check Broken Links
         uses: lycheeverse/lychee-action@v2
         with:
-          args: --verbose --no-progress --exclude-path docs/node_modules './docs/**/*.md'
+          args: >-
+            --verbose --no-progress
+            --root-dir ${{ github.workspace }}/docs
+            --fallback-extensions md
+            --exclude-path docs/node_modules
+            './docs/**/*.md'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload artifact
+        if: github.event_name != 'pull_request'
         uses: actions/upload-pages-artifact@v4
         with:
           path: docs/.vitepress/dist
@@ -70,6 +85,7 @@ jobs:
     name: Deploy to Pages
     runs-on: ubuntu-latest
     needs: build
+    if: github.event_name != 'pull_request'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,7 +18,6 @@ on:
 permissions:
   contents: read
 
-
 concurrency:
   group: pages-${{ github.ref }}
   cancel-in-progress: false
@@ -30,7 +29,8 @@ jobs:
 
     steps:
       - name: Checkout
-        persist-credentials: false
+        with:
+          persist-credentials: false
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup pnpm


### PR DESCRIPTION
## Description

Docs publish on merge kept failing as checks weren't set to the correct root.

## Related Issues

<!-- Link to related issues using keywords like "Closes #123" or "Fixes #456" -->

## Testing

<!-- Describe the tests you ran to verify your changes -->

## Type of Change

<!-- Mark relevant options with an "x" -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [x] Build/CI changes
- [ ] Test improvements


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Improved Markdown formatting and broken-link checks.
  - Extensionless documentation links are now validated more accurately.
  - Documentation updates in pull requests are checked automatically.

- **Chores**
  - Improved the safety and reliability of documentation workflows.
  - Reduced unnecessary publishing and deployment actions during pull request validation.
  - Strengthened workflow permissions and credential handling.
  - Updated documentation validation tooling for more consistent results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->