### PR TITLE
fix(stratos) - remove double cid encording on createRecord

### DIFF
--- a/lexicons/zone/stratos/admin/listAdmins.json
+++ b/lexicons/zone/stratos/admin/listAdmins.json
@@ -9,7 +9,7 @@
         "encoding": "application/json",
         "schema": {
           "type": "object",
-          "required": ["admins"],
+          "required": ["admins", "viewer"],
           "properties": {
             "admins": {
               "type": "array",

--- a/stratos-client/src/lexicons.gen.ts
+++ b/stratos-client/src/lexicons.gen.ts
@@ -68,6 +68,257 @@ export const stratosLexicons: LexiconDoc[] = [
 },
 {
   "lexicon": 1,
+  "id": "zone.stratos.admin.addAdmin",
+  "defs": {
+    "main": {
+      "type": "procedure",
+      "description": "Grant admin access to a DID. Requires admin authorization.",
+      "input": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["did"],
+          "properties": {
+            "did": {
+              "type": "string",
+              "format": "did",
+              "description": "The DID to grant admin access to."
+            }
+          }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["did"],
+          "properties": {
+            "did": { "type": "string", "format": "did" }
+          }
+        }
+      }
+    }
+  }
+},
+{
+  "lexicon": 1,
+  "id": "zone.stratos.admin.listAdmins",
+  "defs": {
+    "main": {
+      "type": "query",
+      "description": "List everyone holding admin access. Requires admin authorization.",
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["admins"],
+          "properties": {
+            "admins": {
+              "type": "array",
+              "items": { "type": "ref", "ref": "#admin" }
+            },
+            "viewer": {
+              "type": "string",
+              "format": "did",
+              "description": "The DID of the requesting admin."
+            }
+          }
+        }
+      }
+    },
+    "admin": {
+      "type": "object",
+      "required": ["did", "source"],
+      "properties": {
+        "did": { "type": "string", "format": "did" },
+        "source": {
+          "type": "string",
+          "description": "Where the grant comes from. Config admins cannot be revoked through the API.",
+          "knownValues": ["config", "database"]
+        },
+        "addedAt": {
+          "type": "string",
+          "format": "datetime",
+          "description": "When access was granted. Absent for config admins."
+        },
+        "addedBy": {
+          "type": "string",
+          "format": "did",
+          "description": "Who granted access. Absent for config admins."
+        }
+      }
+    }
+  }
+},
+{
+  "lexicon": 1,
+  "id": "zone.stratos.admin.listEnrollments",
+  "defs": {
+    "main": {
+      "type": "query",
+      "description": "List enrollments in this Stratos service. Requires admin authorization.",
+      "parameters": {
+        "type": "params",
+        "properties": {
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100,
+            "default": 50,
+            "description": "Maximum number of enrollments to return."
+          },
+          "cursor": {
+            "type": "string",
+            "description": "Pagination cursor from a previous response."
+          },
+          "boundary": {
+            "type": "string",
+            "description": "Only return members holding this boundary."
+          }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["enrollments"],
+          "properties": {
+            "enrollments": {
+              "type": "array",
+              "items": {
+                "type": "ref",
+                "ref": "#enrollment"
+              }
+            },
+            "cursor": {
+              "type": "string",
+              "description": "Cursor for the next page. Absent on the last page."
+            },
+            "total": {
+              "type": "integer",
+              "description": "Total number of enrollments in the service. Absent when a boundary filter is applied."
+            }
+          }
+        }
+      }
+    },
+    "enrollment": {
+      "type": "object",
+      "required": ["did", "enrolledAt", "active", "boundaries"],
+      "properties": {
+        "did": {
+          "type": "string",
+          "format": "did",
+          "description": "The enrolled DID."
+        },
+        "enrolledAt": {
+          "type": "string",
+          "format": "datetime",
+          "description": "When the DID was enrolled."
+        },
+        "active": {
+          "type": "boolean",
+          "description": "Whether the enrollment is currently active."
+        },
+        "isService": {
+          "type": "boolean",
+          "description": "Whether this is a service enrollment rather than a user."
+        },
+        "boundaries": {
+          "type": "array",
+          "items": {
+            "type": "ref",
+            "ref": "zone.stratos.boundary.defs#Domain"
+          }
+        }
+      }
+    }
+  }
+},
+{
+  "lexicon": 1,
+  "id": "zone.stratos.admin.removeAdmin",
+  "defs": {
+    "main": {
+      "type": "procedure",
+      "description": "Revoke admin access from a DID. Config-provided admins cannot be revoked here, and an admin cannot revoke their own access.",
+      "input": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["did"],
+          "properties": {
+            "did": {
+              "type": "string",
+              "format": "did",
+              "description": "The DID to revoke admin access from."
+            }
+          }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["did"],
+          "properties": {
+            "did": { "type": "string", "format": "did" }
+          }
+        }
+      },
+      "errors": [
+        {
+          "name": "NotFound",
+          "description": "The DID does not hold admin access."
+        }
+      ]
+    }
+  }
+},
+{
+  "lexicon": 1,
+  "id": "zone.stratos.admin.setActive",
+  "defs": {
+    "main": {
+      "type": "procedure",
+      "description": "Activate or deactivate an enrolled member. Requires admin authorization. Deactivation is reversible and preserves the member's boundaries.",
+      "input": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["did", "active"],
+          "properties": {
+            "did": {
+              "type": "string",
+              "format": "did",
+              "description": "The member to update."
+            },
+            "active": {
+              "type": "boolean",
+              "description": "Whether the member's enrollment should be active."
+            }
+          }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["did", "active"],
+          "properties": {
+            "did": { "type": "string", "format": "did" },
+            "active": { "type": "boolean" }
+          }
+        }
+      },
+      "errors": [
+        { "name": "NotFound", "description": "The DID is not enrolled." }
+      ]
+    }
+  }
+},
+{
+  "lexicon": 1,
   "id": "zone.stratos.boundary.defs",
   "defs": {
     "Domain": {
@@ -747,19 +998,6 @@ export const stratosLexicons: LexiconDoc[] = [
           }
         }
       }
-    }
-  }
-},
-{
-  "lexicon": 1,
-  "id": "zone.stratos.space.feed",
-  "defs": {
-    "main": {
-      "type": "space",
-      "description": "A members-only Stratos post feed",
-      "key": "any",
-      "name": "Stratos Feed",
-      "collections": ["zone.stratos.feed.post"]
     }
   }
 },

