### PR TITLE
fix(auth): deny deactivated enrollments on subscription and cred path

### DIFF
--- a/stratos-service/src/features/space-credential/handler.ts
+++ b/stratos-service/src/features/space-credential/handler.ts
@@ -84,8 +84,9 @@ export function registerSpaceCredentialHandlers(
  *   3. Resolve identity: if a `delegationToken` is present, verify it
  *      (its target space MUST equal `space`) and take identity from it; else use
  *      the DPoP-authenticated user (reject anonymous).
- *   4. Map the space URI to its boundary and confirm the user is enrolled in it
- *      (live enrollment-store lookup, no cache) → else {@link NotEnrolled}.
+ *   4. Map the space URI to its boundary, then confirm the user's enrollment is
+ *      present AND active, and that it carries that boundary (live
+ *      enrollment-store lookup, no cache) → else {@link NotEnrolled}.
  *   5. App-axis gating: if the space's `appAccess` is `#allowList`,
  *      require a valid client attestation whose attested `client_id` is listed
  *      (else `AttestationRequired` / `ClientNotAllowed`). `#open` spaces ignore
@@ -124,6 +125,17 @@ async function handleGetSpaceCredential(
 
   // Membership: the user must be enrolled in the boundary for this space.
   const boundary = `${spaceDid}/${skey}`
+
+  // Boundary rows outlive deactivation, so a boundaries-only check would let a
+  // suspended member keep minting credentials. Deny inactive enrollments first,
+  // under the same NotEnrolled shape (no membership-status oracle).
+  const enrollment = await ctx.enrollmentStore.getEnrollment(userDid)
+  if (!enrollment || !enrollment.active) {
+    throw new InvalidRequestError(
+      'User is not enrolled in this space',
+      'NotEnrolled',
+    )
+  }
 
   const boundaries = await ctx.enrollmentStore.getBoundaries(userDid)
   if (!boundaries.includes(boundary)) {

--- a/stratos-service/src/subscription/subscribe-records.ts
+++ b/stratos-service/src/subscription/subscribe-records.ts
@@ -337,6 +337,13 @@ export function createSubscribeRecordsHandler(ctx: AppContext) {
       throw new AuthRequiredError('Service auth required')
     }
 
+    // Boundary rows outlive deactivation, so a boundaries-only check would keep
+    // a suspended caller streaming. Mirror verifyEnrolled: deny inactive first.
+    const enrollment = await ctx.enrollmentStore.getEnrollment(callerDid)
+    if (!enrollment || !enrollment.active) {
+      throw new AuthRequiredError('Enrollment is missing or deactivated')
+    }
+
     const boundaries = await ctx.enrollmentStore.getBoundaries(callerDid)
     if (boundaries.length === 0) {
       throw new AuthRequiredError('Service is not enrolled in any boundary')

--- a/stratos-service/tests/space-credential-app-gating.test.ts
+++ b/stratos-service/tests/space-credential-app-gating.test.ts
@@ -124,6 +124,12 @@ function createMockCtx(opts: MockCtxOptions): AppContext {
       },
     },
     enrollmentStore: {
+      getEnrollment: vi.fn(async (did: string) => ({
+        did,
+        enrolledAt: '1995-10-04T00:00:00.000Z',
+        signingKeyDid: 'did:key:zDnaeUsagi',
+        active: true,
+      })),
       getBoundaries: vi.fn(async () => [SPACE_BOUNDARY]),
     },
     authVerifier: { optionalStandard },

--- a/stratos-service/tests/space-credential-handler.test.ts
+++ b/stratos-service/tests/space-credential-handler.test.ts
@@ -4,6 +4,8 @@
  * Exercises both identity paths against a mock XRPC server + mock AppContext:
  *   - Interim DPoP path (live): enrolled user gets a credential; non-enrolled
  *     is rejected `NotEnrolled`; a foreign-space URI is rejected `UnknownSpace`.
+ *   - Deactivation gate: a deactivated member is rejected `NotEnrolled` even
+ *     while holding the boundary, and the deny lands on the very next mint.
  *   - Delegation-token path (dormant, real delegation verifier): happy path
  *     issues a credential; every verification failure surfaces as `InvalidToken`.
  * The issued credential is decoded and verified against the service key (and
@@ -14,6 +16,12 @@ import { describe, expect, it, vi } from 'vitest'
 import { Secp256k1Keypair, verifySignature } from '@atproto/crypto'
 import type { Keypair } from '@atproto/crypto'
 import type { IdResolver } from '@atproto/identity'
+import { SqliteEnrollmentStore } from '../src/context.js'
+import {
+  closeServiceDb,
+  createServiceDb,
+  migrateServiceDb,
+} from '../src/db/index.js'
 import { registerSpaceCredentialHandlers } from '../src/features/space-credential/index.js'
 import { DELEGATION_TYP } from '../src/infra/auth/delegation-verifier.js'
 import type { NxExStore } from '../src/infra/auth/replay-store.js'
@@ -126,6 +134,8 @@ function atprotoResolver(did: string, keypair: Keypair): IdResolver {
 interface MockCtxOptions {
   signingKey: Keypair
   enrolledBoundaries?: string[]
+  /** Whether the caller's enrollment row is still active. Defaults to true. */
+  enrollmentActive?: boolean
   idResolver?: IdResolver
   cache?: NxExStore
 }
@@ -145,6 +155,12 @@ function createMockCtx(opts: MockCtxOptions): AppContext {
       stratos: { spaceCredentialTtlSeconds: TTL_SECONDS },
     },
     enrollmentStore: {
+      getEnrollment: vi.fn(async (did: string) => ({
+        did,
+        enrolledAt: '1995-10-04T00:00:00.000Z',
+        signingKeyDid: 'did:key:zDnaeUsagi',
+        active: opts.enrollmentActive ?? true,
+      })),
       getBoundaries: vi.fn(async () => opts.enrolledBoundaries ?? []),
     },
     authVerifier: {
@@ -317,6 +333,99 @@ describe('getSpaceCredential — DPoP path', () => {
 
     const res = await invoke(server, { space: 'not-a-space-uri' }, USER_DID)
     expect(res.error?.name).toBe('UnknownSpace')
+  })
+})
+
+// ===========================================================================
+// Deactivation gate
+// ===========================================================================
+
+/**
+ * Deactivation revokes credential issuance.
+ *
+ * Boundary rows survive a deactivation, so a boundaries-only membership check
+ * would let a suspended member keep minting credentials. Both the never-enrolled
+ * and the deactivated caller must get the same `NotEnrolled` shape — the surface
+ * must not become a membership-status oracle.
+ */
+describe('getSpaceCredential — deactivation gate', () => {
+  /** Register the handler against a fresh mock ctx and issue one request. */
+  async function mint(opts: Omit<MockCtxOptions, 'signingKey'>) {
+    const signingKey = await Secp256k1Keypair.create()
+    const ctx = createMockCtx({ signingKey, ...opts })
+    const server = createMockXrpcServer()
+    registerSpaceCredentialHandlers(server as any, ctx)
+    return invoke(server, { space: SPACE_URI }, USER_DID)
+  }
+
+  it('rejects a deactivated user holding a matching boundary with NotEnrolled', async () => {
+    const res = await mint({
+      enrolledBoundaries: [SPACE_BOUNDARY],
+      enrollmentActive: false,
+    })
+
+    expect(res.error?.name).toBe('NotEnrolled')
+    expect(res.body).toBeUndefined()
+  })
+
+  it('is indistinguishable from a never-enrolled rejection (no status oracle)', async () => {
+    const deactivated = await mint({
+      enrolledBoundaries: [SPACE_BOUNDARY],
+      enrollmentActive: false,
+    })
+    const neverEnrolled = await mint({ enrolledBoundaries: [] })
+
+    expect(deactivated.error).toEqual(neverEnrolled.error)
+  })
+
+  it('rejects a user with no enrollment row with NotEnrolled', async () => {
+    const signingKey = await Secp256k1Keypair.create()
+    const ctx = createMockCtx({
+      signingKey,
+      enrolledBoundaries: [SPACE_BOUNDARY],
+    })
+    ;(ctx.enrollmentStore.getEnrollment as any) = vi.fn(async () => null)
+    const server = createMockXrpcServer()
+    registerSpaceCredentialHandlers(server as any, ctx)
+
+    const res = await invoke(server, { space: SPACE_URI }, USER_DID)
+    expect(res.error?.name).toBe('NotEnrolled')
+    expect(res.body).toBeUndefined()
+  })
+
+  it('deactivation is immediate: the NEXT mint after it is rejected', async () => {
+    // Real store, so the deny is driven by an actual deactivation write rather
+    // than a re-stubbed mock — that is what "immediate" has to mean.
+    const db = createServiceDb(':memory:')
+    await migrateServiceDb(db)
+    const store = new SqliteEnrollmentStore(db)
+    await store.enroll({
+      did: USER_DID,
+      enrolledAt: new Date().toISOString(),
+      boundaries: [SPACE_BOUNDARY],
+      signingKeyDid: 'did:key:zDnaeUsagi',
+      active: true,
+    })
+
+    const signingKey = await Secp256k1Keypair.create()
+    const ctx = createMockCtx({ signingKey })
+    ;(ctx as any).enrollmentStore = store
+    const server = createMockXrpcServer()
+    registerSpaceCredentialHandlers(server as any, ctx)
+
+    try {
+      const before = await invoke(server, { space: SPACE_URI }, USER_DID)
+      expect(before.error).toBeUndefined()
+      expect(before.body?.credential).toBeTruthy()
+
+      await store.updateEnrollment(USER_DID, { active: false })
+
+      const after = await invoke(server, { space: SPACE_URI }, USER_DID)
+      expect(after.error?.name).toBe('NotEnrolled')
+      expect(after.body).toBeUndefined()
+    } finally {
+      await closeServiceDb(db)
+    }
   })
 })
 

--- a/stratos-service/tests/subscription-auth.test.ts
+++ b/stratos-service/tests/subscription-auth.test.ts
@@ -7,12 +7,16 @@
  * paths an AppView indexer will encounter — including the expiry case that
  * triggers on reconnect when a stale token is reused.
  */
+import { EventEmitter } from 'node:events'
 import { describe, expect, it, vi } from 'vitest'
 import { Secp256k1Keypair } from '@atproto/crypto'
-import { createServiceJwt } from '@atproto/xrpc-server'
+import { AuthRequiredError, createServiceJwt } from '@atproto/xrpc-server'
 import type { IdResolver } from '@atproto/identity'
+import type { StoredEnrollment } from '@northskysocial/stratos-core'
 import { verifyServiceAuth } from '../src/infra/auth/index.js'
 import { createSubscribeAuthVerifier } from '../src/infra/auth/verifiers.js'
+import { createSubscribeRecordsHandler } from '../src/subscription/index.js'
+import type { AppContext } from '../src/index.js'
 
 const OUR_DID = 'did:web:stratos.test'
 const LXM = 'zone.stratos.sync.subscribeRecords'
@@ -318,5 +322,91 @@ describe('createSubscribeAuthVerifier (stream auth gate)', () => {
     await expect(verifier(ctx)).rejects.toThrow(
       'Service authorization required',
     )
+  })
+})
+
+/**
+ * Stream admission (deactivation gate).
+ *
+ * A valid service JWT only proves who the caller is. Admission additionally
+ * requires a LIVE enrollment that is still active: boundary rows survive
+ * deactivation, so a boundaries-only check would leave a suspended consumer
+ * streaming indefinitely.
+ */
+describe('subscribeRecords admission (enrollment active gate)', () => {
+  const CONSUMER_DID = 'did:web:jupiter.sailormoon.jp'
+  const BOUNDARY = 'did:web:nerv.tokyo.jp/alpha'
+
+  function enrollmentFor(did: string, active: boolean): StoredEnrollment {
+    return {
+      did,
+      enrolledAt: new Date('1995-10-04').toISOString(),
+      signingKeyDid: 'did:key:zDnaeMakoto',
+      active,
+      isService: true,
+    }
+  }
+
+  function makeCtx(
+    enrollment: StoredEnrollment | null,
+    boundaries: string[],
+  ): AppContext {
+    return {
+      enrollmentStore: {
+        getEnrollment: vi.fn(async () => enrollment),
+        getBoundaries: vi.fn(async () => boundaries),
+        listEnrollments: vi.fn(async () => []),
+      },
+      enrollmentEvents: new EventEmitter(),
+      actorStore: { exists: vi.fn(async () => false) },
+      logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    } as unknown as AppContext
+  }
+
+  const serviceCreds = {
+    credentials: { type: 'service', iss: CONSUMER_DID, did: CONSUMER_DID },
+  }
+
+  /** Drive the generator to its first result (admission runs on first next). */
+  function admit(ctx: AppContext, signal: AbortSignal) {
+    return createSubscribeRecordsHandler(ctx)({}, serviceCreds, signal).next()
+  }
+
+  it('rejects a deactivated caller even though its boundary rows remain', async () => {
+    const ctx = makeCtx(enrollmentFor(CONSUMER_DID, false), [BOUNDARY])
+
+    await expect(admit(ctx, new AbortController().signal)).rejects.toThrow(
+      AuthRequiredError,
+    )
+    await expect(admit(ctx, new AbortController().signal)).rejects.toThrow(
+      'Enrollment is missing or deactivated',
+    )
+  })
+
+  it('rejects a caller with no enrollment row at all', async () => {
+    const ctx = makeCtx(null, [BOUNDARY])
+
+    await expect(admit(ctx, new AbortController().signal)).rejects.toThrow(
+      AuthRequiredError,
+    )
+  })
+
+  it('still rejects an active caller enrolled in no boundary', async () => {
+    const ctx = makeCtx(enrollmentFor(CONSUMER_DID, true), [])
+
+    await expect(admit(ctx, new AbortController().signal)).rejects.toThrow(
+      'Service is not enrolled in any boundary',
+    )
+  })
+
+  it('admits an active caller with boundaries', async () => {
+    const ctx = makeCtx(enrollmentFor(CONSUMER_DID, true), [BOUNDARY])
+    const aborted = AbortSignal.abort()
+
+    // An already-aborted signal makes the delegated stream terminate at once,
+    // so reaching `done` proves admission passed rather than threw.
+    await expect(admit(ctx, aborted)).resolves.toMatchObject({ done: true })
+    expect(ctx.enrollmentStore.getEnrollment).toHaveBeenCalledWith(CONSUMER_DID)
+    expect(ctx.enrollmentStore.getBoundaries).toHaveBeenCalledWith(CONSUMER_DID)
   })
 })


### PR DESCRIPTION
## Description

Deactivation was only enforced at the OAuth front door by verifyEnrolled. The subscribeRecords sync stream and space-credential issuance both gated on boundaries alone, and getBoundaries does not filter on the active flag — so a suspended member kept their sync stream and could still mint read credentials.

Mirror the verifyEnrolled predicate at both paths: load the enrollment and deny when it is missing or inactive, before the existing boundary checks. The credential path deliberately reuses the existing NotEnrolled message and code so the surface does not become a membership-status oracle.

## Related Issues

<!-- Link to related issues using keywords like "Closes #123" or "Fixes #456" -->

## Testing

<!-- Describe the tests you ran to verify your changes -->

## Type of Change

<!-- Mark relevant options with an "x" -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Build/CI changes
- [ ] Test improvements


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Credential issuance now requires an active enrollment.
  * Deactivated or missing enrollments are rejected consistently without exposing credentials.
  * Subscription streams now require an active enrollment before access is granted.
  * Active enrollments without valid space boundaries remain blocked.

* **Tests**
  * Added coverage for enrollment deactivation, missing enrollments, credential protection, and subscription access decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->