### PR TITLE
docs(stratos) - Add explainer on spaces alignment

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -29,7 +29,7 @@ export default defineConfig({
       },
       {
         text: 'Architecture',
-        link: '/architecture/hydration',
+        link: '/architecture/permissioned-spaces',
         activeMatch: '/architecture/',
       },
       { text: 'Lexicons', link: '/lexicons/', activeMatch: '/lexicons/' },
@@ -97,6 +97,10 @@ export default defineConfig({
         {
           text: 'Architecture',
           items: [
+            {
+              text: 'Permissioned Spaces',
+              link: '/architecture/permissioned-spaces',
+            },
             { text: 'Hydration Architecture', link: '/architecture/hydration' },
             { text: 'Indexer Architecture', link: '/indexer-architecture' },
             {

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -104,6 +104,10 @@ export default defineConfig({
             { text: 'Hydration Architecture', link: '/architecture/hydration' },
             { text: 'Indexer Architecture', link: '/indexer-architecture' },
             {
+              text: 'Feed Generator',
+              link: '/architecture/feed-generator',
+            },
+            {
               text: 'Enrollment Signing',
               link: '/architecture/enrollment-signing',
             },

--- a/docs/.vitepress/theme/components/FeedgenIndexingFlow.vue
+++ b/docs/.vitepress/theme/components/FeedgenIndexingFlow.vue
@@ -1,0 +1,279 @@
+<template>
+  <div ref="containerRef" class="anim-outer">
+    <div ref="stageRef" class="stage">
+      <svg class="arsvg" viewBox="0 0 900 440">
+        <defs>
+          <marker
+            id="fgi-ml"
+            markerHeight="5"
+            markerWidth="7"
+            orient="auto"
+            refX="7"
+            refY="2.5"
+          >
+            <polygon fill="#9145EC" points="0 0,7 2.5,0 5" />
+          </marker>
+          <marker
+            id="fgi-mg"
+            markerHeight="5"
+            markerWidth="7"
+            orient="auto"
+            refX="7"
+            refY="2.5"
+          >
+            <polygon fill="#24cf6e" points="0 0,7 2.5,0 5" />
+          </marker>
+        </defs>
+        <path
+          class="ar"
+          d="M 238 196 L 370 116"
+          marker-end="url(#fgi-ml)"
+          stroke="#9145EC"
+        />
+        <path
+          class="ar"
+          d="M 480 156 L 480 288"
+          marker-end="url(#fgi-ml)"
+          stroke="#9145EC"
+        />
+        <path
+          class="ar"
+          d="M 238 252 L 370 332"
+          marker-end="url(#fgi-ml)"
+          stroke="#9145EC"
+        />
+        <path
+          class="ar"
+          d="M 590 336 L 680 244"
+          marker-end="url(#fgi-mg)"
+          stroke="#24cf6e"
+        />
+      </svg>
+
+      <div class="node" style="left: 38px; top: 170px; width: 200px">
+        <div class="ni">🏛️</div>
+        <div class="nn">Stratos Service</div>
+        <div class="ns">upstream sync streams</div>
+      </div>
+
+      <div class="node" style="left: 370px; top: 44px; width: 220px">
+        <div class="ni">📇</div>
+        <div class="nn">enrolled_actor</div>
+        <div class="ns">who to follow</div>
+        <div class="tag">from #enrollment events</div>
+      </div>
+
+      <div class="node" style="left: 370px; top: 288px; width: 220px">
+        <div class="ni">⚙️</div>
+        <div class="nn">Per-actor workers</div>
+        <div class="ns">one stream per actor</div>
+      </div>
+
+      <div class="node" style="left: 680px; top: 152px; width: 185px">
+        <div class="ni">🗃️</div>
+        <div class="nn">Local index</div>
+        <div class="ns">SQLite (WAL)</div>
+        <div class="tag">post · post_boundary · cursor</div>
+      </div>
+
+      <div class="pill" style="left: 128px; top: 88px">
+        <div class="pill-row">
+          <span class="icon">📶</span
+          ><span class="c-pur">service-level subscribeRecords</span>
+        </div>
+        <div class="pill-row">
+          <span class="c-dim">no did · replays #enrollment</span>
+        </div>
+      </div>
+
+      <div class="pill" style="left: 500px; top: 196px">
+        <div class="pill-row">
+          <span class="icon">🔁</span
+          ><span class="c-pur">starts / stops workers</span>
+        </div>
+      </div>
+
+      <div class="pill" style="left: 96px; top: 330px">
+        <div class="pill-row">
+          <span class="icon">📶</span
+          ><span class="c-pur">per-actor subscribeRecords</span>
+        </div>
+        <div class="pill-row">
+          <span class="c-dim">did + domain=&lt;boundary&gt;</span>
+        </div>
+      </div>
+
+      <div class="pill" style="left: 596px; top: 366px">
+        <div class="pill-row">
+          <span class="icon">📦</span
+          ><span class="c-grn">decoded commits → rows</span>
+        </div>
+        <div class="pill-row">
+          <span class="c-dim">cursors persisted for resume</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { onBeforeUnmount, onMounted, ref } from 'vue'
+
+const containerRef = ref(null)
+const stageRef = ref(null)
+
+function fit() {
+  if (!containerRef.value || !stageRef.value) return
+  const scale = containerRef.value.clientWidth / 900
+  stageRef.value.style.transform = `scale(${scale})`
+}
+
+let ro
+onMounted(() => {
+  ro = new ResizeObserver(fit)
+  ro.observe(containerRef.value)
+  fit()
+})
+onBeforeUnmount(() => {
+  ro?.disconnect()
+})
+</script>
+
+<style scoped>
+.anim-outer {
+  width: 100%;
+  aspect-ratio: 900 / 440;
+  position: relative;
+  overflow: hidden;
+  background: #1f0b35;
+  border-radius: 12px;
+}
+
+.stage {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 900px;
+  height: 440px;
+  transform-origin: top left;
+  --card: #240d45;
+  --bdr: #7780dc;
+  --txt: #cdc6ff;
+  --dim: #8878b0;
+  --blu: #9145ec;
+  --grn: #24cf6e;
+  --pur: #9145ec;
+}
+
+.stage::before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 700px;
+  height: 340px;
+  background: radial-gradient(
+    ellipse,
+    rgba(80, 20, 130, 0.25) 0%,
+    transparent 70%
+  );
+  pointer-events: none;
+}
+
+.node {
+  position: absolute;
+  background: var(--card);
+  border: 1.5px solid var(--bdr);
+  border-radius: 12px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
+  padding: 12px 14px;
+}
+
+.ni {
+  font-size: 32px;
+  line-height: 1;
+}
+.nn {
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--txt);
+  text-align: center;
+  white-space: nowrap;
+}
+.ns {
+  font-size: 12px;
+  color: var(--dim);
+  text-align: center;
+  white-space: nowrap;
+}
+
+.tag {
+  font-size: 11px;
+  padding: 3px 10px;
+  border-radius: 99px;
+  font-weight: 600;
+  white-space: nowrap;
+  margin-top: 3px;
+  background: rgba(145, 69, 236, 0.15);
+  color: var(--blu);
+  border: 1px solid rgba(145, 69, 236, 0.35);
+}
+
+.pill {
+  position: absolute;
+  background: var(--card);
+  border: 1px solid var(--bdr);
+  border-radius: 8px;
+  padding: 7px 12px;
+  font-size: 11px;
+  line-height: 1.6;
+  pointer-events: none;
+}
+.pill-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  white-space: nowrap;
+}
+.pill-row .icon {
+  font-size: 14px;
+}
+
+.c-grn {
+  color: var(--grn);
+}
+.c-pur {
+  color: var(--pur);
+}
+.c-dim {
+  color: var(--dim);
+}
+
+@keyframes fgi-march {
+  to {
+    stroke-dashoffset: -12;
+  }
+}
+
+.arsvg {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  overflow: visible;
+}
+.ar {
+  fill: none;
+  stroke-width: 2;
+  stroke-linecap: butt;
+  stroke-dasharray: 8 4;
+  animation: fgi-march 0.5s linear infinite;
+}
+</style>

--- a/docs/.vitepress/theme/components/FeedgenRequestFlow.vue
+++ b/docs/.vitepress/theme/components/FeedgenRequestFlow.vue
@@ -72,11 +72,19 @@
       <div class="panel" style="left: 640px; top: 168px; width: 220px">
         <div class="prow">
           <span class="icon">🔏</span>
-          <span class="c-txt">verify service JWT<br /><span class="c-dim">against the user&#39;s DID doc</span></span>
+          <span class="c-txt"
+            >verify service JWT<br /><span class="c-dim"
+              >against the user&#39;s DID doc</span
+            ></span
+          >
         </div>
         <div class="prow">
           <span class="icon">🧭</span>
-          <span class="c-txt">viewer boundaries<br /><span class="c-dim">TTL + LRU cache</span></span>
+          <span class="c-txt"
+            >viewer boundaries<br /><span class="c-dim"
+              >TTL + LRU cache</span
+            ></span
+          >
         </div>
         <div class="prow">
           <span class="icon">🗃️</span>

--- a/docs/.vitepress/theme/components/FeedgenRequestFlow.vue
+++ b/docs/.vitepress/theme/components/FeedgenRequestFlow.vue
@@ -1,0 +1,326 @@
+<template>
+  <div ref="containerRef" class="anim-outer">
+    <div ref="stageRef" class="stage">
+      <svg class="arsvg" viewBox="0 0 900 520">
+        <defs>
+          <marker
+            id="fgr-ml"
+            markerHeight="5"
+            markerWidth="7"
+            orient="auto"
+            refX="7"
+            refY="2.5"
+          >
+            <polygon fill="#9145EC" points="0 0,7 2.5,0 5" />
+          </marker>
+          <marker
+            id="fgr-mg"
+            markerHeight="5"
+            markerWidth="7"
+            orient="auto"
+            refX="7"
+            refY="2.5"
+          >
+            <polygon fill="#24cf6e" points="0 0,7 2.5,0 5" />
+          </marker>
+        </defs>
+        <path
+          class="ar"
+          d="M 208 240 L 330 240"
+          marker-end="url(#fgr-ml)"
+          stroke="#9145EC"
+        />
+        <path
+          class="ar"
+          d="M 520 218 L 640 120"
+          marker-end="url(#fgr-ml)"
+          stroke="#9145EC"
+        />
+        <path
+          class="ar"
+          d="M 750 396 L 750 424"
+          marker-end="url(#fgr-ml)"
+          stroke="#9145EC"
+        />
+        <path
+          class="ar"
+          d="M 640 300 L 208 262"
+          marker-end="url(#fgr-mg)"
+          stroke="#24cf6e"
+        />
+      </svg>
+
+      <div class="node" style="left: 38px; top: 204px; width: 170px">
+        <div class="ni">💻</div>
+        <div class="nn">Client</div>
+        <div class="ns">boundary member</div>
+      </div>
+
+      <div class="node" style="left: 330px; top: 196px; width: 190px">
+        <div class="ni">🗄️</div>
+        <div class="nn">User&#39;s PDS</div>
+        <div class="ns">OAuth + DPoP</div>
+        <div class="tag tb">atproto-proxy</div>
+      </div>
+
+      <div class="node" style="left: 640px; top: 36px; width: 220px">
+        <div class="ni">📡</div>
+        <div class="nn">Feed Generator</div>
+        <div class="ns">did:web…#stratos_feedgen</div>
+      </div>
+
+      <div class="panel" style="left: 640px; top: 168px; width: 220px">
+        <div class="prow">
+          <span class="icon">🔏</span>
+          <span class="c-txt">verify service JWT<br /><span class="c-dim">against the user&#39;s DID doc</span></span>
+        </div>
+        <div class="prow">
+          <span class="icon">🧭</span>
+          <span class="c-txt">viewer boundaries<br /><span class="c-dim">TTL + LRU cache</span></span>
+        </div>
+        <div class="prow">
+          <span class="icon">🗃️</span>
+          <span class="c-txt">query local post index</span>
+        </div>
+        <div class="prow">
+          <span class="icon">💧</span>
+          <span class="c-txt">hydrate index misses</span>
+        </div>
+        <div class="prow">
+          <span class="icon">🖼️</span>
+          <span class="c-txt">blobs from S3 cache</span>
+        </div>
+      </div>
+
+      <div class="node" style="left: 640px; top: 424px; width: 220px">
+        <div class="ni">🏛️</div>
+        <div class="nn">Upstream Stratos</div>
+        <div class="ns">resolveEnrollments · hydrateRecords · getBlob</div>
+      </div>
+
+      <div class="pill" style="left: 218px; top: 158px">
+        <div class="pill-row">
+          <span class="icon">📄</span><span class="c-pur">getFeed</span>
+        </div>
+        <div class="pill-row">
+          <span class="c-dim">zone.stratos.feedgen.getFeed</span>
+        </div>
+      </div>
+
+      <div class="pill" style="left: 470px; top: 100px">
+        <div class="pill-row">
+          <span class="icon">🎫</span><span class="c-pur">service JWT</span>
+        </div>
+        <div class="pill-row">
+          <span class="c-dim">iss = user DID · exp &lt; 60s</span>
+        </div>
+      </div>
+
+      <div class="pill" style="left: 430px; top: 400px">
+        <div class="pill-row">
+          <span class="icon">🎫</span><span class="c-pur">on cache miss</span>
+        </div>
+        <div class="pill-row">
+          <span class="c-dim">service JWT · iss = feedgen DID</span>
+        </div>
+      </div>
+
+      <div class="pill" style="left: 300px; top: 300px">
+        <div class="pill-row">
+          <span class="icon">📦</span><span class="c-grn">hydrated feed</span>
+        </div>
+        <div class="pill-row">
+          <span class="c-dim">boundary-filtered, labels attached</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { onBeforeUnmount, onMounted, ref } from 'vue'
+
+const containerRef = ref(null)
+const stageRef = ref(null)
+
+function fit() {
+  if (!containerRef.value || !stageRef.value) return
+  const scale = containerRef.value.clientWidth / 900
+  stageRef.value.style.transform = `scale(${scale})`
+}
+
+let ro
+onMounted(() => {
+  ro = new ResizeObserver(fit)
+  ro.observe(containerRef.value)
+  fit()
+})
+onBeforeUnmount(() => {
+  ro?.disconnect()
+})
+</script>
+
+<style scoped>
+.anim-outer {
+  width: 100%;
+  aspect-ratio: 900 / 520;
+  position: relative;
+  overflow: hidden;
+  background: #1f0b35;
+  border-radius: 12px;
+}
+
+.stage {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 900px;
+  height: 520px;
+  transform-origin: top left;
+  --card: #240d45;
+  --bdr: #7780dc;
+  --txt: #cdc6ff;
+  --dim: #8878b0;
+  --blu: #9145ec;
+  --grn: #24cf6e;
+  --pur: #9145ec;
+}
+
+.stage::before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 700px;
+  height: 400px;
+  background: radial-gradient(
+    ellipse,
+    rgba(80, 20, 130, 0.25) 0%,
+    transparent 70%
+  );
+  pointer-events: none;
+}
+
+.node {
+  position: absolute;
+  background: var(--card);
+  border: 1.5px solid var(--bdr);
+  border-radius: 12px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
+  padding: 12px 14px;
+}
+
+.ni {
+  font-size: 32px;
+  line-height: 1;
+}
+.nn {
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--txt);
+  text-align: center;
+  white-space: nowrap;
+}
+.ns {
+  font-size: 12px;
+  color: var(--dim);
+  text-align: center;
+}
+
+.tag {
+  font-size: 11px;
+  padding: 3px 10px;
+  border-radius: 99px;
+  font-weight: 600;
+  white-space: nowrap;
+  margin-top: 3px;
+  background: rgba(145, 69, 236, 0.15);
+  color: var(--blu);
+  border: 1px solid rgba(145, 69, 236, 0.35);
+}
+.tb {
+  background: rgba(145, 69, 236, 0.15);
+}
+
+.panel {
+  position: absolute;
+  background: var(--card);
+  border: 1.5px solid var(--bdr);
+  border-radius: 12px;
+  padding: 10px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.prow {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  font-size: 12px;
+  line-height: 1.4;
+}
+.prow .icon {
+  font-size: 14px;
+}
+.c-txt {
+  color: var(--txt);
+}
+
+.pill {
+  position: absolute;
+  background: var(--card);
+  border: 1px solid var(--bdr);
+  border-radius: 8px;
+  padding: 7px 12px;
+  font-size: 11px;
+  line-height: 1.6;
+  pointer-events: none;
+}
+.pill-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  white-space: nowrap;
+}
+.pill-row .icon {
+  font-size: 14px;
+}
+
+.c-grn {
+  color: var(--grn);
+}
+.c-pur {
+  color: var(--pur);
+}
+.c-dim {
+  color: var(--dim);
+}
+
+@keyframes fgr-march {
+  to {
+    stroke-dashoffset: -12;
+  }
+}
+
+.arsvg {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  overflow: visible;
+}
+.ar {
+  fill: none;
+  stroke-width: 2;
+  stroke-linecap: butt;
+  stroke-dasharray: 8 4;
+  animation: fgr-march 0.5s linear infinite;
+}
+</style>

--- a/docs/.vitepress/theme/components/SpaceCredentialFlowAnimation.vue
+++ b/docs/.vitepress/theme/components/SpaceCredentialFlowAnimation.vue
@@ -1,0 +1,492 @@
+<template>
+  <div ref="containerRef" class="anim-outer">
+    <div ref="stageRef" class="stage">
+      <svg class="arsvg" viewBox="0 0 900 520">
+        <defs>
+          <marker
+            id="scf-ml"
+            markerHeight="5"
+            markerWidth="7"
+            orient="auto"
+            refX="7"
+            refY="2.5"
+          >
+            <polygon fill="#9145EC" points="0 0,7 2.5,0 5" />
+          </marker>
+          <marker
+            id="scf-mg"
+            markerHeight="5"
+            markerWidth="7"
+            orient="auto"
+            refX="7"
+            refY="2.5"
+          >
+            <polygon fill="#24cf6e" points="0 0,7 2.5,0 5" />
+          </marker>
+        </defs>
+        <path
+          id="scf-a1"
+          class="ar"
+          d="M 208 240 L 654 148"
+          marker-end="url(#scf-ml)"
+          stroke="#9145EC"
+        />
+        <path
+          id="scf-a2"
+          class="ar"
+          d="M 654 160 L 208 250"
+          marker-end="url(#scf-mg)"
+          stroke="#24cf6e"
+        />
+        <path
+          id="scf-a3"
+          class="ar"
+          d="M 208 262 L 654 370"
+          marker-end="url(#scf-ml)"
+          stroke="#9145EC"
+        />
+        <path
+          id="scf-a4"
+          class="ar"
+          d="M 654 382 L 208 272"
+          marker-end="url(#scf-mg)"
+          stroke="#24cf6e"
+        />
+      </svg>
+
+      <div
+        id="scf-ncl"
+        class="node"
+        style="left: 38px; top: 210px; width: 170px"
+      >
+        <div class="ni">💻</div>
+        <div class="nn">Client</div>
+        <div class="ns">space member</div>
+        <div id="scf-cl-record" class="av-content">record ✓</div>
+      </div>
+
+      <div
+        id="scf-nau"
+        class="node"
+        style="left: 654px; top: 88px; width: 200px"
+      >
+        <div class="ni">🏛️</div>
+        <div class="nn">Space Authority</div>
+        <div class="ns">stratos.example.com</div>
+        <div class="tag tp">mints credentials</div>
+      </div>
+
+      <div
+        id="scf-nrh"
+        class="node"
+        style="left: 654px; top: 318px; width: 200px"
+      >
+        <div class="ni">🗄️</div>
+        <div class="nn">Repo Host</div>
+        <div class="ns">any host of the space</div>
+        <div class="tag tb">serves records</div>
+      </div>
+
+      <div id="scf-req-pill" class="pill" style="left: 300px; top: 130px">
+        <div class="pill-row">
+          <span class="icon">🔐</span
+          ><span class="c-pur">getSpaceCredential</span>
+        </div>
+        <div class="pill-row">
+          <span class="c-dim">at://…/space/…/engineering</span>
+        </div>
+      </div>
+
+      <div
+        id="scf-chk-pill"
+        class="pill"
+        style="left: 654px; top: 202px; width: 200px"
+      >
+        <div class="pill-row">
+          <span class="icon">🔍</span
+          ><span class="c-pur">checking enrollment</span>
+        </div>
+        <div class="pill-row">
+          <span class="icon">📱</span><span class="c-pur">app allow-list</span>
+        </div>
+      </div>
+
+      <div id="scf-cred-pill" class="pill" style="left: 310px; top: 196px">
+        <div class="pill-row">
+          <span class="icon">🎫</span
+          ><span class="c-grn">space credential (JWT)</span>
+        </div>
+        <div class="pill-row">
+          <span class="c-dim">iss: authority · no aud · 2h</span>
+        </div>
+      </div>
+
+      <div id="scf-read-pill" class="pill" style="left: 300px; top: 330px">
+        <div class="pill-row">
+          <span class="icon">📄</span><span class="c-pur">getRecord</span>
+        </div>
+        <div class="pill-row">
+          <span class="c-dim">Bearer: space credential</span>
+        </div>
+      </div>
+
+      <div
+        id="scf-vfy-pill"
+        class="pill"
+        style="left: 654px; top: 432px; width: 200px"
+      >
+        <div class="pill-row">
+          <span class="icon">🔏</span
+          ><span class="c-pur">verify via DID document</span>
+        </div>
+        <div class="pill-row">
+          <span class="c-dim">offline, no callback</span>
+        </div>
+      </div>
+
+      <div id="scf-rec-pill" class="pill" style="left: 330px; top: 300px">
+        <div class="pill-row">
+          <span class="icon">📦</span><span class="c-grn">record</span>
+        </div>
+        <div class="pill-row">
+          <span class="c-dim">in-space only, no leak</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { onBeforeUnmount, onMounted, ref } from 'vue'
+
+const containerRef = ref(null)
+const stageRef = ref(null)
+
+const $ = (id) => stageRef.value?.querySelector('#' + id)
+const add = (el, ...c) => el?.classList.add(...c)
+const rm = (el, ...c) => el?.classList.remove(...c)
+
+function fit() {
+  if (!containerRef.value || !stageRef.value) return
+  const scale = containerRef.value.clientWidth / 900
+  stageRef.value.style.transform = `scale(${scale})`
+}
+
+const timeouts = []
+const later = (fn, ms) => {
+  const t = setTimeout(fn, ms)
+  timeouts.push(t)
+  return t
+}
+
+function reset() {
+  ;['scf-ncl', 'scf-nau', 'scf-nrh'].forEach((id) =>
+    rm($(id), 'hl', 'ok', 'processing'),
+  )
+  ;['scf-a1', 'scf-a2', 'scf-a3', 'scf-a4'].forEach((id) => rm($(id), 'show'))
+  ;[
+    'scf-req-pill',
+    'scf-chk-pill',
+    'scf-cred-pill',
+    'scf-read-pill',
+    'scf-vfy-pill',
+    'scf-rec-pill',
+  ].forEach((id) => rm($(id), 'show'))
+  rm($('scf-cl-record'), 'show')
+}
+
+const steps = [
+  {
+    dur: 2000,
+    fn() {
+      add($('scf-ncl'), 'hl')
+      add($('scf-nau'), 'hl')
+      add($('scf-a1'), 'show')
+      later(() => add($('scf-req-pill'), 'show'), 250)
+    },
+  },
+  {
+    dur: 2200,
+    fn() {
+      rm($('scf-req-pill'), 'show')
+      rm($('scf-ncl'), 'hl')
+      rm($('scf-nau'), 'hl')
+      add($('scf-nau'), 'processing')
+      add($('scf-chk-pill'), 'show')
+    },
+  },
+  {
+    dur: 2200,
+    fn() {
+      rm($('scf-nau'), 'processing')
+      rm($('scf-chk-pill'), 'show')
+      add($('scf-a2'), 'show')
+      later(() => add($('scf-cred-pill'), 'show'), 250)
+    },
+  },
+  {
+    dur: 2000,
+    fn() {
+      rm($('scf-cred-pill'), 'show')
+      add($('scf-ncl'), 'hl')
+      add($('scf-nrh'), 'hl')
+      add($('scf-a3'), 'show')
+      later(() => add($('scf-read-pill'), 'show'), 250)
+    },
+  },
+  {
+    dur: 2200,
+    fn() {
+      rm($('scf-read-pill'), 'show')
+      rm($('scf-ncl'), 'hl')
+      rm($('scf-nrh'), 'hl')
+      add($('scf-nrh'), 'processing')
+      add($('scf-vfy-pill'), 'show')
+    },
+  },
+  {
+    dur: 2200,
+    fn() {
+      rm($('scf-nrh'), 'processing')
+      rm($('scf-vfy-pill'), 'show')
+      add($('scf-a4'), 'show')
+      later(() => add($('scf-rec-pill'), 'show'), 250)
+    },
+  },
+  {
+    dur: 2000,
+    fn() {
+      rm($('scf-rec-pill'), 'show')
+      add($('scf-ncl'), 'ok')
+      add($('scf-cl-record'), 'show')
+    },
+  },
+]
+
+function run(i) {
+  steps[i].fn()
+  later(() => {
+    const next = (i + 1) % steps.length
+    if (next === 0) {
+      reset()
+      later(() => run(0), 800)
+    } else run(next)
+  }, steps[i].dur)
+}
+
+let ro
+onMounted(() => {
+  ro = new ResizeObserver(fit)
+  ro.observe(containerRef.value)
+  fit()
+  reset()
+  later(() => run(0), 600)
+})
+onBeforeUnmount(() => {
+  ro?.disconnect()
+  timeouts.forEach(clearTimeout)
+})
+</script>
+
+<style scoped>
+.anim-outer {
+  width: 100%;
+  aspect-ratio: 900 / 520;
+  position: relative;
+  overflow: hidden;
+  background: #1f0b35;
+  border-radius: 12px;
+}
+
+.stage {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 900px;
+  height: 520px;
+  transform-origin: top left;
+  --card: #240d45;
+  --bdr: #7780dc;
+  --txt: #cdc6ff;
+  --dim: #8878b0;
+  --blu: #9145ec;
+  --grn: #24cf6e;
+  --pur: #9145ec;
+}
+
+.stage::before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 700px;
+  height: 400px;
+  background: radial-gradient(
+    ellipse,
+    rgba(80, 20, 130, 0.25) 0%,
+    transparent 70%
+  );
+  pointer-events: none;
+}
+
+.node {
+  position: absolute;
+  background: var(--card);
+  border: 1.5px solid var(--bdr);
+  border-radius: 12px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
+  padding: 12px 14px;
+  transition:
+    border-color 0.4s,
+    box-shadow 0.4s,
+    opacity 0.4s,
+    transform 0.4s;
+}
+
+.ni {
+  font-size: 32px;
+  line-height: 1;
+}
+.nn {
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--txt);
+  text-align: center;
+  white-space: nowrap;
+}
+.ns {
+  font-size: 13px;
+  color: var(--dim);
+  text-align: center;
+  white-space: nowrap;
+}
+
+.tag {
+  font-size: 11px;
+  padding: 3px 10px;
+  border-radius: 99px;
+  font-weight: 600;
+  white-space: nowrap;
+  margin-top: 3px;
+}
+.tb {
+  background: rgba(145, 69, 236, 0.15);
+  color: var(--blu);
+  border: 1px solid rgba(145, 69, 236, 0.35);
+}
+.tp {
+  background: rgba(145, 69, 236, 0.15);
+  color: var(--pur);
+  border: 1px solid rgba(145, 69, 236, 0.3);
+}
+
+.av-content {
+  position: absolute;
+  bottom: 4px;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 11px;
+  color: var(--dim);
+  opacity: 0;
+  transition: opacity 0.4s;
+  white-space: nowrap;
+}
+.av-content.show {
+  opacity: 1;
+  color: var(--grn);
+}
+
+.pill {
+  position: absolute;
+  background: var(--card);
+  border: 1px solid var(--bdr);
+  border-radius: 8px;
+  padding: 7px 12px;
+  font-size: 11px;
+  line-height: 1.6;
+  opacity: 0;
+  transform: scale(0.85);
+  pointer-events: none;
+  transition:
+    opacity 0.4s,
+    transform 0.4s;
+}
+.pill.show {
+  opacity: 1;
+  transform: scale(1);
+}
+.pill-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  white-space: nowrap;
+}
+.pill-row .icon {
+  font-size: 14px;
+}
+
+.c-grn {
+  color: var(--grn);
+}
+.c-pur {
+  color: var(--pur);
+}
+.c-dim {
+  color: var(--dim);
+}
+
+@keyframes scf-breathe {
+  0%,
+  100% {
+    box-shadow: 0 0 22px rgba(145, 69, 236, 0.35);
+  }
+  50% {
+    box-shadow: 0 0 42px rgba(145, 69, 236, 0.7);
+  }
+}
+@keyframes scf-march {
+  to {
+    stroke-dashoffset: -12;
+  }
+}
+
+.hl {
+  border-color: var(--blu) !important;
+  animation: scf-breathe 2s ease-in-out infinite;
+}
+.ok {
+  border-color: var(--grn) !important;
+  box-shadow: 0 0 24px rgba(36, 207, 110, 0.4) !important;
+}
+.processing {
+  border-color: var(--pur) !important;
+  animation: scf-breathe 1.2s ease-in-out infinite !important;
+}
+
+.arsvg {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  overflow: visible;
+}
+.ar {
+  fill: none;
+  stroke-width: 2;
+  stroke-linecap: butt;
+  stroke-dasharray: 8 4;
+  opacity: 0;
+  transition: opacity 0.4s;
+}
+.ar.show {
+  opacity: 1;
+  animation: scf-march 0.5s linear infinite;
+}
+</style>

