### PR TITLE
Fix createRecord CID, add indexer typecheck, widen mutation coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,6 +56,9 @@ jobs:
       - name: Build packages
         run: pnpm run build
 
+      - name: Run typecheck
+        run: pnpm run typecheck
+
       - name: Run tests
         run: pnpm test
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "test": "vitest run",
+    "typecheck": "pnpm -r --if-present run typecheck",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "mutation": "pnpm -r run mutation",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -295,8 +295,8 @@ importers:
         specifier: ^0.0.214
         version: 0.0.214
       '@atproto/identity':
-        specifier: ^0.4.8
-        version: 0.4.11
+        specifier: ^0.4.12
+        version: 0.4.12
       '@atproto/lex-data':
         specifier: ^0.0.9
         version: 0.0.9

--- a/stratos-feedgen/stryker.config.json
+++ b/stratos-feedgen/stryker.config.json
@@ -13,6 +13,10 @@
     "src/subscription/service-stream.ts",
     "src/upstream/client.ts",
     "src/purge/**/*.ts",
+    "src/enrollment/**/*.ts",
+    "src/api/**/*.ts",
+    "src/auth/**/*.ts",
+    "src/db/**/*.ts",
     "!src/**/index.ts",
     "!src/**/*.d.ts"
   ],

--- a/stratos-indexer/package.json
+++ b/stratos-indexer/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "lint": "eslint src tests"
+    "lint": "eslint src tests",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@atcute/atproto": "^3.1.10",
@@ -13,7 +14,7 @@
     "@atcute/cid": "^2.4.1",
     "@atcute/firehose": "^0.1.0",
     "@atproto/bsky": "^0.0.214",
-    "@atproto/identity": "^0.4.8",
+    "@atproto/identity": "^0.4.12",
     "@atproto/lex-data": "^0.0.9",
     "@atproto/lexicon": "^0.6.1",
     "@atproto/repo": "^0.8.1",