--- a/stratos-client/src/lexicons.gen.ts
+++ b/stratos-client/src/lexicons.gen.ts
@@ -111,7 +111,7 @@ export const stratosLexicons: LexiconDoc[] = [
         "encoding": "application/json",
         "schema": {
           "type": "object",
-          "required": ["admins"],
+          "required": ["admins", "viewer"],
           "properties": {
             "admins": {
               "type": "array",

--- a/stratos-service/admin-ui/src/lib/api/client.ts
+++ b/stratos-service/admin-ui/src/lib/api/client.ts
@@ -313,7 +313,7 @@ export interface AdminUser {
 
 export interface ListAdminsResponse {
   admins: AdminUser[]
-  viewer?: string
+  viewer: string
 }
 
 /**

--- a/stratos-service/src/api/records/create.ts
+++ b/stratos-service/src/api/records/create.ts
@@ -157,7 +157,7 @@ async function precomputeRecordData(
   const rkey = inputRkey ?? TID.nextStr()
   const uri = AtUri.make(callerDid, collection, rkey)
   const recordBytes = encodeRecord(record as Record<string, unknown>)
-  const recordCid = await computeCid(recordBytes)
+  const recordCid = await computeCid(record as Record<string, unknown>)
   phases.prepareCommitBuild = performance.now() - t0
   return { uri, recordBytes, cid: recordCid }
 }

--- a/stratos-service/tests/records-create-cid.integration.test.ts
+++ b/stratos-service/tests/records-create-cid.integration.test.ts
@@ -1,0 +1,164 @@
+/**
+ * A created record must be addressed by the hash of its own content.
+ *
+ * `computeCid` CBOR-encodes its argument internally, so passing the already
+ * encoded `encodeRecord(record)` bytes yields `hash(cbor(cbor(record)))` — a
+ * CID that no external verifier re-hashing the stored block can reproduce.
+ * These tests pin the create path to the content CID and to the value the
+ * update path independently produces.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mkdir, rm } from 'node:fs/promises'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { randomBytes } from 'crypto'
+import {
+  computeCid,
+  encodeRecord,
+  parseCid,
+} from '@northskysocial/stratos-core'
+import { decode } from '@atcute/cbor'
+
+import { StratosActorStore } from '../src/context.js'
+import {
+  closeServiceDb,
+  createServiceDb,
+  migrateServiceDb,
+  ServiceDb,
+} from '../src/db/index.js'
+import {
+  createRecord,
+  getRecord,
+  updateRecord,
+} from '../src/api/records/index.js'
+import { createMockBlobStore, createTestConfig } from './utils/index.js'
+
+const DOMAIN = 'did:web:nerv.tokyo.jp/engineering'
+
+describe('Create record CID derivation', () => {
+  let dataDir: string
+  let actorStore: StratosActorStore
+  let db: ServiceDb
+  let ctx: any
+
+  const testDid = 'did:plc:asuka-langley'
+  const serviceDid = 'did:web:nerv.tokyo.jp'
+  const collection = 'zone.stratos.feed.post'
+
+  function post(text: string) {
+    return {
+      $type: collection,
+      text,
+      createdAt: '1996-10-04T00:00:00.000Z',
+      boundary: {
+        $type: 'zone.stratos.boundary.defs#Domains',
+        values: [{ value: DOMAIN }],
+      },
+    }
+  }
+
+  beforeEach(async () => {
+    dataDir = join(tmpdir(), `stratos-test-${randomBytes(8).toString('hex')}`)
+    await mkdir(dataDir, { recursive: true })
+
+    const cfg = createTestConfig(dataDir)
+    db = createServiceDb(join(dataDir, 'service.sqlite'))
+    await migrateServiceDb(db)
+
+    actorStore = new StratosActorStore({
+      dataDir,
+      blobstore: () => createMockBlobStore() as any,
+      cborToRecord: (content) => decode(content) as Record<string, unknown>,
+    })
+
+    ctx = {
+      cfg,
+      actorStore,
+      enrollmentStore: {
+        getEnrollment: vi
+          .fn()
+          .mockResolvedValue({ active: true, isService: false }),
+      },
+      serviceDid,
+      writeRateLimiter: { assertWriteAllowed: vi.fn() },
+      actorSigner: {
+        sign: vi.fn().mockResolvedValue(new Uint8Array(64)),
+        getSignFn: vi
+          .fn()
+          .mockResolvedValue(() => Promise.resolve(new Uint8Array(64))),
+        getPublicKey: vi.fn().mockResolvedValue('did:key:zDnaeTestKey'),
+        ensureKey: vi.fn().mockResolvedValue(undefined),
+      },
+      repoWriteLocks: { acquire: vi.fn().mockResolvedValue(() => {}) },
+      logger: {
+        debug: vi.fn(),
+        info: vi.fn(),
+        error: vi.fn(),
+        warn: vi.fn(),
+      },
+      sequenceEvents: { emit: vi.fn() },
+      boundaryResolver: {
+        getBoundaries: vi.fn().mockResolvedValue([DOMAIN]),
+      },
+    }
+
+    await actorStore.create(testDid)
+  })
+
+  afterEach(async () => {
+    await closeServiceDb(db)
+    await rm(dataDir, { recursive: true, force: true })
+  })
+
+  it('returns the CID of the record content, not of its encoded bytes', async () => {
+    const record = post('Get in the robot')
+
+    const result = await createRecord(
+      ctx,
+      { repo: testDid, collection, rkey: 'unit01', record },
+      testDid,
+    )
+
+    const contentCid = (await computeCid(record)).toString()
+    const doubleEncodedCid = (await computeCid(encodeRecord(record))).toString()
+
+    expect(result.cid).toBe(contentCid)
+    expect(result.cid).not.toBe(doubleEncodedCid)
+  })
+
+  it('agrees with the update path on identical content', async () => {
+    const record = post('Anywhere but here')
+
+    const created = await createRecord(
+      ctx,
+      { repo: testDid, collection, rkey: 'unit02', record },
+      testDid,
+    )
+
+    const updated = await (updateRecord as any)(
+      ctx,
+      { repo: testDid, collection, rkey: 'unit02', record },
+      testDid,
+    )
+
+    expect(updated.cid).toBe(created.cid)
+  })
+
+  it('reads back the CID the create response reported', async () => {
+    const record = post('The beast that shouted love')
+
+    const created = await createRecord(
+      ctx,
+      { repo: testDid, collection, rkey: 'unit00', record },
+      testDid,
+    )
+
+    const read = await getRecord(
+      ctx,
+      { repo: testDid, collection, rkey: 'unit00' },
+      testDid,
+    )
+
+    expect(parseCid(read.cid as any).toString()).toBe(created.cid)
+  })
+})


### PR DESCRIPTION
## Description

A content-addressed record is supposed to be named by the hash of its content.
`createRecord` names it by the hash of the content encoded *twice* — it feeds
already-CBOR-encoded bytes into `computeCid`, which CBOR-encodes again before
hashing. So the CID on the block is `hash(cbor(cbor(record)))` while the block
itself is `cbor(record)`. The address does not match the thing it addresses.
Every external verifier that re-hashes the block — CAR export checks,
inclusion proofs, the client's `verification.ts` — computes a different CID
and rejects the record.


## Related Issues

<!-- Link to related issues using keywords like "Closes #123" or "Fixes #456" -->

## Testing

e2e test passes

## Type of Change

<!-- Mark relevant options with an "x" -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Build/CI changes
- [ ] Test improvements


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added API support for administrator management, enrollment listing, and member activation or deactivation.
  * Added pagination, enrollment metadata, and viewer information for administrative workflows.

* **Bug Fixes**
  * Corrected record identifiers returned during creation so they consistently represent the record content and match identifiers from updates.
  * Records can now be reliably retrieved using the identifier returned at creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->