--- a/docs/.vitepress/theme/components/SpaceDataResidencyAnimation.vue
+++ b/docs/.vitepress/theme/components/SpaceDataResidencyAnimation.vue
@@ -1,0 +1,480 @@
+<template>
+  <div ref="containerRef" class="anim-outer">
+    <div ref="stageRef" class="stage">
+      <svg class="arsvg" viewBox="0 0 900 520">
+        <defs>
+          <marker
+            id="sdr-ml"
+            markerHeight="5"
+            markerWidth="7"
+            orient="auto"
+            refX="7"
+            refY="2.5"
+          >
+            <polygon fill="#9145EC" points="0 0,7 2.5,0 5" />
+          </marker>
+          <marker
+            id="sdr-mg"
+            markerHeight="5"
+            markerWidth="7"
+            orient="auto"
+            refX="7"
+            refY="2.5"
+          >
+            <polygon fill="#24cf6e" points="0 0,7 2.5,0 5" />
+          </marker>
+        </defs>
+        <path
+          id="sdr-a1"
+          class="ar"
+          d="M 208 252 L 360 252"
+          marker-end="url(#sdr-ml)"
+          stroke="#9145EC"
+        />
+        <path
+          id="sdr-a2"
+          class="ar"
+          d="M 566 218 L 654 130"
+          marker-end="url(#sdr-ml)"
+          stroke="#9145EC"
+        />
+        <path
+          id="sdr-a3"
+          class="ar"
+          d="M 566 286 L 654 396"
+          marker-end="url(#sdr-mg)"
+          stroke="#24cf6e"
+        />
+      </svg>
+
+      <div
+        id="sdr-nus"
+        class="node"
+        style="left: 38px; top: 208px; width: 170px"
+      >
+        <div class="ni">👤</div>
+        <div class="nn">User</div>
+        <div class="ns">did:plc:ewvi7n…</div>
+      </div>
+
+      <div
+        id="sdr-nst"
+        class="node"
+        style="left: 360px; top: 190px; width: 206px"
+      >
+        <div class="ni">🏛️</div>
+        <div class="nn">Stratos Service</div>
+        <div class="ns">space authority</div>
+        <div class="tag tp">full records, signed repo</div>
+      </div>
+
+      <div
+        id="sdr-npds"
+        class="node"
+        style="left: 654px; top: 40px; width: 200px"
+      >
+        <div class="ni">🗄️</div>
+        <div class="nn">User&#39;s PDS</div>
+        <div class="ns">public network</div>
+        <div class="tag tb">enrollment pointer only</div>
+      </div>
+
+      <div
+        id="sdr-nh2"
+        class="node"
+        style="left: 654px; top: 360px; width: 200px"
+      >
+        <div class="ni">📦</div>
+        <div class="nn">Second Host</div>
+        <div class="ns">another Stratos / PDS</div>
+        <div id="sdr-h2-ok" class="av-content">same CIDs, verified ✓</div>
+      </div>
+
+      <div id="sdr-write-pill" class="pill" style="left: 190px; top: 176px">
+        <div class="pill-row">
+          <span class="icon">✍️</span><span class="c-pur">createRecord</span>
+        </div>
+        <div class="pill-row">
+          <span class="c-dim">zone.stratos.feed.post</span>
+        </div>
+      </div>
+
+      <div
+        id="sdr-store-pill"
+        class="pill"
+        style="left: 360px; top: 312px; width: 206px"
+      >
+        <div class="pill-row">
+          <span class="icon">🌳</span
+          ><span class="c-pur">MST commit, IPLD blocks</span>
+        </div>
+        <div class="pill-row">
+          <span class="c-dim">signed with the user&#39;s key</span>
+        </div>
+      </div>
+
+      <div id="sdr-ptr-pill" class="pill" style="left: 470px; top: 110px">
+        <div class="pill-row">
+          <span class="icon">📌</span
+          ><span class="c-blu">enrollment record</span>
+        </div>
+        <div class="pill-row">
+          <span class="c-dim">no content on the firehose</span>
+        </div>
+      </div>
+
+      <div id="sdr-car-pill" class="pill" style="left: 452px; top: 344px">
+        <div class="pill-row">
+          <span class="icon">🚚</span><span class="c-grn">repo.car</span>
+        </div>
+        <div class="pill-row">
+          <span class="c-dim">blocks + signed commit</span>
+        </div>
+      </div>
+
+      <div
+        id="sdr-vfy-pill"
+        class="pill"
+        style="left: 654px; top: 466px; width: 200px"
+      >
+        <div class="pill-row">
+          <span class="icon">🔏</span
+          ><span class="c-pur">verifying signatures</span>
+        </div>
+        <div class="pill-row">
+          <span class="c-dim">no trust in the old host</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { onBeforeUnmount, onMounted, ref } from 'vue'
+
+const containerRef = ref(null)
+const stageRef = ref(null)
+
+const $ = (id) => stageRef.value?.querySelector('#' + id)
+const add = (el, ...c) => el?.classList.add(...c)
+const rm = (el, ...c) => el?.classList.remove(...c)
+
+function fit() {
+  if (!containerRef.value || !stageRef.value) return
+  const scale = containerRef.value.clientWidth / 900
+  stageRef.value.style.transform = `scale(${scale})`
+}
+
+const timeouts = []
+const later = (fn, ms) => {
+  const t = setTimeout(fn, ms)
+  timeouts.push(t)
+  return t
+}
+
+function reset() {
+  ;['sdr-nus', 'sdr-nst', 'sdr-npds', 'sdr-nh2'].forEach((id) =>
+    rm($(id), 'hl', 'ok', 'processing'),
+  )
+  ;['sdr-a1', 'sdr-a2', 'sdr-a3'].forEach((id) => rm($(id), 'show'))
+  ;[
+    'sdr-write-pill',
+    'sdr-store-pill',
+    'sdr-ptr-pill',
+    'sdr-car-pill',
+    'sdr-vfy-pill',
+  ].forEach((id) => rm($(id), 'show'))
+  rm($('sdr-h2-ok'), 'show')
+}
+
+const steps = [
+  {
+    dur: 2000,
+    fn() {
+      add($('sdr-nus'), 'hl')
+      add($('sdr-nst'), 'hl')
+      add($('sdr-a1'), 'show')
+      later(() => add($('sdr-write-pill'), 'show'), 250)
+    },
+  },
+  {
+    dur: 2200,
+    fn() {
+      rm($('sdr-write-pill'), 'show')
+      rm($('sdr-nus'), 'hl')
+      rm($('sdr-nst'), 'hl')
+      add($('sdr-nst'), 'processing')
+      add($('sdr-store-pill'), 'show')
+    },
+  },
+  {
+    dur: 2200,
+    fn() {
+      rm($('sdr-nst'), 'processing')
+      rm($('sdr-store-pill'), 'show')
+      add($('sdr-npds'), 'hl')
+      add($('sdr-a2'), 'show')
+      later(() => add($('sdr-ptr-pill'), 'show'), 250)
+    },
+  },
+  {
+    dur: 2200,
+    fn() {
+      rm($('sdr-npds'), 'hl')
+      rm($('sdr-ptr-pill'), 'show')
+      rm($('sdr-a2'), 'show')
+      add($('sdr-nh2'), 'hl')
+      add($('sdr-a3'), 'show')
+      later(() => add($('sdr-car-pill'), 'show'), 250)
+    },
+  },
+  {
+    dur: 2200,
+    fn() {
+      rm($('sdr-car-pill'), 'show')
+      rm($('sdr-nh2'), 'hl')
+      add($('sdr-nh2'), 'processing')
+      add($('sdr-vfy-pill'), 'show')
+    },
+  },
+  {
+    dur: 2200,
+    fn() {
+      rm($('sdr-nh2'), 'processing')
+      rm($('sdr-vfy-pill'), 'show')
+      add($('sdr-nh2'), 'ok')
+      add($('sdr-h2-ok'), 'show')
+    },
+  },
+]
+
+function run(i) {
+  steps[i].fn()
+  later(() => {
+    const next = (i + 1) % steps.length
+    if (next === 0) {
+      reset()
+      later(() => run(0), 800)
+    } else run(next)
+  }, steps[i].dur)
+}
+
+let ro
+onMounted(() => {
+  ro = new ResizeObserver(fit)
+  ro.observe(containerRef.value)
+  fit()
+  reset()
+  later(() => run(0), 600)
+})
+onBeforeUnmount(() => {
+  ro?.disconnect()
+  timeouts.forEach(clearTimeout)
+})
+</script>
+
+<style scoped>
+.anim-outer {
+  width: 100%;
+  aspect-ratio: 900 / 520;
+  position: relative;
+  overflow: hidden;
+  background: #1f0b35;
+  border-radius: 12px;
+}
+
+.stage {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 900px;
+  height: 520px;
+  transform-origin: top left;
+  --card: #240d45;
+  --bdr: #7780dc;
+  --txt: #cdc6ff;
+  --dim: #8878b0;
+  --blu: #9145ec;
+  --grn: #24cf6e;
+  --pur: #9145ec;
+}
+
+.stage::before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 700px;
+  height: 400px;
+  background: radial-gradient(
+    ellipse,
+    rgba(80, 20, 130, 0.25) 0%,
+    transparent 70%
+  );
+  pointer-events: none;
+}
+
+.node {
+  position: absolute;
+  background: var(--card);
+  border: 1.5px solid var(--bdr);
+  border-radius: 12px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
+  padding: 12px 14px;
+  transition:
+    border-color 0.4s,
+    box-shadow 0.4s,
+    opacity 0.4s,
+    transform 0.4s;
+}
+
+.ni {
+  font-size: 32px;
+  line-height: 1;
+}
+.nn {
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--txt);
+  text-align: center;
+  white-space: nowrap;
+}
+.ns {
+  font-size: 13px;
+  color: var(--dim);
+  text-align: center;
+  white-space: nowrap;
+}
+
+.tag {
+  font-size: 11px;
+  padding: 3px 10px;
+  border-radius: 99px;
+  font-weight: 600;
+  white-space: nowrap;
+  margin-top: 3px;
+}
+.tb {
+  background: rgba(145, 69, 236, 0.15);
+  color: var(--blu);
+  border: 1px solid rgba(145, 69, 236, 0.35);
+}
+.tp {
+  background: rgba(145, 69, 236, 0.15);
+  color: var(--pur);
+  border: 1px solid rgba(145, 69, 236, 0.3);
+}
+
+.av-content {
+  position: absolute;
+  bottom: 4px;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 11px;
+  color: var(--dim);
+  opacity: 0;
+  transition: opacity 0.4s;
+  white-space: nowrap;
+}
+.av-content.show {
+  opacity: 1;
+  color: var(--grn);
+}
+
+.pill {
+  position: absolute;
+  background: var(--card);
+  border: 1px solid var(--bdr);
+  border-radius: 8px;
+  padding: 7px 12px;
+  font-size: 11px;
+  line-height: 1.6;
+  opacity: 0;
+  transform: scale(0.85);
+  pointer-events: none;
+  transition:
+    opacity 0.4s,
+    transform 0.4s;
+}
+.pill.show {
+  opacity: 1;
+  transform: scale(1);
+}
+.pill-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  white-space: nowrap;
+}
+.pill-row .icon {
+  font-size: 14px;
+}
+
+.c-blu {
+  color: var(--blu);
+}
+.c-grn {
+  color: var(--grn);
+}
+.c-pur {
+  color: var(--pur);
+}
+.c-dim {
+  color: var(--dim);
+}
+
+@keyframes sdr-breathe {
+  0%,
+  100% {
+    box-shadow: 0 0 22px rgba(145, 69, 236, 0.35);
+  }
+  50% {
+    box-shadow: 0 0 42px rgba(145, 69, 236, 0.7);
+  }
+}
+@keyframes sdr-march {
+  to {
+    stroke-dashoffset: -12;
+  }
+}
+
+.hl {
+  border-color: var(--blu) !important;
+  animation: sdr-breathe 2s ease-in-out infinite;
+}
+.ok {
+  border-color: var(--grn) !important;
+  box-shadow: 0 0 24px rgba(36, 207, 110, 0.4) !important;
+}
+.processing {
+  border-color: var(--pur) !important;
+  animation: sdr-breathe 1.2s ease-in-out infinite !important;
+}
+
+.arsvg {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  overflow: visible;
+}
+.ar {
+  fill: none;
+  stroke-width: 2;
+  stroke-linecap: butt;
+  stroke-dasharray: 8 4;
+  opacity: 0;
+  transition: opacity 0.4s;
+}
+.ar.show {
+  opacity: 1;
+  animation: sdr-march 0.5s linear infinite;
+}
+</style>