--- a/stratos-indexer/src/indexer.ts
+++ b/stratos-indexer/src/indexer.ts
@@ -544,8 +544,8 @@ export class Indexer {
       for (const did of didsList) {
         this.enrolledDids.add(did)
         this.syncManager?.addActor(did)
-        background.add(() => {
-          void indexingService.indexHandle(did, new Date().toISOString())
+        background.add(async () => {
+          await indexingService.indexHandle(did, new Date().toISOString())
         })
       }
 

--- a/stratos-indexer/src/indexer.ts
+++ b/stratos-indexer/src/indexer.ts
@@ -9,6 +9,7 @@ import {
   createDatabase,
   createIdResolver,
   createIndexingService,
+  ensureIndexerSchema,
 } from './storage/db.js'
 import { HandleDedup } from './util/handle-dedup.js'
 import { CursorManager } from './storage/cursor-manager.js'
@@ -56,6 +57,7 @@ export class Indexer {
     // Database
     const db = createDatabase(this.config.db)
     this.db = db
+    await ensureIndexerSchema(db)
 
     const idResolver = createIdResolver(this.config.identity)
     const { indexingService, background } = createIndexingService(

--- a/stratos-indexer/src/indexer.ts
+++ b/stratos-indexer/src/indexer.ts
@@ -436,39 +436,24 @@ export class Indexer {
         background.add(async () => {
           const now = new Date().toISOString()
           try {
-            // Persist enrollment to database
+            const boundariesJson = JSON.stringify(boundaries)
             await rawDb
               .insertInto('stratos_enrollment')
               .values({
                 did,
                 serviceUrl,
-                createdAt: now,
-                updatedAt: now,
+                enrolledAt: now,
+                lastChecked: now,
+                boundaries: boundariesJson,
               })
               .onConflict((oc) =>
                 oc.column('did').doUpdateSet({
                   serviceUrl,
-                  updatedAt: now,
+                  lastChecked: now,
+                  boundaries: boundariesJson,
                 }),
               )
               .execute()
-
-            // Persist boundaries
-            if (boundaries.length > 0) {
-              await rawDb
-                .deleteFrom('stratos_boundary')
-                .where('did', '=', did)
-                .execute()
-              await rawDb
-                .insertInto('stratos_boundary')
-                .values(
-                  boundaries.map((boundary) => ({
-                    did,
-                    boundary,
-                  })),
-                )
-                .execute()
-            }
           } catch (err) {
             console.error(
               { err, did },
@@ -488,10 +473,6 @@ export class Indexer {
           try {
             await rawDb
               .deleteFrom('stratos_enrollment')
-              .where('did', '=', did)
-              .execute()
-            await rawDb
-              .deleteFrom('stratos_boundary')
               .where('did', '=', did)
               .execute()
           } catch (err) {

--- a/stratos-indexer/src/pds/pds-firehose.ts
+++ b/stratos-indexer/src/pds/pds-firehose.ts
@@ -5,8 +5,8 @@ import { AtUri } from '@atproto/syntax'
 import { CID } from 'multiformats/cid'
 import type { IndexingService } from '@atproto/bsky/dist/data-plane/server/indexing/index.js'
 import type { HandleDedup } from '../util/handle-dedup.js'
+import type { BackgroundQueue } from '@atproto/bsky'
 import {
-  type BackgroundQueue,
   decodeCommitOps,
   ENROLLMENT_COLLECTION,
   jsonToLex,
@@ -327,7 +327,7 @@ async function processCommit(
   const rawOps = message.ops
 
   if (handleDedup.shouldIndex(did)) {
-    background.add(`indexHandle-${did}`, async () => {
+    background.add(async () => {
       await indexingService.indexHandle(did, timestamp)
     })
   }

--- a/stratos-indexer/src/pds/pds-subscriber.ts
+++ b/stratos-indexer/src/pds/pds-subscriber.ts
@@ -6,7 +6,7 @@ import {
 } from './pds-firehose.js'
 import type { IndexingService } from '@atproto/bsky/dist/data-plane/server/indexing/index.js'
 import type { CursorManager } from '../storage/cursor-manager.js'
-import { BackgroundQueue } from '@northskysocial/stratos-core'
+import type { BackgroundQueue } from '@atproto/bsky'
 import { HandleDedup } from '../util/handle-dedup.js'
 import { WorkerPool } from '../util/worker-pool.js'
 

--- a/stratos-indexer/src/storage/db.ts
+++ b/stratos-indexer/src/storage/db.ts
@@ -11,95 +11,147 @@ const DID_CACHE_SWEEP_INTERVAL = 60 * 1000 // sweep every 60s
 const DID_CACHE_MAX_SIZE = 10_000
 
 /**
+ * Columns created by pre-quoting builds of this file, which declared them
+ * unquoted and so had Postgres fold them to lower case. Kysely emits quoted
+ * camelCase, so those tables must be renamed forward or every write fails.
+ */
+const LEGACY_LOWERCASE_COLUMNS = [
+  { table: 'stratos_enrollment', from: 'serviceurl', to: 'serviceUrl' },
+  { table: 'stratos_enrollment', from: 'createdat', to: 'createdAt' },
+  { table: 'stratos_enrollment', from: 'updatedat', to: 'updatedAt' },
+  { table: 'stratos_sync_cursor', from: 'updatedat', to: 'updatedAt' },
+  { table: 'stratos_record', from: 'indexedat', to: 'indexedAt' },
+] as const
+
+/**
  * Create a new database instance with the given configuration.
  *
  * @param cfg - Database configuration.
  * @returns A new Database instance.
  */
 export function createDatabase(cfg: DbConfig): Database {
-  const db = new Database({
+  return new Database({
     url: cfg.postgresUrl,
     schema: cfg.schema,
     poolSize: cfg.poolSize,
   })
+}
 
-  // Ensure optimized indexes for Stratos-specific hydration and sync patterns
-  // Note: These are added to the PostgreSQL bsky schema
-  void (async () => {
-    try {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
-      const rawDb = (db as any).db as Kysely<Record<string, unknown>>
-      // Postgres folds unquoted identifiers to lower case, while kysely always
-      // emits quoted camelCase — every camelCase column here must stay quoted
-      // or the writes in actor-syncer/cursor-manager fail at runtime.
-      await sql`
-        CREATE TABLE IF NOT EXISTS stratos_enrollment (
-          did TEXT PRIMARY KEY,
-          "serviceUrl" TEXT NOT NULL,
-          "createdAt" TEXT NOT NULL,
-          "updatedAt" TEXT NOT NULL
-        )
-      `.execute(rawDb)
-      await sql`
-        CREATE TABLE IF NOT EXISTS stratos_boundary
-        (
-          did      TEXT NOT NULL,
-          boundary TEXT NOT NULL,
-          PRIMARY KEY (did, boundary)
-        )
-      `.execute(rawDb)
-      await sql`
-        CREATE TABLE IF NOT EXISTS stratos_sync_cursor (
-          did TEXT PRIMARY KEY,
-          seq INTEGER NOT NULL,
-          "updatedAt" TEXT NOT NULL
-        )
-      `.execute(rawDb)
-      await sql`
-        CREATE TABLE IF NOT EXISTS post (
-          uri TEXT PRIMARY KEY,
-          cid TEXT NOT NULL,
-          creator TEXT NOT NULL,
-          text TEXT NOT NULL,
-          "createdAt" TEXT NOT NULL,
-          "indexedAt" TEXT NOT NULL,
-          "sortAt" TEXT GENERATED ALWAYS AS (LEAST("createdAt", "indexedAt")) STORED NOT NULL
-        )
-      `.execute(rawDb)
-      await sql`
-        CREATE TABLE IF NOT EXISTS stratos_record (
-          uri TEXT PRIMARY KEY,
-          cid TEXT NOT NULL,
-          json TEXT NOT NULL,
-          "indexedAt" TEXT NOT NULL
-        )
-      `.execute(rawDb)
-      await sql`
-        CREATE TABLE IF NOT EXISTS stratos_record_boundary (
-          uri TEXT NOT NULL,
-          boundary TEXT NOT NULL,
-          PRIMARY KEY (uri, boundary)
-        )
-      `.execute(rawDb)
-      // Optimized index for boundary-based hydration
-      await sql`
-        CREATE INDEX IF NOT EXISTS stratos_post_boundary_idx 
-        ON stratos_record_boundary (boundary)
-      `.execute(rawDb)
-      // Optimized index for actor-based feed queries
-      await sql`
-        CREATE INDEX IF NOT EXISTS stratos_post_did_indexed_at_idx 
-        ON post (creator, "indexedAt" DESC)
-      `.execute(rawDb)
-    } catch (err) {
-      console.error(
-        { err },
-        'failed to initialize stratos indexer tables/indexes',
+/**
+ * Rename a legacy lower-cased column to its camelCase form. No-ops when the
+ * table is absent, already renamed, or freshly created, so it is safe to rerun.
+ *
+ * @param db - Raw kysely instance.
+ * @param table - Table holding the column.
+ * @param from - Existing lower-cased column name.
+ * @param to - Target camelCase column name.
+ */
+async function renameLegacyColumn(
+  db: Kysely<Record<string, unknown>>,
+  table: string,
+  from: string,
+  to: string,
+): Promise<void> {
+  const { rows } = await sql<{ column_name: string }>`
+    SELECT column_name
+    FROM information_schema.columns
+    WHERE table_schema = current_schema()
+      AND table_name = ${table}
+      AND column_name IN (${from}, ${to})
+  `.execute(db)
+
+  const present = new Set(rows.map((row) => row.column_name))
+  if (!present.has(from) || present.has(to)) return
+
+  await sql`
+    ALTER TABLE ${sql.table(table)}
+    RENAME COLUMN ${sql.id(from)} TO ${sql.id(to)}
+  `.execute(db)
+}
+
+/**
+ * Create the indexer's tables and indexes, and repair legacy column casing.
+ * Must complete before any indexing write runs.
+ *
+ * @param db - Database instance to initialize.
+ */
+export async function ensureIndexerSchema(db: Database): Promise<void> {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
+    const rawDb = (db as any).db as Kysely<Record<string, unknown>>
+    // Postgres folds unquoted identifiers to lower case, while kysely always
+    // emits quoted camelCase — every camelCase column here must stay quoted
+    // or the writes in actor-syncer/cursor-manager fail at runtime.
+    await sql`
+      CREATE TABLE IF NOT EXISTS stratos_enrollment (
+        did TEXT PRIMARY KEY,
+        "serviceUrl" TEXT NOT NULL,
+        "createdAt" TEXT NOT NULL,
+        "updatedAt" TEXT NOT NULL
       )
-    }
-  })()
+    `.execute(rawDb)
+    await sql`
+      CREATE TABLE IF NOT EXISTS stratos_boundary
+      (
+        did      TEXT NOT NULL,
+        boundary TEXT NOT NULL,
+        PRIMARY KEY (did, boundary)
+      )
+    `.execute(rawDb)
+    await sql`
+      CREATE TABLE IF NOT EXISTS stratos_sync_cursor (
+        did TEXT PRIMARY KEY,
+        seq INTEGER NOT NULL,
+        "updatedAt" TEXT NOT NULL
+      )
+    `.execute(rawDb)
+    await sql`
+      CREATE TABLE IF NOT EXISTS post (
+        uri TEXT PRIMARY KEY,
+        cid TEXT NOT NULL,
+        creator TEXT NOT NULL,
+        text TEXT NOT NULL,
+        "createdAt" TEXT NOT NULL,
+        "indexedAt" TEXT NOT NULL,
+        "sortAt" TEXT GENERATED ALWAYS AS (LEAST("createdAt", "indexedAt")) STORED NOT NULL
+      )
+    `.execute(rawDb)
+    await sql`
+      CREATE TABLE IF NOT EXISTS stratos_record (
+        uri TEXT PRIMARY KEY,
+        cid TEXT NOT NULL,
+        json TEXT NOT NULL,
+        "indexedAt" TEXT NOT NULL
+      )
+    `.execute(rawDb)
+    await sql`
+      CREATE TABLE IF NOT EXISTS stratos_record_boundary (
+        uri TEXT NOT NULL,
+        boundary TEXT NOT NULL,
+        PRIMARY KEY (uri, boundary)
+      )
+    `.execute(rawDb)
 
-  return db
+    for (const { table, from, to } of LEGACY_LOWERCASE_COLUMNS) {
+      await renameLegacyColumn(rawDb, table, from, to)
+    }
+
+    // Optimized index for boundary-based hydration
+    await sql`
+      CREATE INDEX IF NOT EXISTS stratos_post_boundary_idx
+      ON stratos_record_boundary (boundary)
+    `.execute(rawDb)
+    // Optimized index for actor-based feed queries
+    await sql`
+      CREATE INDEX IF NOT EXISTS stratos_post_did_indexed_at_idx
+      ON post (creator, "indexedAt" DESC)
+    `.execute(rawDb)
+  } catch (err) {
+    console.error(
+      { err },
+      'failed to initialize stratos indexer tables/indexes',
+    )
+  }
 }
 
 /**

--- a/stratos-indexer/src/storage/db.ts
+++ b/stratos-indexer/src/storage/db.ts
@@ -57,9 +57,10 @@ export function createDatabase(cfg: DbConfig): Database {
           uri TEXT PRIMARY KEY,
           cid TEXT NOT NULL,
           creator TEXT NOT NULL,
-          content TEXT NOT NULL,
+          text TEXT NOT NULL,
           createdAt TEXT NOT NULL,
-          indexedAt TEXT NOT NULL
+          indexedAt TEXT NOT NULL,
+          sortAt TEXT GENERATED ALWAYS AS (LEAST("createdAt", "indexedAt")) STORED NOT NULL
         )
       `.execute(rawDb)
       await sql`

--- a/stratos-indexer/src/storage/db.ts
+++ b/stratos-indexer/src/storage/db.ts
@@ -134,7 +134,10 @@ export async function ensureIndexerSchema(db: Database): Promise<void> {
       ON post (creator, "indexedAt" DESC)
     `.execute(rawDb)
   } catch (err) {
-    console.error({ err }, 'failed to initialize stratos indexer tables/indexes')
+    console.error(
+      { err },
+      'failed to initialize stratos indexer tables/indexes',
+    )
     throw err
   }
 }

--- a/stratos-indexer/src/storage/db.ts
+++ b/stratos-indexer/src/storage/db.ts
@@ -17,18 +17,12 @@ const DID_CACHE_MAX_SIZE = 10_000
  */
 const LEGACY_LOWERCASE_COLUMNS = [
   { table: 'stratos_enrollment', from: 'serviceurl', to: 'serviceUrl' },
-  { table: 'stratos_enrollment', from: 'createdat', to: 'createdAt' },
-  { table: 'stratos_enrollment', from: 'updatedat', to: 'updatedAt' },
+  { table: 'stratos_enrollment', from: 'enrolledat', to: 'enrolledAt' },
+  { table: 'stratos_enrollment', from: 'lastchecked', to: 'lastChecked' },
   { table: 'stratos_sync_cursor', from: 'updatedat', to: 'updatedAt' },
   { table: 'stratos_record', from: 'indexedat', to: 'indexedAt' },
 ] as const
 
-/**
- * Create a new database instance with the given configuration.
- *
- * @param cfg - Database configuration.
- * @returns A new Database instance.
- */
 export function createDatabase(cfg: DbConfig): Database {
   return new Database({
     url: cfg.postgresUrl,
@@ -37,14 +31,14 @@ export function createDatabase(cfg: DbConfig): Database {
   })
 }
 
+/** `Database` keeps its kysely instance off its public type. */
+interface RawDbHolder {
+  db: Kysely<Record<string, unknown>>
+}
+
 /**
  * Rename a legacy lower-cased column to its camelCase form. No-ops when the
  * table is absent, already renamed, or freshly created, so it is safe to rerun.
- *
- * @param db - Raw kysely instance.
- * @param table - Table holding the column.
- * @param from - Existing lower-cased column name.
- * @param to - Target camelCase column name.
  */
 async function renameLegacyColumn(
   db: Kysely<Record<string, unknown>>,
@@ -71,31 +65,24 @@ async function renameLegacyColumn(
 
 /**
  * Create the indexer's tables and indexes, and repair legacy column casing.
- * Must complete before any indexing write runs.
- *
- * @param db - Database instance to initialize.
+ * Safe to rerun; must complete before any indexing write runs.
  */
 export async function ensureIndexerSchema(db: Database): Promise<void> {
   try {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
-    const rawDb = (db as any).db as Kysely<Record<string, unknown>>
+    const { db: rawDb } = db as unknown as RawDbHolder
     // Postgres folds unquoted identifiers to lower case, while kysely always
     // emits quoted camelCase — every camelCase column here must stay quoted
     // or the writes in actor-syncer/cursor-manager fail at runtime.
+    //
+    // stratos_enrollment is shared with the AppView, whose migration declares
+    // these exact columns — see atproto-stratos bsky db/tables/stratos-enrollment.ts.
     await sql`
       CREATE TABLE IF NOT EXISTS stratos_enrollment (
         did TEXT PRIMARY KEY,
         "serviceUrl" TEXT NOT NULL,
-        "createdAt" TEXT NOT NULL,
-        "updatedAt" TEXT NOT NULL
-      )
-    `.execute(rawDb)
-    await sql`
-      CREATE TABLE IF NOT EXISTS stratos_boundary
-      (
-        did      TEXT NOT NULL,
-        boundary TEXT NOT NULL,
-        PRIMARY KEY (did, boundary)
+        "enrolledAt" TEXT NOT NULL,
+        "lastChecked" TEXT NOT NULL,
+        boundaries TEXT
       )
     `.execute(rawDb)
     await sql`
@@ -147,19 +134,11 @@ export async function ensureIndexerSchema(db: Database): Promise<void> {
       ON post (creator, "indexedAt" DESC)
     `.execute(rawDb)
   } catch (err) {
-    console.error(
-      { err },
-      'failed to initialize stratos indexer tables/indexes',
-    )
+    console.error({ err }, 'failed to initialize stratos indexer tables/indexes')
+    throw err
   }
 }
 
-/**
- * Create a new ID resolver instance with the given configuration.
- *
- * @param cfg - Identity configuration.
- * @returns A new IdResolver instance.
- */
 export function createIdResolver(cfg: IdentityConfig): IdResolver {
   const cache = new MemoryCache(DID_CACHE_STALE_TTL, DID_CACHE_MAX_TTL)
 
@@ -184,13 +163,6 @@ export function createIdResolver(cfg: IdentityConfig): IdResolver {
   })
 }
 
-/**
- * Cap the size of a background queue by limiting concurrency and maximum size.
- *
- * @param background - The background queue to cap.
- * @param concurrency - Maximum number of concurrent tasks.
- * @param maxSize - Maximum total number of tasks in the queue.
- */
 function capBackgroundQueue(
   background: BackgroundQueue,
   concurrency: number,
@@ -206,14 +178,6 @@ function capBackgroundQueue(
   }
 }
 
-/**
- * Create an indexing service with the given database, ID resolver, and configuration.
- *
- * @param db - Database instance for indexing operations.
- * @param idResolver - ID resolver for resolving DIDs.
- * @param config - Configuration for the indexing service.
- * @returns A tuple containing the indexing service and the background queue.
- */
 export function createIndexingService(
   db: Database,
   idResolver: IdResolver,

--- a/stratos-indexer/src/storage/db.ts
+++ b/stratos-indexer/src/storage/db.ts
@@ -29,12 +29,15 @@ export function createDatabase(cfg: DbConfig): Database {
     try {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
       const rawDb = (db as any).db as Kysely<Record<string, unknown>>
+      // Postgres folds unquoted identifiers to lower case, while kysely always
+      // emits quoted camelCase — every camelCase column here must stay quoted
+      // or the writes in actor-syncer/cursor-manager fail at runtime.
       await sql`
         CREATE TABLE IF NOT EXISTS stratos_enrollment (
           did TEXT PRIMARY KEY,
-          serviceUrl TEXT NOT NULL,
-          createdAt TEXT NOT NULL,
-          updatedAt TEXT NOT NULL
+          "serviceUrl" TEXT NOT NULL,
+          "createdAt" TEXT NOT NULL,
+          "updatedAt" TEXT NOT NULL
         )
       `.execute(rawDb)
       await sql`
@@ -49,7 +52,7 @@ export function createDatabase(cfg: DbConfig): Database {
         CREATE TABLE IF NOT EXISTS stratos_sync_cursor (
           did TEXT PRIMARY KEY,
           seq INTEGER NOT NULL,
-          updatedAt TEXT NOT NULL
+          "updatedAt" TEXT NOT NULL
         )
       `.execute(rawDb)
       await sql`
@@ -58,9 +61,9 @@ export function createDatabase(cfg: DbConfig): Database {
           cid TEXT NOT NULL,
           creator TEXT NOT NULL,
           text TEXT NOT NULL,
-          createdAt TEXT NOT NULL,
-          indexedAt TEXT NOT NULL,
-          sortAt TEXT GENERATED ALWAYS AS (LEAST("createdAt", "indexedAt")) STORED NOT NULL
+          "createdAt" TEXT NOT NULL,
+          "indexedAt" TEXT NOT NULL,
+          "sortAt" TEXT GENERATED ALWAYS AS (LEAST("createdAt", "indexedAt")) STORED NOT NULL
         )
       `.execute(rawDb)
       await sql`
@@ -68,7 +71,7 @@ export function createDatabase(cfg: DbConfig): Database {
           uri TEXT PRIMARY KEY,
           cid TEXT NOT NULL,
           json TEXT NOT NULL,
-          indexedAt TEXT NOT NULL
+          "indexedAt" TEXT NOT NULL
         )
       `.execute(rawDb)
       await sql`
@@ -86,7 +89,7 @@ export function createDatabase(cfg: DbConfig): Database {
       // Optimized index for actor-based feed queries
       await sql`
         CREATE INDEX IF NOT EXISTS stratos_post_did_indexed_at_idx 
-        ON post (creator, indexedAt DESC)
+        ON post (creator, "indexedAt" DESC)
       `.execute(rawDb)
     } catch (err) {
       console.error(

--- a/stratos-indexer/src/storage/schema.ts
+++ b/stratos-indexer/src/storage/schema.ts
@@ -1,4 +1,9 @@
-import type { Insertable, Selectable, Updateable } from 'kysely'
+import type {
+  GeneratedAlways,
+  Insertable,
+  Selectable,
+  Updateable,
+} from 'kysely'
 
 export interface StratosSyncCursorTable {
   did: string
@@ -33,9 +38,10 @@ export interface PostTable {
   uri: string
   cid: string
   creator: string
-  content: string
+  text: string
   createdAt: string
   indexedAt: string
+  sortAt: GeneratedAlways<string>
 }
 
 export interface StratosBoundaryTable {

--- a/stratos-indexer/src/storage/schema.ts
+++ b/stratos-indexer/src/storage/schema.ts
@@ -1,7 +1,4 @@
-import type { Insertable, Kysely, Selectable, Updateable } from 'kysely'
-import type { DatabaseSchema } from '@atproto/bsky'
-
-type DatabaseSchemaType = DatabaseSchema extends Kysely<infer T> ? T : never
+import type { Insertable, Selectable, Updateable } from 'kysely'
 
 export interface StratosSyncCursorTable {
   did: string
@@ -46,8 +43,13 @@ export interface StratosBoundaryTable {
   boundary: string
 }
 
-// eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
-export type StratosIndexerSchema = DatabaseSchemaType & {
+/**
+ * The subset of the AppView database this indexer reads and writes. Declared
+ * standalone rather than intersected with `@atproto/bsky`'s schema: bsky pins
+ * kysely 0.22 while this package uses 0.28, so inferring its table map through
+ * `Kysely<infer T>` silently yielded `never` and left every query untyped.
+ */
+export interface StratosIndexerSchema {
   stratos_sync_cursor: StratosSyncCursorTable
   stratos_enrollment: StratosEnrollmentTable
   stratos_boundary: StratosBoundaryTable

--- a/stratos-indexer/src/storage/schema.ts
+++ b/stratos-indexer/src/storage/schema.ts
@@ -18,8 +18,9 @@ export type StratosSyncCursorUpdate = Updateable<StratosSyncCursorTable>
 export interface StratosEnrollmentTable {
   did: string
   serviceUrl: string
-  createdAt: string
-  updatedAt: string
+  enrolledAt: string
+  lastChecked: string
+  boundaries: string | null
 }
 
 export interface StratosRecordTable {
@@ -44,11 +45,6 @@ export interface PostTable {
   sortAt: GeneratedAlways<string>
 }
 
-export interface StratosBoundaryTable {
-  did: string
-  boundary: string
-}
-
 /**
  * The subset of the AppView database this indexer reads and writes. Declared
  * standalone rather than intersected with `@atproto/bsky`'s schema: bsky pins
@@ -58,7 +54,6 @@ export interface StratosBoundaryTable {
 export interface StratosIndexerSchema {
   stratos_sync_cursor: StratosSyncCursorTable
   stratos_enrollment: StratosEnrollmentTable
-  stratos_boundary: StratosBoundaryTable
   stratos_record: StratosRecordTable
   stratos_record_boundary: StratosRecordBoundaryTable
   post: PostTable

--- a/stratos-indexer/src/sync/actor-syncer.ts
+++ b/stratos-indexer/src/sync/actor-syncer.ts
@@ -180,7 +180,11 @@ export class ActorSyncer {
               ? e.error
               : 'unknown'
         this.options.onError?.(
-          new StratosError(`WebSocket error for ${this.did}: ${errorMsg}`),
+          new StratosError(
+            `WebSocket error for ${this.did}: ${errorMsg}`,
+            'ActorSyncStreamError',
+            { cause: e.error instanceof Error ? e.error : undefined },
+          ),
         )
       }
     }

--- a/stratos-indexer/src/sync/actor-syncer.ts
+++ b/stratos-indexer/src/sync/actor-syncer.ts
@@ -1,5 +1,6 @@
 import { decodeFirst } from '@atcute/cbor'
 import { Kysely } from 'kysely'
+import type { Insertable } from 'kysely'
 import { extractBoundaries, StratosError } from '@northskysocial/stratos-core'
 import type { CursorManager } from '../storage/cursor-manager.ts'
 import type { PostTable, StratosIndexerSchema } from '../storage/schema.ts'
@@ -508,7 +509,7 @@ async function batchIndexStratosRecords(
           .onConflict((oc) =>
             oc.column('uri').doUpdateSet({
               cid: postRow.cid,
-              content: postRow.content,
+              text: postRow.text,
               indexedAt: postRow.indexedAt,
             }),
           )
@@ -565,13 +566,13 @@ function preparePostRow(
   cid: string,
   record: Record<string, unknown>,
   timestamp: string,
-): PostTable | null {
+): Insertable<PostTable> | null {
   if (record.$type !== STRATOS_POST_COLLECTION) return null
   return {
     uri,
     cid,
     creator: didFromUri(uri),
-    content: (record.text as string) || '',
+    text: (record.text as string) || '',
     createdAt: (record.createdAt as string) || timestamp,
     indexedAt: timestamp,
   }

--- a/stratos-indexer/src/sync/stratos-sync.ts
+++ b/stratos-indexer/src/sync/stratos-sync.ts
@@ -136,9 +136,11 @@ export class StratosServiceSubscription {
             : 'unknown'
       const cause = e.error instanceof Error ? e.error : undefined
       this.onError?.(
-        new StratosError(`Enrollment stream error: ${errorMsg}`, {
-          cause,
-        }),
+        new StratosError(
+          `Enrollment stream error: ${errorMsg}`,
+          'EnrollmentStreamError',
+          { cause },
+        ),
       )
     }
 

--- a/stratos-indexer/src/sync/sync-manager.ts
+++ b/stratos-indexer/src/sync/sync-manager.ts
@@ -43,10 +43,7 @@ export interface StratosSyncManagerOptions {
   indexingService: IndexingService
   background: BackgroundQueue
   enrollmentCallback: EnrollmentCallback
-  onReferencedActorBackfill: (
-    did: string,
-    opts: BackfillOptions,
-  ) => Promise<void>
+  onReferencedActorBackfill: (did: string, opts: BackfillOptions) => void
   onError?: (err: Error) => void
 }
 
@@ -84,7 +81,6 @@ export class StratosSyncManager {
           console.error({ err: err.message }, 'Sync Manager actor sync error')
         }
       },
-      // eslint-disable-next-line @typescript-eslint/no-misused-promises
       opts.config.pds.enrolledOnly
         ? (did) => opts.onReferencedActorBackfill(did, backfillOpts)
         : undefined,

--- a/stratos-indexer/tests/actor-queue.test.ts
+++ b/stratos-indexer/tests/actor-queue.test.ts
@@ -183,9 +183,9 @@ describe('enrollment stream errors', () => {
       const subscription = new StratosServiceSubscription(
         { stratosServiceUrl: 'ws://localhost', syncToken: 'test' },
         {
-          onEnrollmentDiscovered: vi.fn(),
-          onEnrollmentRemoved: vi.fn(),
-        } as never,
+          onEnroll: vi.fn(),
+          onUnenroll: vi.fn(),
+        },
         (err) => errors.push(err),
       )
 

--- a/stratos-indexer/tests/actor-queue.test.ts
+++ b/stratos-indexer/tests/actor-queue.test.ts
@@ -1,7 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import type { CursorManager } from '../src'
-import { StratosActorSync, StratosActorSyncOptions } from '../src'
-import { ActorSyncer } from '../src/sync/actor-syncer'
+import type { CursorManager } from '../src/index.js'
+import {
+  StratosActorSync,
+  StratosActorSyncOptions,
+  StratosServiceSubscription,
+} from '../src/index.js'
+import { ActorSyncer } from '../src/sync/actor-syncer.js'
+import { StratosError } from '@northskysocial/stratos-core'
 
 function createTestSync(opts: Partial<StratosActorSyncOptions> = {}) {
   const errors: Error[] = []
@@ -151,5 +156,53 @@ describe('enqueueMessage overflow', () => {
     enqueueFn.call(syncer, new Uint8Array(3))
 
     expect(mockWs.close).toHaveBeenCalled()
+  })
+})
+
+describe('enrollment stream errors', () => {
+  it('reports a coded StratosError preserving the underlying cause', () => {
+    const errors: Error[] = []
+    const sockets: Array<Record<string, unknown>> = []
+
+    class FakeWebSocket {
+      binaryType = ''
+      onerror: ((e: Event & { error?: unknown }) => void) | null = null
+      onmessage: unknown = null
+      onclose: unknown = null
+      addEventListener = vi.fn()
+      close = vi.fn()
+      constructor() {
+        sockets.push(this as unknown as Record<string, unknown>)
+      }
+    }
+
+    const originalWebSocket = globalThis.WebSocket
+    globalThis.WebSocket = FakeWebSocket as unknown as typeof WebSocket
+
+    try {
+      const subscription = new StratosServiceSubscription(
+        { stratosServiceUrl: 'ws://localhost', syncToken: 'test' },
+        {
+          onEnrollmentDiscovered: vi.fn(),
+          onEnrollmentRemoved: vi.fn(),
+        } as never,
+        (err) => errors.push(err),
+      )
+
+      subscription.start()
+
+      const socket = sockets[0] as unknown as FakeWebSocket
+      const underlying = new Error('cell games interrupted')
+      socket.onerror?.({ error: underlying } as Event & { error?: unknown })
+
+      expect(errors).toHaveLength(1)
+      const [reported] = errors
+      expect(reported).toBeInstanceOf(StratosError)
+      expect((reported as StratosError).code).toBe('EnrollmentStreamError')
+      expect(reported.message).toContain('cell games interrupted')
+      expect(reported.cause).toBe(underlying)
+    } finally {
+      globalThis.WebSocket = originalWebSocket
+    }
   })
 })

--- a/stratos-indexer/tests/backfill.test.ts
+++ b/stratos-indexer/tests/backfill.test.ts
@@ -4,7 +4,7 @@ import {
   BackfillOptions,
   backfillRepos,
   backfillSingleActor,
-} from '../src/backfill'
+} from '../src/backfill.js'
 
 function makeOpts(overrides?: Partial<BackfillOptions>): BackfillOptions {
   return {

--- a/stratos-indexer/tests/config.test.ts
+++ b/stratos-indexer/tests/config.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
-import { loadConfig } from '../src'
+import { loadConfig } from '../src/index.js'
 
 describe('loadConfig', () => {
   const originalEnv = process.env

--- a/stratos-indexer/tests/cursor-manager.test.ts
+++ b/stratos-indexer/tests/cursor-manager.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
-import { CursorManager, type CursorState } from '../src/storage/cursor-manager'
+import {
+  CursorManager,
+  type CursorState,
+} from '../src/storage/cursor-manager.js'
 
 describe('CursorManager', () => {
   let flushed: CursorState[]

--- a/stratos-indexer/tests/helpers/test-indexer.ts
+++ b/stratos-indexer/tests/helpers/test-indexer.ts
@@ -1,5 +1,5 @@
-import type { IndexerConfig } from '../../src'
-import { Indexer, loadConfig } from '../../src'
+import type { IndexerConfig } from '../../src/index.js'
+import { Indexer, loadConfig } from '../../src/index.js'
 
 export class TestIndexer {
   public indexer: Indexer

--- a/stratos-indexer/tests/pds-firehose.test.ts
+++ b/stratos-indexer/tests/pds-firehose.test.ts
@@ -9,8 +9,8 @@ import {
 import type { CursorManager, WorkerPool } from '../src/index.ts'
 import type { IndexingService } from '@atproto/bsky/dist/data-plane/server/indexing/index.js'
 // Re-import mocked functions to use in tests
+import type { BackgroundQueue } from '@atproto/bsky'
 import {
-  type BackgroundQueue,
   decodeCommitOps,
   ENROLLMENT_COLLECTION,
   parseEnrollmentRecord,
@@ -182,7 +182,7 @@ describe('processFirehoseWork', () => {
     } as unknown as IndexingService
 
     background = {
-      add: vi.fn((key, fn) => fn()),
+      add: vi.fn((fn) => fn()),
     } as unknown as BackgroundQueue
 
     enrollmentCallback = {

--- a/stratos-indexer/tests/worker-pool.test.ts
+++ b/stratos-indexer/tests/worker-pool.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it } from 'vitest'
-import { WorkerPool } from '../src'
+import { WorkerPool } from '../src/index.js'
 
 describe('WorkerPool', () => {
   let errors: Error[]

--- a/stratos-indexer/tsconfig.json
+++ b/stratos-indexer/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "./src",
     "target": "ES2022",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
@@ -12,7 +11,16 @@
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
     "allowImportingTsExtensions": true,
-    "noEmit": true
+    "noEmit": true,
+    // stratos-core publishes its `types` as raw `src/*.ts` written against
+    // `moduleResolution: Bundler`. Checking those sources through this
+    // package's NodeNext lens reports extensionless-import errors that are
+    // valid in their own package, so resolve against its built `dist`
+    // instead. This is why CI must run typecheck after build.
+    "paths": {
+      "@northskysocial/stratos-core": ["../stratos-core/dist/index.d.ts"],
+      "@northskysocial/stratos-core/*": ["../stratos-core/dist/*"]
+    }
   },
   "include": ["src/**/*", "tests/**/*", "vitest.config.ts"],
   "exclude": ["node_modules", "dist"]

--- a/stratos-service/stryker.config.json
+++ b/stratos-service/stryker.config.json
@@ -25,6 +25,8 @@
     "src/infra/storage/cached-enrollment-store.ts",
     "src/infra/storage/reserved-domain-enrollment-store.ts",
     "src/api/handlers/repo-read-handlers.ts",
+    "src/api/records/**/*.ts",
+    "src/features/space-read/**/*.ts",
     "!src/**/index.ts",
     "!src/**/*.d.ts"
   ],


### PR DESCRIPTION
## Summary

 fixes to the verification baseline,

**1. `listAdmins` schema understated its contract** (`90a0a0c`, `3731b71`)
The handler always returns `viewer` on success, but both the lexicon and the
hand-written admin-ui client type marked it optional. The admin UI needs it: the
session is an opaque HttpOnly cookie, so the browser has no other way to learn
its own DID for the "(you)" badge and self-revoke guard.

**2. stratos-indexer was never typechecked — and was hiding a live bug** (`2180aa1`)
It had no `build` or `typecheck` script, so `pnpm -r build` skipped it and CI
never compiled it. Adding `tsc --noEmit` immediately surfaced a production defect:
`pds-firehose` called `background.add(name, fn)` against bsky's `BackgroundQueue`,
whose `add(task)` takes **one** argument — so the name string was consumed as the
task and the real function discarded. **Handle indexing from the PDS firehose
silently never ran.** The test mock encoded the same two-arg contract, which is
exactly why it went unnoticed.

Three latent defects sat behind it, two marked by eslint suppressions:
- `storage/schema.ts` inferred bsky's table map through `DatabaseSchema extends
  Kysely<infer T>`, comparing bsky's kysely **0.22** against this package's
  **0.28**. Incompatible copies → conditional false → `never`, leaving every
  indexer query untyped. The `no-redundant-type-constituents` disable was
  silencing precisely that.
- `sync-manager` declared `onReferencedActorBackfill` as `=> Promise<void>` while
  implementation and consumer are both fire-and-forget `void`, forcing a
  `no-misused-promises` disable.
- `actor-syncer` built a `StratosError` without its `code` argument — the same
  call-shape bug as the enrollment stream error plan 006 targeted.

Also deduped `@atproto/identity` 0.4.11/0.4.12, so the indexer no longer runs two
DID resolvers with separate caches in one process.

**3. Mutation globs widened**
Service: `src/api/records/**` (the record-write hot path) and
`src/features/space-read/**`. Feedgen: `enrollment`, `api`, `auth`, `db`.

## Reviewer notes

- `stratos-indexer/tsconfig.json` now maps `@northskysocial/stratos-core` to its
  built `dist`. Core publishes `types` as raw `src` written for
  `moduleResolution: Bundler`; checking those through the indexer's NodeNext lens
  reports 23 errors that are valid in core's own package. **Consequence: the
  indexer's typecheck requires core to be built first** — the CI step is ordered
  after build for this reason.
- Plan 006 was scoped as a one-line fix; it grew to 21 files once the typecheck
  actually ran. Expansion was authorized deliberately, not accidental.

## Test plan

- [x] `pnpm run build` — exit 0
- [x] `pnpm run typecheck` — exit 0 (new)
- [x] `pnpm run lint` — exit 0
- [x] `pnpm prettier --check .` — exit 0
- [x] `pnpm test` — 1536 passed, 0 failed
- [x] Both regression tests verified by reverting their fixes and confirming failure:
      createRecord CID (2 of 3 cases fail) and `EnrollmentStreamError`
      (`expected { Object (cause) } to be 'EnrollmentStreamError'`)
- [ ] Mutation runs on the newly-covered globs (slow, not CI-enforced — follow-up)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Improved background processing for enrolled-only indexing and commit handle updates.
* Improved synchronization error reporting with specific error codes and preserved underlying causes.
* Improved post indexing consistency, ordering, and database initialization during synchronization and backfills.
* Added automatic handling for legacy database columns and required indexes.

## Tests

* Expanded mutation testing coverage across core indexing and service functionality.
* Added coverage for coded enrollment stream errors.

## Chores

* Added workspace-wide TypeScript type checking to build validation.
* Improved type-checking configuration and module resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->