--- a/docs/architecture/feed-generator.md
+++ b/docs/architecture/feed-generator.md
@@ -10,10 +10,10 @@ browsable timelines. It subscribes to a single upstream Stratos service,
 maintains a local post index, and serves fully hydrated, boundary-scoped
 feeds to clients over two XRPC methods:
 
-| Lexicon                              | Type                    | Purpose                                        |
-| ------------------------------------ | ----------------------- | ---------------------------------------------- |
-| `zone.stratos.feedgen.getFeed`       | query (authenticated)   | Hydrated posts the viewer is entitled to see   |
-| `zone.stratos.feedgen.describeFeed`  | query (unauthenticated) | The configured feed list, for introspection    |
+| Lexicon                             | Type                    | Purpose                                      |
+| ----------------------------------- | ----------------------- | -------------------------------------------- |
+| `zone.stratos.feedgen.getFeed`      | query (authenticated)   | Hydrated posts the viewer is entitled to see |
+| `zone.stratos.feedgen.describeFeed` | query (unauthenticated) | The configured feed list, for introspection  |
 
 The spec-shaped `zone.stratos.space.getRecord` endpoint answers one record
 for one caller; it cannot build a timeline. The feed generator exists to
@@ -49,8 +49,8 @@ request time. Two kinds of background subscription keep that index current:
 
 <FeedgenIndexingFlow />
 
-The service-level stream tells the feed generator *who* to follow; the
-per-actor streams deliver *what* they wrote, already scoped to the
+The service-level stream tells the feed generator _who_ to follow; the
+per-actor streams deliver _what_ they wrote, already scoped to the
 boundaries the feed generator is entitled to observe. Posts land in a SQLite
 (WAL) index keyed by uri, author, boundary, and `sortAt`, with cursors
 persisted so restarts resume rather than re-index.
@@ -59,12 +59,12 @@ persisted so restarts resume rather than re-index.
 
 Every hop is authenticated, and each direction uses a different mechanism:
 
-| Direction                     | Mechanism                                                                             | Verified by                                             |
-| ----------------------------- | ------------------------------------------------------------------------------------- | ------------------------------------------------------- |
-| Client → PDS                  | OAuth + DPoP                                                                          | The PDS                                                  |
-| PDS → Feed generator          | Service-auth JWT: `iss` = user DID, `aud` = feedgen DID, `lxm` = endpoint, `exp` < 60s | Feed generator, via the user's DID document              |
-| Feed generator → Stratos      | Service-auth JWT: `iss` = feedgen DID, `aud` = Stratos DID, `lxm` = endpoint           | Stratos `service` verifier                               |
-| Feed generator → Stratos (WS) | Same JWT shape as a Bearer header, `lxm` = `zone.stratos.sync.subscribeRecords`        | Stratos `subscribeAuth` verifier                         |
+| Direction                     | Mechanism                                                                              | Verified by                                 |
+| ----------------------------- | -------------------------------------------------------------------------------------- | ------------------------------------------- |
+| Client → PDS                  | OAuth + DPoP                                                                           | The PDS                                     |
+| PDS → Feed generator          | Service-auth JWT: `iss` = user DID, `aud` = feedgen DID, `lxm` = endpoint, `exp` < 60s | Feed generator, via the user's DID document |
+| Feed generator → Stratos      | Service-auth JWT: `iss` = feedgen DID, `aud` = Stratos DID, `lxm` = endpoint           | Stratos `service` verifier                  |
+| Feed generator → Stratos (WS) | Same JWT shape as a Bearer header, `lxm` = `zone.stratos.sync.subscribeRecords`        | Stratos `subscribeAuth` verifier            |
 
 The feed generator has its own identity: a `did:web` whose DID document
 publishes an `#atproto` verification method (its signing key) and a service
@@ -97,12 +97,12 @@ client's job, the same division of responsibility the public network uses.
 The feed generator binds to exactly one upstream Stratos service. Required
 configuration:
 
-| Env var               | Description                                            |
-| --------------------- | ------------------------------------------------------ |
-| `FEEDGEN_SERVICE_DID` | The feed generator's own DID (`did:web:<host>`)        |
-| `FEEDGEN_SIGNING_KEY` | Its signing key (hex secp256k1)                        |
-| `STRATOS_SERVICE_URL` | Base URL of the upstream Stratos                       |
-| `STRATOS_SERVICE_DID` | DID of the upstream Stratos                            |
+| Env var               | Description                                     |
+| --------------------- | ----------------------------------------------- |
+| `FEEDGEN_SERVICE_DID` | The feed generator's own DID (`did:web:<host>`) |
+| `FEEDGEN_SIGNING_KEY` | Its signing key (hex secp256k1)                 |
+| `STRATOS_SERVICE_URL` | Base URL of the upstream Stratos                |
+| `STRATOS_SERVICE_DID` | DID of the upstream Stratos                     |
 
 Because all reads go through the local index and blob cache, the feed
 generator absorbs feed traffic that would otherwise hit the Stratos service,

--- a/docs/architecture/feed-generator.md
+++ b/docs/architecture/feed-generator.md
@@ -1,0 +1,113 @@
+# Feed Generator
+
+<script setup>
+import FeedgenRequestFlow from '../.vitepress/theme/components/FeedgenRequestFlow.vue'
+import FeedgenIndexingFlow from '../.vitepress/theme/components/FeedgenIndexingFlow.vue'
+</script>
+
+`stratos-feedgen` is a standalone service that turns a Stratos instance into
+browsable timelines. It subscribes to a single upstream Stratos service,
+maintains a local post index, and serves fully hydrated, boundary-scoped
+feeds to clients over two XRPC methods:
+
+| Lexicon                              | Type                    | Purpose                                        |
+| ------------------------------------ | ----------------------- | ---------------------------------------------- |
+| `zone.stratos.feedgen.getFeed`       | query (authenticated)   | Hydrated posts the viewer is entitled to see   |
+| `zone.stratos.feedgen.describeFeed`  | query (unauthenticated) | The configured feed list, for introspection    |
+
+The spec-shaped `zone.stratos.space.getRecord` endpoint answers one record
+for one caller; it cannot build a timeline. The feed generator exists to
+close that gap: it is the component that assembles many boundary-gated
+records into a feed without ever showing a viewer a post from a boundary
+they are not enrolled in. See [Permissioned Spaces](./permissioned-spaces.md)
+for the access model it enforces.
+
+In that model the feed generator is a syncer and verifier, never a signer:
+it holds sync credentials and the verification logic, while signing keys
+stay in the Stratos service's isolated signer. That keeps the feed
+generator's compromise blast radius to read access, which is still worth
+guarding closely, but it cannot forge records.
+
+## Request path
+
+A client never calls the feed generator directly. It asks its own PDS with
+an `atproto-proxy` header naming the feed generator
+(`did:web:feedgen.example.com#stratos_feedgen`), and the PDS forwards the
+request with a short-lived service-auth JWT that identifies the user.
+
+<FeedgenRequestFlow />
+
+The viewer's DID comes from the JWT `iss` claim, so the feed generator never
+handles user credentials. Boundary membership is resolved from the upstream
+Stratos and cached in process (300 s TTL by default), which bounds how long
+a revoked member can keep reading through a warm cache.
+
+## Indexing path
+
+Feed queries are served from a local index, not by fanning out to Stratos at
+request time. Two kinds of background subscription keep that index current:
+
+<FeedgenIndexingFlow />
+
+The service-level stream tells the feed generator *who* to follow; the
+per-actor streams deliver *what* they wrote, already scoped to the
+boundaries the feed generator is entitled to observe. Posts land in a SQLite
+(WAL) index keyed by uri, author, boundary, and `sortAt`, with cursors
+persisted so restarts resume rather than re-index.
+
+## Auth flows
+
+Every hop is authenticated, and each direction uses a different mechanism:
+
+| Direction                     | Mechanism                                                                             | Verified by                                             |
+| ----------------------------- | ------------------------------------------------------------------------------------- | ------------------------------------------------------- |
+| Client → PDS                  | OAuth + DPoP                                                                          | The PDS                                                  |
+| PDS → Feed generator          | Service-auth JWT: `iss` = user DID, `aud` = feedgen DID, `lxm` = endpoint, `exp` < 60s | Feed generator, via the user's DID document              |
+| Feed generator → Stratos      | Service-auth JWT: `iss` = feedgen DID, `aud` = Stratos DID, `lxm` = endpoint           | Stratos `service` verifier                               |
+| Feed generator → Stratos (WS) | Same JWT shape as a Bearer header, `lxm` = `zone.stratos.sync.subscribeRecords`        | Stratos `subscribeAuth` verifier                         |
+
+The feed generator has its own identity: a `did:web` whose DID document
+publishes an `#atproto` verification method (its signing key) and a service
+entry with id `#stratos_feedgen` and type `NorthskyStratosFeedGen`. One key
+signs outgoing JWTs to Stratos and proves the feed generator's identity to
+callers.
+
+## Moderation labels
+
+The feed generator can subscribe to labeler DIDs (`FEEDGEN_LABELERS`),
+caches their labels locally, and attaches them to `postView.labels` at
+serialization time. Self-labels from the record are merged with external
+labels filtered by the caller's `atproto-accept-labelers` header, and the
+response reports the labelers consulted in `atproto-content-labelers`.
+
+Labels annotate; they never filter. Deciding to blur, warn, or hide is the
+client's job, the same division of responsibility the public network uses.
+
+## Storage
+
+| Concern                        | Choice                               |
+| ------------------------------ | ------------------------------------ |
+| Post / boundary / cursor index | SQLite (WAL) via Drizzle             |
+| Blob cache                     | S3 or filestore                      |
+| Viewer boundary cache          | In-process TTL + LRU (300 s default) |
+| Feed configuration             | Static file or environment variable  |
+
+## Deployment notes
+
+The feed generator binds to exactly one upstream Stratos service. Required
+configuration:
+
+| Env var               | Description                                            |
+| --------------------- | ------------------------------------------------------ |
+| `FEEDGEN_SERVICE_DID` | The feed generator's own DID (`did:web:<host>`)        |
+| `FEEDGEN_SIGNING_KEY` | Its signing key (hex secp256k1)                        |
+| `STRATOS_SERVICE_URL` | Base URL of the upstream Stratos                       |
+| `STRATOS_SERVICE_DID` | DID of the upstream Stratos                            |
+
+Because all reads go through the local index and blob cache, the feed
+generator absorbs feed traffic that would otherwise hit the Stratos service,
+and it can be scaled or restarted independently of it. A ready-made compose
+overlay (`docker-compose.feedgen.yml`) is described in the
+[deployment examples](/operator/examples/#feed-generator-overlay-docker-compose-feedgen-yml).
+Source lives in `stratos/stratos-feedgen/`; the package README covers build,
+test, and the full module layout.

--- a/docs/architecture/permissioned-spaces.md
+++ b/docs/architecture/permissioned-spaces.md
@@ -7,8 +7,9 @@ import SpaceDataResidencyAnimation from '../.vitepress/theme/components/SpaceDat
 
 The AT Protocol permissioned data proposal
 ([proposal 0016](https://github.com/bluesky-social/proposals/blob/main/0016-permissioned-data/README.md),
-with a work-in-progress implementation branch at
-[bluesky-social/atproto#5187](https://github.com/bluesky-social/atproto/pull/5187))
+implemented on the `permissioned-data` branch at
+[bluesky-social/atproto#5187](https://github.com/bluesky-social/atproto/pull/5187),
+which now ships an alpha PDS as the GHCR image tagged `pds-spaces-alpha`)
 defines a standard model for private records: a _space_ is a named,
 membership-gated container of records, addressed by an `at://` URI and served
 by a _space authority_ that decides who may read from it. Stratos implements
@@ -68,6 +69,10 @@ The literal `space` segment sits where a collection NSID appears in a public
 `at://` URI. An NSID always contains at least two dots and can never be the
 bare word `space`, so the two URI shapes cannot collide. Parsing is strict:
 canonical form is byte equality, with no case folding and no normalization.
+The alpha implementation registers this same grammar as a dedicated lexicon
+string format, `space-ref`: the three-part form only, with a DID authority
+(never a handle), and a URI naming a record _within_ a space deliberately
+does not qualify. Stratos's parser already enforces those rules.
 The single source of truth for this grammar is
 `stratos-core/src/spaces/domain.ts`, and `stratos-client` re-exports the same
 parser so clients never hand-roll it.
@@ -154,6 +159,15 @@ key (`kid: #atproto`, resolvable from the authority's DID document), so a
 host can verify it without ever contacting the authority. The default
 lifetime is two hours.
 
+The alpha PDS added a third property Stratos does not yet implement:
+sender-constraint. An upstream credential carries a `cnf.jkt` claim binding
+it to the DPoP key that signed the mint request, is presented under the
+`DPoP` authorization scheme with a fresh proof on every request, and the
+delegation tokens and client attestations that feed issuance are single-use.
+A Stratos credential is still bearer-shaped: possession is proof. The
+two-hour lifetime bounds the exposure, and closing this gap is tracked as
+alignment work.
+
 Credential issuance supports two optional inputs:
 
 - A **delegation token**, a space-delegation JWT whose target space must
@@ -219,30 +233,44 @@ stream and serves them back to viewers as hydrated timelines.
 The `zone.stratos.space.*` methods are deliberately shaped as mirrors, not
 approximations:
 
-| Stratos NSID                                        | Proposal counterpart          | Status                         |
-| --------------------------------------------------- | ----------------------------- | ------------------------------ |
-| `zone.stratos.space.getRecord`                      | `com.atproto.space.getRecord` | Spec-shaped mirror             |
-| `zone.stratos.space.getSpaceCredential`             | Space credential issuance     | Spec-shaped mirror             |
-| `zone.stratos.space.feed`                           | Space type declaration        | Standard `type: space` lexicon |
-| `zone.stratos.repo.hydrateRecord(s)`                | none                          | Stratos-specific               |
-| `zone.stratos.sync.subscribeRecords`                | none                          | Stratos-specific               |
-| `zone.stratos.sync.listRepoOps` / `listRecordPaths` | none                          | Stratos-specific pull sync     |
+| Stratos NSID                                        | Proposal counterpart            | Status                         |
+| --------------------------------------------------- | ------------------------------- | ------------------------------ |
+| `zone.stratos.space.getRecord`                      | `com.atproto.space.getRecord`   | Spec-shaped mirror             |
+| `zone.stratos.space.getSpaceCredential`             | Space credential issuance       | Spec-shaped mirror             |
+| `zone.stratos.space.feed`                           | Space type declaration          | Standard `type: space` lexicon |
+| `zone.stratos.repo.hydrateRecord(s)`                | none                            | Stratos-specific               |
+| `zone.stratos.sync.subscribeRecords`                | none                            | Stratos-specific               |
+| `zone.stratos.sync.listRepoOps` / `listRecordPaths` | `com.atproto.space.listRepoOps` | Diverged; see caveats below    |
 
-On the wire, the credential format follows the spec exactly: the
-`atproto-space-credential+jwt` type header, `ES256K` or `ES256` signing, and
-the `kid` fallback rule. The proposal permits either `#atproto_space` or
+On the wire, the credential format follows the spec's bearer shape exactly:
+the `atproto-space-credential+jwt` type header, `ES256K` or `ES256` signing,
+and the `kid` fallback rule. The proposal permits either `#atproto_space` or
 `#atproto` as the key id; Stratos always emits `#atproto`, so verifiers that
 implement the fallback accept its credentials without a dedicated space key
-in the DID document.
+in the DID document. The DPoP sender-constraint the alpha added on top of
+that shape is the one wire-level difference, as covered above.
 
 Some caveats worth stating plainly:
 
-- The proposal text still describes itself as not final. If
-  `com.atproto.space.*` changes shape before a release, the
-  `zone.stratos.space.*` mirrors will track it, and the mirrored NSIDs give
-  us room to version that transition without breaking deployed clients.
+- The proposal is not final, and the alpha PDS moved it: since the mirrors
+  were written, upstream added DPoP sender-constraint to credentials
+  (`cnf.jkt`, single-use delegation tokens), registered the `space-ref`
+  string format, reworked notify registration around service identifiers
+  with an explicit `unregisterNotify`, and added space-scoped blob
+  enumeration (`listBlobs`). The `zone.stratos.space.*` mirrors will track
+  these, and the mirrored NSIDs give us room to version that transition
+  without breaking deployed clients.
+- Pull sync diverged in the other direction. Stratos's
+  `zone.stratos.sync.listRepoOps` detects truncation explicitly
+  (`OplogTruncated`) and falls back to `listRecordPaths`; the alpha's
+  `com.atproto.space.listRepoOps` instead treats the oplog as a transport
+  optimization with no history guarantee — cursor pagination, the signed
+  commit only on the final page, and recovery through `getRepo` (which
+  gained an index-only `excludeValues` mode). Reconciling the two models is
+  open alignment work.
 - Compatibility is mostly outbound. Stratos can consume spec-hosted spaces
-  once they exist; a generic spec client cannot read Stratos data, because
+  as hosts ship them (the alpha PDS is the first); a generic spec client
+  cannot read Stratos data, because
   access is app-gated and commit verification resolves keys through the
   enrollment record rather than the author's DID document.
 - The repo format is MST with durable signed commits. The proposal's
@@ -379,7 +407,9 @@ the caller reaches the head it receives `caughtUp: true` along with the
 current signed commit. If the requested revision predates retained history,
 the endpoint returns `OplogTruncated` and the caller falls back to
 `zone.stratos.sync.listRecordPaths`: enumerate paths and CIDs, diff against
-local state, fetch what is missing.
+local state, fetch what is missing. (The alpha's `com.atproto.space.*`
+counterpart settled on a different recovery model — no truncation
+signal, with `getRepo` as the fallback; see the compatibility notes.)
 
 Portability here means movement between Stratos instances, not a handoff
 to a PDS; the spaces Stratos owns stay Stratos-hosted, as covered above.

--- a/docs/architecture/permissioned-spaces.md
+++ b/docs/architecture/permissioned-spaces.md
@@ -9,9 +9,9 @@ The AT Protocol permissioned data proposal
 ([proposal 0016](https://github.com/bluesky-social/proposals/blob/main/0016-permissioned-data/README.md),
 with a work-in-progress implementation branch at
 [bluesky-social/atproto#5187](https://github.com/bluesky-social/atproto/pull/5187))
-defines a standard model for private records: a *space* is a named,
+defines a standard model for private records: a _space_ is a named,
 membership-gated container of records, addressed by an `at://` URI and served
-by a *space authority* that decides who may read from it. Stratos implements
+by a _space authority_ that decides who may read from it. Stratos implements
 this model. Every Stratos boundary is served as a permissioned space, and the
 service exposes spec-shaped endpoints under `zone.stratos.space.*` that mirror
 the proposed `com.atproto.space.*` methods.
@@ -39,28 +39,28 @@ stays gated by enrollment and, where configured, an app allow-list.
 A Stratos boundary is a qualified string, `{serviceDid}/{domainName}`. A
 space URI is:
 
-```
+```text
 at://{spaceDid}/space/{spaceType}/{skey}
 ```
 
 The two map onto each other field by field:
 
-| Boundary component | Space component | Example                        |
-| ------------------ | --------------- | ------------------------------ |
-| `serviceDid`       | `spaceDid`      | `did:web:stratos.example.com`  |
-| `domainName`       | `skey`          | `engineering`                  |
-| (implied)          | `spaceType`     | `zone.stratos.space.feed`      |
+| Boundary component | Space component | Example                       |
+| ------------------ | --------------- | ----------------------------- |
+| `serviceDid`       | `spaceDid`      | `did:web:stratos.example.com` |
+| `domainName`       | `skey`          | `engineering`                 |
+| (implied)          | `spaceType`     | `zone.stratos.space.feed`     |
 
 So the boundary `did:web:stratos.example.com/engineering` is the space:
 
-```
+```text
 at://did:web:stratos.example.com/space/zone.stratos.space.feed/engineering
 ```
 
 A record inside a space gets a longer URI that appends the author, the
 collection, and the record key:
 
-```
+```text
 at://did:web:stratos.example.com/space/zone.stratos.space.feed/engineering/did:plc:ewvi7nxzyoun6zhxrhs64oiz/zone.stratos.feed.post/3jt6walwmos2y
 ```
 
@@ -123,7 +123,7 @@ Access to a space follows three stages: membership, credential, read.
 records which boundaries the user belongs to, and a
 `zone.stratos.actor.enrollment` record is written to the user's PDS so that
 clients and AppViews can discover the service. In space terms, boundary
-membership *is* space membership; there is no separate membership store.
+membership _is_ space membership; there is no separate membership store.
 
 **Credential.** A member (or a service acting for one) calls
 `zone.stratos.space.getSpaceCredential` with the space URI. The service
@@ -201,12 +201,12 @@ Stratos service and its authorized consumers.
 
 Reads reach the data over four paths, all boundary-gated:
 
-| Path                                  | Consumer            | Auth                       |
-| ------------------------------------- | ------------------- | -------------------------- |
-| Record CRUD (`zone.stratos.repo.*`)   | The owning user     | OAuth + DPoP               |
-| Hydration (`hydrateRecord(s)`)        | AppViews, clients   | Service JWT / user auth    |
-| Spec-shaped read (`space.getRecord`)  | Spec clients, hosts | User auth or space credential |
-| Sync (`sync.subscribeRecords`, pull sync) | Indexers, feedgens | Service JWT               |
+| Path                                      | Consumer            | Auth                          |
+| ----------------------------------------- | ------------------- | ----------------------------- |
+| Record CRUD (`zone.stratos.repo.*`)       | The owning user     | OAuth + DPoP                  |
+| Hydration (`hydrateRecord(s)`)            | AppViews, clients   | Service JWT / user auth       |
+| Spec-shaped read (`space.getRecord`)      | Spec clients, hosts | User auth or space credential |
+| Sync (`sync.subscribeRecords`, pull sync) | Indexers, feedgens  | Service JWT                   |
 
 The [feed generator](./feed-generator.md) is the reference consumer of the
 sync and hydration paths: it indexes boundary-scoped posts from the sync
@@ -219,14 +219,14 @@ stream and serves them back to viewers as hydrated timelines.
 The `zone.stratos.space.*` methods are deliberately shaped as mirrors, not
 approximations:
 
-| Stratos NSID                            | Proposal counterpart            | Status                     |
-| --------------------------------------- | ------------------------------- | -------------------------- |
-| `zone.stratos.space.getRecord`          | `com.atproto.space.getRecord`   | Spec-shaped mirror         |
-| `zone.stratos.space.getSpaceCredential` | Space credential issuance       | Spec-shaped mirror         |
-| `zone.stratos.space.feed`               | Space type declaration          | Standard `type: space` lexicon |
-| `zone.stratos.repo.hydrateRecord(s)`    | none                            | Stratos-specific           |
-| `zone.stratos.sync.subscribeRecords`    | none                            | Stratos-specific           |
-| `zone.stratos.sync.listRepoOps` / `listRecordPaths` | none                | Stratos-specific pull sync |
+| Stratos NSID                                        | Proposal counterpart          | Status                         |
+| --------------------------------------------------- | ----------------------------- | ------------------------------ |
+| `zone.stratos.space.getRecord`                      | `com.atproto.space.getRecord` | Spec-shaped mirror             |
+| `zone.stratos.space.getSpaceCredential`             | Space credential issuance     | Spec-shaped mirror             |
+| `zone.stratos.space.feed`                           | Space type declaration        | Standard `type: space` lexicon |
+| `zone.stratos.repo.hydrateRecord(s)`                | none                          | Stratos-specific               |
+| `zone.stratos.sync.subscribeRecords`                | none                          | Stratos-specific               |
+| `zone.stratos.sync.listRepoOps` / `listRecordPaths` | none                          | Stratos-specific pull sync     |
 
 On the wire, the credential format follows the spec exactly: the
 `atproto-space-credential+jwt` type header, `ES256K` or `ES256` signing, and

--- a/docs/architecture/permissioned-spaces.md
+++ b/docs/architecture/permissioned-spaces.md
@@ -155,9 +155,12 @@ credential. Decoded, the credential looks like this:
 Two details matter. The credential carries no `aud` claim, which is what
 makes it multi-use: it works against any repo host serving the space, not one
 predetermined audience. And it is signed by the space authority's own signing
-key (`kid: #atproto`, resolvable from the authority's DID document), so a
-host can verify it without ever contacting the authority. The default
-lifetime is two hours.
+key (`kid: #atproto`), so a host that resolves that key from the authority's
+DID document could verify it without contacting the authority. Today the only
+verifier is Stratos itself, and as the authority it takes the shortcut that
+implies: it requires the literal `kid` value and checks the signature against
+its local service key, with no DID resolution. The default lifetime is two
+hours.
 
 The alpha PDS added a third property Stratos does not yet implement:
 sender-constraint. An upstream credential carries a `cnf.jkt` claim binding

--- a/docs/architecture/permissioned-spaces.md
+++ b/docs/architecture/permissioned-spaces.md
@@ -423,7 +423,8 @@ Services that need to stay current rather than move data use pull sync.
 `zone.stratos.sync.listRepoOps` returns the operation log after a known
 revision, boundary-gated to the caller and with current values inlined; when
 the caller reaches the head it receives `caughtUp: true` along with the
-current signed commit. A drained log is not always the head: if a write
+current signed commit (a repository with no root yet has no commit to
+return). A drained log is not always the head: if a write
 lands while the head is being read, the response is `caughtUp: false` with
 no commit — possibly with no ops and the caller's own cursor repeated — so
 callers key off `caughtUp` and poll again rather than treating an unchanged

--- a/docs/architecture/permissioned-spaces.md
+++ b/docs/architecture/permissioned-spaces.md
@@ -1,0 +1,388 @@
+# Permissioned Spaces
+
+<script setup>
+import SpaceCredentialFlowAnimation from '../.vitepress/theme/components/SpaceCredentialFlowAnimation.vue'
+import SpaceDataResidencyAnimation from '../.vitepress/theme/components/SpaceDataResidencyAnimation.vue'
+</script>
+
+The AT Protocol permissioned data proposal
+([proposal 0016](https://github.com/bluesky-social/proposals/blob/main/0016-permissioned-data/README.md),
+with a work-in-progress implementation branch at
+[bluesky-social/atproto#5187](https://github.com/bluesky-social/atproto/pull/5187))
+defines a standard model for private records: a *space* is a named,
+membership-gated container of records, addressed by an `at://` URI and served
+by a *space authority* that decides who may read from it. Stratos implements
+this model. Every Stratos boundary is served as a permissioned space, and the
+service exposes spec-shaped endpoints under `zone.stratos.space.*` that mirror
+the proposed `com.atproto.space.*` methods.
+
+This page explains why Stratos aligns with the proposal, how the mapping
+works, where the data physically lives, which of its own design decisions
+Stratos keeps and why, and what happens to that data when PDS
+implementations ship native spaces support.
+
+## Why align with the spaces proposal
+
+Stratos and the spaces proposal solve the same problem: records in the
+atproto identity and repository model that only an authorized group may
+read. Stratos shipped first, so rather than wait for `com.atproto.space.*`
+to finalize, it mirrors the spec shapes under its own namespace. The
+concepts carry over unchanged: space URIs, offline-verifiable credentials,
+no-existence-leak reads. What alignment buys is mostly outbound. A Stratos
+deployment already speaks the dialect it will need to consume spaces
+hosted elsewhere once the spec ships, and its data model needs no rework
+to get there. It does not make Stratos part of the open network; access
+stays gated by enrollment and, where configured, an app allow-list.
+
+## The model: boundaries as spaces
+
+A Stratos boundary is a qualified string, `{serviceDid}/{domainName}`. A
+space URI is:
+
+```
+at://{spaceDid}/space/{spaceType}/{skey}
+```
+
+The two map onto each other field by field:
+
+| Boundary component | Space component | Example                        |
+| ------------------ | --------------- | ------------------------------ |
+| `serviceDid`       | `spaceDid`      | `did:web:stratos.example.com`  |
+| `domainName`       | `skey`          | `engineering`                  |
+| (implied)          | `spaceType`     | `zone.stratos.space.feed`      |
+
+So the boundary `did:web:stratos.example.com/engineering` is the space:
+
+```
+at://did:web:stratos.example.com/space/zone.stratos.space.feed/engineering
+```
+
+A record inside a space gets a longer URI that appends the author, the
+collection, and the record key:
+
+```
+at://did:web:stratos.example.com/space/zone.stratos.space.feed/engineering/did:plc:ewvi7nxzyoun6zhxrhs64oiz/zone.stratos.feed.post/3jt6walwmos2y
+```
+
+The literal `space` segment sits where a collection NSID appears in a public
+`at://` URI. An NSID always contains at least two dots and can never be the
+bare word `space`, so the two URI shapes cannot collide. Parsing is strict:
+canonical form is byte equality, with no case folding and no normalization.
+The single source of truth for this grammar is
+`stratos-core/src/spaces/domain.ts`, and `stratos-client` re-exports the same
+parser so clients never hand-roll it.
+
+The space key (`skey`) uses atproto record-key syntax and must be 1 to 512
+UTF-8 bytes. Since domain names already satisfy record-key syntax, every
+existing boundary name is a valid skey.
+
+### One record, one space
+
+A record belongs to exactly one space. The write path rejects zero
+boundaries and multiple boundaries, so the record's single boundary field
+is its space assignment; there is no placement record and no fanout layer.
+Editing the boundary moves the record between spaces, and the move
+surfaces to sync consumers as a removal in the old space plus a create in
+the new one, so a consumer scoped only to the old space observes the
+disappearance rather than keeping a stale copy.
+
+The "visible to every member" case is served by a reserved space of the
+same feed type, skey `general` by default, force-included in every
+enrollment. Writes with an empty boundary are rejected; clients target the
+reserved space explicitly, and access checks need no special case for it.
+
+### The space type declaration
+
+`spaceType` is an NSID pointing at a lexicon of `"type": "space"` that
+declares what the space contains. Stratos ships one:
+
+```json
+{
+  "lexicon": 1,
+  "id": "zone.stratos.space.feed",
+  "defs": {
+    "main": {
+      "type": "space",
+      "description": "A members-only Stratos post feed",
+      "key": "any",
+      "name": "Stratos Feed",
+      "collections": ["zone.stratos.feed.post"]
+    }
+  }
+}
+```
+
+`"key": "any"` means any valid skey names an instance of this space type,
+which is what lets every boundary name become a space without registration.
+
+## How access works
+
+Access to a space follows three stages: membership, credential, read.
+
+**Membership.** A user enrolls with a Stratos service via OAuth. The service
+records which boundaries the user belongs to, and a
+`zone.stratos.actor.enrollment` record is written to the user's PDS so that
+clients and AppViews can discover the service. In space terms, boundary
+membership *is* space membership; there is no separate membership store.
+
+**Credential.** A member (or a service acting for one) calls
+`zone.stratos.space.getSpaceCredential` with the space URI. The service
+checks membership live against the enrollment store and mints a space
+credential. Decoded, the credential looks like this:
+
+```json
+// header
+{
+  "typ": "atproto-space-credential+jwt",
+  "alg": "ES256K",
+  "kid": "#atproto"
+}
+// payload
+{
+  "iss": "did:web:stratos.example.com",
+  "sub": "at://did:web:stratos.example.com/space/zone.stratos.space.feed/engineering",
+  "iat": 1753948800,
+  "exp": 1753956000,
+  "jti": "8e0d2a4f-6a5c-4b1e-9f3a-2c7d1e5b8a90"
+}
+```
+
+Two details matter. The credential carries no `aud` claim, which is what
+makes it multi-use: it works against any repo host serving the space, not one
+predetermined audience. And it is signed by the space authority's own signing
+key (`kid: #atproto`, resolvable from the authority's DID document), so a
+host can verify it without ever contacting the authority. The default
+lifetime is two hours.
+
+Credential issuance supports two optional inputs:
+
+- A **delegation token**, a space-delegation JWT whose target space must
+  match the request. When present, the caller's identity comes from the token
+  instead of the DPoP session, which lets services obtain credentials on a
+  member's behalf.
+- A **client attestation**, required only for spaces configured with an app
+  allow-list. The attested `client_id` is checked against the list; spaces
+  without an allow-list ignore attestations entirely.
+
+Failure modes are explicit: `NotEnrolled`, `InvalidToken`, `UnknownSpace`,
+`AttestationRequired`, and `ClientNotAllowed`.
+
+**Read.** `zone.stratos.space.getRecord` returns a single record from a
+space. It accepts either standard user auth (the caller must be a member) or
+a space credential for that space. The record must actually belong to the
+requested space. A record outside it, including a record with no space at
+all, resolves to `RecordNotFound`, the same answer as a record that does not
+exist. Callers cannot use the endpoint to probe for the existence of data
+they are not entitled to.
+
+<SpaceCredentialFlowAnimation />
+
+## Where the data lives
+
+The full record never touches the user's PDS. When a user writes a
+`zone.stratos.feed.post`, the record is stored in a per-actor repository on
+the Stratos service: IPLD blocks under a Merkle Search Tree, with each
+commit signed by a per-actor P-256 key. Stratos mints that key at
+enrollment and holds it in an isolated signer; it never enters the user's
+DID document. The binding between key and user is published in the
+enrollment record instead, a `signingKey` field plus a service-signed
+attestation, and that is what verifiers resolve to check commit
+signatures. Signing with the account's own `#atproto` identity key is the
+stated long-term aim, but that key lives with the user's PDS and cannot
+sign on Stratos's serve path today. On disk each repo is a SQLite database
+per actor, or a Postgres schema per actor, depending on the backend.
+
+The user's PDS holds exactly one thing on the happy path: the
+`zone.stratos.actor.enrollment` record, a public pointer that says "this DID
+has private data at this service." The PDS operator, the relay, and the
+public firehose see that pointer and nothing else. Post content, boundary
+names, and even the number of records in a space are not visible outside the
+Stratos service and its authorized consumers.
+
+Reads reach the data over four paths, all boundary-gated:
+
+| Path                                  | Consumer            | Auth                       |
+| ------------------------------------- | ------------------- | -------------------------- |
+| Record CRUD (`zone.stratos.repo.*`)   | The owning user     | OAuth + DPoP               |
+| Hydration (`hydrateRecord(s)`)        | AppViews, clients   | Service JWT / user auth    |
+| Spec-shaped read (`space.getRecord`)  | Spec clients, hosts | User auth or space credential |
+| Sync (`sync.subscribeRecords`, pull sync) | Indexers, feedgens | Service JWT               |
+
+The [feed generator](./feed-generator.md) is the reference consumer of the
+sync and hydration paths: it indexes boundary-scoped posts from the sync
+stream and serves them back to viewers as hydrated timelines.
+
+<SpaceDataResidencyAnimation />
+
+## Compatibility notes
+
+The `zone.stratos.space.*` methods are deliberately shaped as mirrors, not
+approximations:
+
+| Stratos NSID                            | Proposal counterpart            | Status                     |
+| --------------------------------------- | ------------------------------- | -------------------------- |
+| `zone.stratos.space.getRecord`          | `com.atproto.space.getRecord`   | Spec-shaped mirror         |
+| `zone.stratos.space.getSpaceCredential` | Space credential issuance       | Spec-shaped mirror         |
+| `zone.stratos.space.feed`               | Space type declaration          | Standard `type: space` lexicon |
+| `zone.stratos.repo.hydrateRecord(s)`    | none                            | Stratos-specific           |
+| `zone.stratos.sync.subscribeRecords`    | none                            | Stratos-specific           |
+| `zone.stratos.sync.listRepoOps` / `listRecordPaths` | none                | Stratos-specific pull sync |
+
+On the wire, the credential format follows the spec exactly: the
+`atproto-space-credential+jwt` type header, `ES256K` or `ES256` signing, and
+the `kid` fallback rule. The proposal permits either `#atproto_space` or
+`#atproto` as the key id; Stratos always emits `#atproto`, so verifiers that
+implement the fallback accept its credentials without a dedicated space key
+in the DID document.
+
+Some caveats worth stating plainly:
+
+- The proposal text still describes itself as not final. If
+  `com.atproto.space.*` changes shape before a release, the
+  `zone.stratos.space.*` mirrors will track it, and the mirrored NSIDs give
+  us room to version that transition without breaking deployed clients.
+- Compatibility is mostly outbound. Stratos can consume spec-hosted spaces
+  once they exist; a generic spec client cannot read Stratos data, because
+  access is app-gated and commit verification resolves keys through the
+  enrollment record rather than the author's DID document.
+- The repo format is MST with durable signed commits. The proposal's
+  current draft specifies an LtHash set digest with commits minted at serve
+  time. Stratos launches on MST because it is proven and already built, and
+  keeps the format behind an internal seam so a later cutover is one
+  controlled change rather than a permanent dual format.
+- `getRecord` is the only spec-shaped read today. Listing records within a
+  space and subscribing to a space use Stratos-specific endpoints until the
+  proposal settles their shapes.
+- The enrollment record on the user's PDS publishes which spaces the user
+  belongs to. The proposal never enumerates membership at protocol level,
+  so Stratos is more visible than spec-default on exactly this axis. Treat
+  space names as public metadata when choosing them.
+- Records are access-controlled, not end-to-end encrypted. The service and
+  its authorized consumers handle plaintext by design.
+- Hydration (the `source` field pattern described in
+  [Hydration Architecture](./hydration.md)) predates the proposal and remains
+  the way AppViews present Stratos records inside public timelines. The two
+  access paths coexist and serve different consumers.
+
+## Design decisions Stratos keeps, and why
+
+Alignment did not mean adopting the proposal wholesale. Several Stratos
+design decisions predate it and stay in place deliberately, not as legacy.
+
+**Boundaries remain the internal model.** Records carry a `boundary` field
+(`{serviceDid}/{name}`), and the space URI is derived from it, not stored
+alongside it. The mapping is mechanical and lossless in both directions
+(`boundaryToSpaceUri` / `spaceUriToBoundary`), so deployed records need no
+rewrite as the proposal evolves, and a boundary string is self-describing: it
+names the authority DID that governs access right in the value. If the
+proposal's addressing changes shape again before finalizing, only the
+derivation function changes.
+
+**Membership lives in the enrollment store, checked live.** The spec
+direction leans toward membership as records. Stratos keeps membership as
+service-side state established through OAuth enrollment because that is what
+an organization-operated authority needs: an operator can add or remove a
+member, and the change takes effect at the next credential mint rather than
+after a record propagates. Combined with the two-hour credential TTL, the
+window between revocation and loss of access is bounded without maintaining
+revocation lists that every host would have to consult.
+
+**Hydration stays alongside spec-shaped reads.** `space.getRecord` answers
+one record for one caller. It cannot build a timeline. AppViews and the
+[feed generator](./feed-generator.md) interleaving private posts into feeds
+need batch, boundary-filtered hydration with the `source` field for
+verification, which is what [hydration](./hydration.md) provides. The two
+paths serve different consumers and neither substitutes for the other.
+
+**Per-actor repos with signed commits, even though the org hosts.** The
+cheaper design would be plain database rows. Stratos pays for MST commits
+and per-actor keys because every property the portability section relies
+on, verifiable CAR export, host-independent CIDs, imports a receiving host
+can check block by block, follows from that structure. One honest limit:
+the per-actor key is minted and held by Stratos, so a commit signature
+proves the repo is intact and attributable to the key the enrollment
+record names. It does not prove the user authorized each commit
+independently of Stratos, which is the same trust position the proposal
+gives any repo host that signs at serve time.
+
+**Actor-scoped sync instead of a global firehose.** A service-wide firehose
+in the public atproto style would leak activity across boundaries to any
+subscriber. `subscribeRecords` is scoped per actor, and pull sync is
+boundary-gated to the caller, so a consumer only ever observes the slice of
+the write stream it is entitled to read. This is slower to fan out than a
+single firehose and that cost is accepted.
+
+## When PDSs host spaces natively
+
+The proposal's default topology puts each per-user space repo on that
+user's own PDS. Stratos deliberately does not adopt it: Stratos remains
+the repo host for the spaces it owns, permanently. The spec allows this
+and names the category directly, a space hosted on a bespoke space service
+rather than on the PDS. There is no planned handoff of Stratos-hosted
+repos to user PDSs.
+
+What changes when PDS implementations ship `com.atproto.space.*` is the
+other direction. Stratos and its consumers can read spaces hosted
+elsewhere, because they already speak the credential and addressing model
+those hosts will use. A space credential names its authority in `iss` and
+its space in `sub`, and any host verifies it against the authority's DID
+document; that verification is the same operation whether the blocks come
+from a Stratos instance or a PDS.
+
+The reverse does not hold, and that is by design. A generic spaces client
+cannot walk up to a Stratos service and read: access is gated by
+enrollment and, where configured, an app allow-list, and commit
+verification resolves the signing key from the enrollment record rather
+than the author's DID document. A PDS-hosted space puts the authority in
+the account owner's hands, the right default for personal use. A Stratos
+service is an organization-operated authority: membership is controlled by
+the operator, spaces can be gated to approved client apps, and the
+indexing and feed infrastructure (indexer, feed generator, AppView
+integration) lives in one administrative domain. The two topologies serve
+different deployments and coexist.
+
+## Data portability
+
+Stratos stores each actor's data as a standard atproto repository: IPLD
+blocks, an MST, and a signed commit. Portability falls out of that choice.
+
+A user (or a tool acting for them) exports the full repo as a CAR file:
+
+```bash
+curl -H "Authorization: Bearer $ACCESS_TOKEN" \
+  "https://stratos.example.com/xrpc/zone.stratos.sync.getRepo?did=did:plc:ewvi7nxzyoun6zhxrhs64oiz" \
+  -o repo.car
+```
+
+The CAR contains every record block, every MST node, and the signed commit.
+Importing it into another Stratos instance restores the repo:
+
+```bash
+curl -X POST \
+  -H "Authorization: Bearer $ACCESS_TOKEN" \
+  -H "Content-Type: application/vnd.ipld.car" \
+  --data-binary @repo.car \
+  "https://stratos-two.example.net/xrpc/zone.stratos.repo.importRepo"
+```
+
+Because commits are signed, the importing host verifies the repo against
+the per-actor key named in the enrollment record; it depends on the
+exporting host for the bytes, not for their integrity. The residual trust
+is in the enrollment binding itself, which the exporting authority
+attested. Content addresses do not change in transit, so a record's CID is
+the same on both hosts.
+
+Services that need to stay current rather than move data use pull sync.
+`zone.stratos.sync.listRepoOps` returns the operation log after a known
+revision, boundary-gated to the caller and with current values inlined; when
+the caller reaches the head it receives `caughtUp: true` along with the
+current signed commit. If the requested revision predates retained history,
+the endpoint returns `OplogTruncated` and the caller falls back to
+`zone.stratos.sync.listRecordPaths`: enumerate paths and CIDs, diff against
+local state, fetch what is missing.
+
+Portability here means movement between Stratos instances, not a handoff
+to a PDS; the spaces Stratos owns stay Stratos-hosted, as covered above.
+Within that scope the blocks, the signatures, and the space URIs are all
+host-independent, so moving an actor's data is moving a CAR file and
+updating the discovery pointer, not rewriting records.

--- a/docs/architecture/permissioned-spaces.md
+++ b/docs/architecture/permissioned-spaces.md
@@ -74,8 +74,8 @@ string format, `space-ref`: the three-part form only, with a DID authority
 (never a handle), and a URI naming a record _within_ a space deliberately
 does not qualify. Stratos's parser already enforces those rules.
 The single source of truth for this grammar is
-`stratos-core/src/spaces/domain.ts`, and `stratos-client` re-exports the same
-parser so clients never hand-roll it.
+`stratos-core/src/spaces/domain.ts`. `stratos-client` does not yet re-export
+it, so client code that needs the parser imports it from core.
 
 The space key (`skey`) uses atproto record-key syntax and must be 1 to 512
 UTF-8 bytes. Since domain names already satisfy record-key syntax, every
@@ -208,19 +208,20 @@ per actor, or a Postgres schema per actor, depending on the backend.
 
 The user's PDS holds exactly one thing on the happy path: the
 `zone.stratos.actor.enrollment` record, a public pointer that says "this DID
-has private data at this service." The PDS operator, the relay, and the
-public firehose see that pointer and nothing else. Post content, boundary
-names, and even the number of records in a space are not visible outside the
-Stratos service and its authorized consumers.
+has private data at this service." Post content and record counts are not
+visible outside the Stratos service and its authorized consumers. Space
+membership is the deliberate exception: the enrollment record enumerates the
+spaces the user belongs to, so space names ride the public firehose — treat
+them as public metadata, as the compatibility notes below spell out.
 
 Reads reach the data over four paths, all boundary-gated:
 
-| Path                                      | Consumer            | Auth                          |
-| ----------------------------------------- | ------------------- | ----------------------------- |
-| Record CRUD (`zone.stratos.repo.*`)       | The owning user     | OAuth + DPoP                  |
-| Hydration (`hydrateRecord(s)`)            | AppViews, clients   | Service JWT / user auth       |
-| Spec-shaped read (`space.getRecord`)      | Spec clients, hosts | User auth or space credential |
-| Sync (`sync.subscribeRecords`, pull sync) | Indexers, feedgens  | Service JWT                   |
+| Path                                      | Consumer            | Auth                                                    |
+| ----------------------------------------- | ------------------- | ------------------------------------------------------- |
+| Record CRUD (`com.atproto.repo.*`)        | The owning user     | OAuth + DPoP                                            |
+| Hydration (`hydrateRecord(s)`)            | AppViews, clients   | Service JWT, user auth, space credential, or anonymous  |
+| Spec-shaped read (`space.getRecord`)      | Spec clients, hosts | User auth or space credential                           |
+| Sync (`sync.subscribeRecords`, pull sync) | Indexers, feedgens  | Service JWT (pull sync also accepts a space credential) |
 
 The [feed generator](./feed-generator.md) is the reference consumer of the
 sync and hydration paths: it indexes boundary-scoped posts from the sync
@@ -233,22 +234,26 @@ stream and serves them back to viewers as hydrated timelines.
 The `zone.stratos.space.*` methods are deliberately shaped as mirrors, not
 approximations:
 
-| Stratos NSID                                        | Proposal counterpart            | Status                         |
-| --------------------------------------------------- | ------------------------------- | ------------------------------ |
-| `zone.stratos.space.getRecord`                      | `com.atproto.space.getRecord`   | Spec-shaped mirror             |
-| `zone.stratos.space.getSpaceCredential`             | Space credential issuance       | Spec-shaped mirror             |
-| `zone.stratos.space.feed`                           | Space type declaration          | Standard `type: space` lexicon |
-| `zone.stratos.repo.hydrateRecord(s)`                | none                            | Stratos-specific               |
-| `zone.stratos.sync.subscribeRecords`                | none                            | Stratos-specific               |
-| `zone.stratos.sync.listRepoOps` / `listRecordPaths` | `com.atproto.space.listRepoOps` | Diverged; see caveats below    |
+| Stratos NSID                            | Proposal counterpart                                 | Status                         |
+| --------------------------------------- | ---------------------------------------------------- | ------------------------------ |
+| `zone.stratos.space.getRecord`          | `com.atproto.space.getRecord`                        | Spec-shaped mirror             |
+| `zone.stratos.space.getSpaceCredential` | Space credential issuance                            | Spec-shaped mirror             |
+| `zone.stratos.space.feed`               | Space type declaration                               | Standard `type: space` lexicon |
+| `zone.stratos.repo.hydrateRecord(s)`    | none                                                 | Stratos-specific               |
+| `zone.stratos.sync.subscribeRecords`    | none                                                 | Stratos-specific               |
+| `zone.stratos.sync.listRepoOps`         | `com.atproto.space.listRepoOps`                      | Diverged; see caveats below    |
+| `zone.stratos.sync.listRecordPaths`     | `getRepo` / `listRecords` (`excludeValues`) recovery | Diverged; see caveats below    |
 
-On the wire, the credential format follows the spec's bearer shape exactly:
-the `atproto-space-credential+jwt` type header, `ES256K` or `ES256` signing,
-and the `kid` fallback rule. The proposal permits either `#atproto_space` or
-`#atproto` as the key id; Stratos always emits `#atproto`, so verifiers that
-implement the fallback accept its credentials without a dedicated space key
-in the DID document. The DPoP sender-constraint the alpha added on top of
-that shape is the one wire-level difference, as covered above.
+On the wire, the credential format matches the proposal's original bearer
+shape: the `atproto-space-credential+jwt` type header, `ES256K` or `ES256`
+signing, and the `kid` fallback rule (the proposal permits either
+`#atproto_space` or `#atproto` as the key id; Stratos always emits
+`#atproto`). But the alpha's DPoP sender-constraint is not additive: the
+upstream parser makes `cnf.jkt` mandatory and rejects a token without it
+before the `kid` fallback is ever consulted. An upstream verifier therefore
+**rejects** a Stratos credential outright today. Until the sender-constraint
+gap closes (it is tracked as alignment work, as covered above), the shapes
+are compatible on paper but not interoperable on the wire.
 
 Some caveats worth stating plainly:
 
@@ -256,18 +261,22 @@ Some caveats worth stating plainly:
   were written, upstream added DPoP sender-constraint to credentials
   (`cnf.jkt`, single-use delegation tokens), registered the `space-ref`
   string format, reworked notify registration around service identifiers
-  with an explicit `unregisterNotify`, and added space-scoped blob
-  enumeration (`listBlobs`). The `zone.stratos.space.*` mirrors will track
+  with an explicit `unregisterNotify`, added space-scoped blob
+  enumeration (`listBlobs`), began enforcing account availability across
+  the space read endpoints (`RepoTakendown`, `RepoSuspended`,
+  `RepoDeactivated`), and reshuffled the simplified surface under
+  `com.atproto.simplespace.*` (space policies in `simplespace/defs`,
+  `getSpace` moved under it). The `zone.stratos.space.*` mirrors will track
   these, and the mirrored NSIDs give us room to version that transition
   without breaking deployed clients.
-- Pull sync diverged in the other direction. Stratos's
-  `zone.stratos.sync.listRepoOps` detects truncation explicitly
-  (`OplogTruncated`) and falls back to `listRecordPaths`; the alpha's
-  `com.atproto.space.listRepoOps` instead treats the oplog as a transport
-  optimization with no history guarantee — cursor pagination, the signed
-  commit only on the final page, and recovery through `getRepo` (which
-  gained an index-only `excludeValues` mode). Reconciling the two models is
-  open alignment work.
+- Pull sync now shares the alpha's transport model — cursor pagination
+  with the signed commit only at the head — and diverges on two narrower
+  points. Stratos keeps `OplogTruncated` as a stricter extension: it
+  detects a cursor that predates retained history and says so explicitly,
+  where the alpha offers no truncation signal. And the recovery fallbacks
+  differ: Stratos falls back to `listRecordPaths`, the alpha to `getRepo`
+  (which gained an index-only `excludeValues` mode). Reconciling the
+  recovery paths is open alignment work.
 - Compatibility is mostly outbound. Stratos can consume spec-hosted spaces
   as hosts ship them (the alpha PDS is the first); a generic spec client
   cannot read Stratos data, because
@@ -279,8 +288,10 @@ Some caveats worth stating plainly:
   keeps the format behind an internal seam so a later cutover is one
   controlled change rather than a permanent dual format.
 - `getRecord` is the only spec-shaped read today. Listing records within a
-  space and subscribing to a space use Stratos-specific endpoints until the
-  proposal settles their shapes.
+  space and subscribing to a space use Stratos-specific endpoints, even
+  though upstream has now settled both shapes — `com.atproto.space.listRecords`
+  (with `excludeValues` for full-state recovery) and the notify registration
+  flow described above. Mirroring them is open alignment work.
 - The enrollment record on the user's PDS publishes which spaces the user
   belongs to. The proposal never enumerates membership at protocol level,
   so Stratos is more visible than spec-default on exactly this axis. Treat
@@ -374,20 +385,28 @@ different deployments and coexist.
 Stratos stores each actor's data as a standard atproto repository: IPLD
 blocks, an MST, and a signed commit. Portability falls out of that choice.
 
-A user (or a tool acting for them) exports the full repo as a CAR file:
+A user (or a tool acting for them) exports the full repo as a CAR file.
+The endpoint binds standard user auth, which is DPoP-only — a `Bearer`
+header is rejected, so the request carries the `DPoP` scheme plus a proof
+signed by the session's DPoP key:
 
 ```bash
-curl -H "Authorization: Bearer $ACCESS_TOKEN" \
+curl -H "Authorization: DPoP $ACCESS_TOKEN" \
+  -H "DPoP: $DPOP_PROOF" \
   "https://stratos.example.com/xrpc/zone.stratos.sync.getRepo?did=did:plc:ewvi7nxzyoun6zhxrhs64oiz" \
   -o repo.car
 ```
 
 The CAR contains every record block, every MST node, and the signed commit.
-Importing it into another Stratos instance restores the repo:
+Importing it into another Stratos instance restores the repo. The
+`zone.stratos.repo.importRepo` lexicon defines that call, but the service
+does not register the handler yet, so the request below is the intended
+shape, not a working example:
 
 ```bash
 curl -X POST \
-  -H "Authorization: Bearer $ACCESS_TOKEN" \
+  -H "Authorization: DPoP $ACCESS_TOKEN" \
+  -H "DPoP: $DPOP_PROOF" \
   -H "Content-Type: application/vnd.ipld.car" \
   --data-binary @repo.car \
   "https://stratos-two.example.net/xrpc/zone.stratos.repo.importRepo"
@@ -404,7 +423,11 @@ Services that need to stay current rather than move data use pull sync.
 `zone.stratos.sync.listRepoOps` returns the operation log after a known
 revision, boundary-gated to the caller and with current values inlined; when
 the caller reaches the head it receives `caughtUp: true` along with the
-current signed commit. If the requested revision predates retained history,
+current signed commit. A drained log is not always the head: if a write
+lands while the head is being read, the response is `caughtUp: false` with
+no commit — possibly with no ops and the caller's own cursor repeated — so
+callers key off `caughtUp` and poll again rather than treating an unchanged
+cursor as a stall. If the requested revision predates retained history,
 the endpoint returns `OplogTruncated` and the caller falls back to
 `zone.stratos.sync.listRecordPaths`: enumerate paths and CIDs, diff against
 local state, fetch what is missing. (The alpha's `com.atproto.space.*`


### PR DESCRIPTION
## Description

Now that docs CI is working, add a dedicated page explaining how stratos works with permissioned spaces, focuses heavily on the rationale and why we are keeping stratos.

**Update 2026-08-20:** upstream shipped an alpha PDS from the `permissioned-data` branch (GHCR tag `pds-spaces-alpha`). The explainer now records the drift since the mirrors were written: DPoP sender-constraint on credentials (`cnf.jkt`, single-use delegation tokens), the `space-ref` lexicon string format, the reworked notify registration lifecycle (`unregisterNotify`, service identifiers), space-scoped blob enumeration (`listBlobs`), and the divergent `listRepoOps` recovery model (cursor pagination + `getRepo excludeValues` instead of truncation detection).

## Related Issues

<!-- Link to related issues using keywords like "Closes #123" or "Fixes #456" -->

## Testing

<!-- Describe the tests you ran to verify your changes -->

## Type of Change

<!-- Mark relevant options with an "x" -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Build/CI changes
- [ ] Test improvements

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added architecture documentation for the standalone feed generator, including request flows, indexing, authentication, moderation, storage, and deployment.
  * Expanded Permissioned Spaces documentation with updated membership, authentication, portability, import, and synchronization details.
  * Added interactive diagrams illustrating feed generation, indexing, credential handling, and data residency.
  * Updated architecture navigation to include Permissioned Spaces and Feed Generator pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->