### PR TITLE
fix(feedgen): stall instead of skipping failed commits

### DIFF
--- a/stratos-feedgen/src/subscription/actor-syncer.ts
+++ b/stratos-feedgen/src/subscription/actor-syncer.ts
@@ -167,8 +167,10 @@ export class ActorSyncer {
       }
       this.ws = null
     }
+    // `draining` belongs to drain(): clearing it here while a frame is still in
+    // flight would let a later start() launch a second concurrent drain. The
+    // drain loop already exits on `!running` and clears the flag itself.
     this.queue = []
-    this.draining = false
   }
 
   private async connect(): Promise<void> {
@@ -338,6 +340,26 @@ export class ActorSyncer {
     }
   }
 
+  /**
+   * Decode a frame and apply its commit.
+   *
+   * The two failure paths here have deliberately opposite policies.
+   *
+   * An *apply* failure stalls (`failConnection`): it is normally a transient
+   * store fault, so retrying the sequence eventually succeeds, and advancing
+   * past it would drop the commit permanently — the feedgen serves feeds from
+   * its own index and has no backfill path.
+   *
+   * A *decode* failure continues. It cannot be retried, because the frame
+   * decodes identically on replay, so stalling would wedge this actor forever
+   * with no fault that can clear. It also means version skew rather than
+   * corruption — the upstream fails closed on events it cannot decode, so a
+   * frame reaching us undecodable implies a framing/CBOR mismatch that would
+   * hit every actor at once; stalling would take the whole feedgen down on a
+   * protocol change. The accepted cost is that the next successful commit
+   * advances the cursor past the lost frame, so these are reported loudly
+   * under their own code.
+   */
   private async handleFrame(data: Uint8Array): Promise<void> {
     let header: Record<string, unknown>
     let rest: Uint8Array

--- a/stratos-feedgen/src/subscription/actor-syncer.ts
+++ b/stratos-feedgen/src/subscription/actor-syncer.ts
@@ -70,6 +70,14 @@ const DEFAULT_JITTER_RATIO = 0.2
 const DEFAULT_MAX_QUEUE_SIZE = 1_000
 const DEFAULT_STABILITY_RESET_MS = 30_000
 const WS_OPEN = 1
+/**
+ * Consecutive failures at the SAME sequence before a distinct stall alarm is
+ * raised. The sequence is still retried indefinitely rather than being passed
+ * over: a lost commit is unrecoverable (the feedgen has no backfill path and
+ * serves feeds straight from its index), whereas a stalled actor is observable
+ * and heals on its own once the underlying fault clears.
+ */
+const APPLY_FAILURE_ALARM_THRESHOLD = 3
 
 /**
  * Maintains a single per-actor WebSocket subscription to
@@ -86,6 +94,8 @@ export class ActorSyncer {
   private stabilityTimer: ReturnType<typeof setTimeout> | null = null
   private queue: Uint8Array[] = []
   private draining = false
+  private lastFailedSeq: number | null = null
+  private sameSeqFailures = 0
   private readonly baseDelayMs: number
   private readonly maxDelayMs: number
   private readonly jitterRatio: number
@@ -211,6 +221,8 @@ export class ActorSyncer {
     })
 
     ws.onmessage = (e: MessageEventLike) => {
+      // A superseded socket must not refill a queue that was just cleared.
+      if (this.ws !== ws) return
       this.lastMessageAt = Date.now()
       const buf = e.data instanceof Uint8Array ? e.data : new Uint8Array(e.data)
       this.enqueue(buf)
@@ -276,6 +288,25 @@ export class ActorSyncer {
     }, delay)
   }
 
+  /**
+   * Abandon the current connection without advancing the cursor. Everything
+   * still buffered is discarded rather than applied: the reconnect replays it
+   * from the last durable cursor, so discarding is lossless, while applying it
+   * would carry the cursor past the sequence we just failed on.
+   */
+  private failConnection(): void {
+    this.queue = []
+    if (this.ws) {
+      try {
+        this.ws.close()
+      } catch {
+        // ignore
+      }
+      this.ws = null
+    }
+    this.scheduleReconnect()
+  }
+
   private enqueue(data: Uint8Array): void {
     if (this.queue.length >= this.maxQueueSize) {
       this.deps.onError?.(
@@ -284,15 +315,7 @@ export class ActorSyncer {
           'ACTOR_SYNC_OVERFLOW',
         ),
       )
-      if (this.ws) {
-        try {
-          this.ws.close()
-        } catch {
-          // ignore
-        }
-        this.ws = null
-      }
-      this.scheduleReconnect()
+      this.failConnection()
       return
     }
     this.queue.push(data)
@@ -324,7 +347,13 @@ export class ActorSyncer {
         Uint8Array,
       ]
     } catch (err) {
-      this.deps.onError?.(err as Error)
+      this.deps.onError?.(
+        new StratosError(
+          `undecodable frame header for ${this.config.did}`,
+          'ACTOR_SYNC_FRAME_UNDECODABLE',
+          { cause: err },
+        ),
+      )
       return
     }
     if (header['t'] !== '#commit') return
@@ -332,7 +361,13 @@ export class ActorSyncer {
     try {
       ;[body] = decodeFirst(rest) as [CommitFrameBody, Uint8Array]
     } catch (err) {
-      this.deps.onError?.(err as Error)
+      this.deps.onError?.(
+        new StratosError(
+          `undecodable commit body for ${this.config.did}`,
+          'ACTOR_SYNC_FRAME_UNDECODABLE',
+          { cause: err },
+        ),
+      )
       return
     }
     try {
@@ -342,8 +377,41 @@ export class ActorSyncer {
         time: body.time,
         ops: body.ops,
       })
+      this.lastFailedSeq = null
+      this.sameSeqFailures = 0
     } catch (err) {
-      this.deps.onError?.(err as Error)
+      this.recordApplyFailure(body.seq, err)
+      this.failConnection()
+    }
+  }
+
+  /**
+   * Report an apply failure and, once the same sequence has failed
+   * `APPLY_FAILURE_ALARM_THRESHOLD` times in a row, raise one distinct alarm.
+   * The alarm fires once per stall episode so a wedged actor produces a signal
+   * rather than a stream of noise.
+   */
+  private recordApplyFailure(seq: number, err: unknown): void {
+    if (seq === this.lastFailedSeq) {
+      this.sameSeqFailures++
+    } else {
+      this.lastFailedSeq = seq
+      this.sameSeqFailures = 1
+    }
+    this.deps.onError?.(
+      new StratosError(
+        `commit apply failed for ${this.config.did} at seq ${seq}`,
+        'ACTOR_SYNC_APPLY_FAILED',
+        { cause: err },
+      ),
+    )
+    if (this.sameSeqFailures === APPLY_FAILURE_ALARM_THRESHOLD) {
+      this.deps.onError?.(
+        new StratosError(
+          `actor sync stalled for ${this.config.did} at seq ${seq} after ${this.sameSeqFailures} consecutive apply failures; retrying indefinitely`,
+          'ACTOR_SYNC_STALLED',
+        ),
+      )
     }
   }
 }

--- a/stratos-feedgen/src/subscription/actor-syncer.ts
+++ b/stratos-feedgen/src/subscription/actor-syncer.ts
@@ -159,14 +159,7 @@ export class ActorSyncer {
       clearTimeout(this.reconnectTimer)
       this.reconnectTimer = null
     }
-    if (this.ws) {
-      try {
-        this.ws.close()
-      } catch {
-        // ignore close errors
-      }
-      this.ws = null
-    }
+    this.detachSocket()
     // `draining` belongs to drain(): clearing it here while a frame is still in
     // flight would let a later start() launch a second concurrent drain. The
     // drain loop already exits on `!running` and clears the flag itself.
@@ -248,6 +241,11 @@ export class ActorSyncer {
     }
 
     ws.onclose = () => {
+      // A socket we already gave up on closes on its own schedule, which can be
+      // later than the reconnect that replaced it. Acting on that close would
+      // detach the live socket instead, and every frame it delivered would then
+      // be dropped by the superseded-socket guard in `onmessage`.
+      if (this.ws !== ws) return
       this.ws = null
       this.clearStabilityTimer()
       if (this.running) {
@@ -298,15 +296,26 @@ export class ActorSyncer {
    */
   private failConnection(): void {
     this.queue = []
-    if (this.ws) {
-      try {
-        this.ws.close()
-      } catch {
-        // ignore
-      }
-      this.ws = null
-    }
+    this.detachSocket()
     this.scheduleReconnect()
+  }
+
+  /**
+   * Close the current socket and give up ownership of it at once. `close()`
+   * only starts the closing handshake — the close event can land well after the
+   * reconnect that follows — so ownership is dropped here rather than in
+   * `onclose`, and the detached socket's own close is then ignored.
+   */
+  private detachSocket(): void {
+    const ws = this.ws
+    if (!ws) return
+    this.ws = null
+    this.clearStabilityTimer()
+    try {
+      ws.close()
+    } catch {
+      // ignore close errors
+    }
   }
 
   private enqueue(data: Uint8Array): void {

--- a/stratos-feedgen/src/subscription/actor-syncer.ts
+++ b/stratos-feedgen/src/subscription/actor-syncer.ts
@@ -359,6 +359,12 @@ export class ActorSyncer {
    * protocol change. The accepted cost is that the next successful commit
    * advances the cursor past the lost frame, so these are reported loudly
    * under their own code.
+   *
+   * A body that decodes but has the wrong *shape* is a decode failure too, and
+   * must be caught here rather than handed to `applyCommit`: a non-array `ops`
+   * would throw inside the apply and be misread as a transient store fault,
+   * stalling the actor forever on a frame that can never succeed, and a
+   * non-numeric `seq` would be written straight to the cursor.
    */
   private async handleFrame(data: Uint8Array): Promise<void> {
     let header: Record<string, unknown>
@@ -379,9 +385,9 @@ export class ActorSyncer {
       return
     }
     if (header['t'] !== '#commit') return
-    let body: CommitFrameBody
+    let decoded: unknown
     try {
-      ;[body] = decodeFirst(rest) as [CommitFrameBody, Uint8Array]
+      ;[decoded] = decodeFirst(rest) as [unknown, Uint8Array]
     } catch (err) {
       this.deps.onError?.(
         new StratosError(
@@ -392,6 +398,16 @@ export class ActorSyncer {
       )
       return
     }
+    if (!isCommitFrameBody(decoded)) {
+      this.deps.onError?.(
+        new StratosError(
+          `malformed commit body for ${this.config.did}`,
+          'ACTOR_SYNC_FRAME_UNDECODABLE',
+        ),
+      )
+      return
+    }
+    const body = decoded
     try {
       await this.deps.indexer.applyCommit({
         did: this.config.did,
@@ -436,6 +452,24 @@ export class ActorSyncer {
       )
     }
   }
+}
+
+/**
+ * Whether a decoded commit body carries the three fields the apply path relies
+ * on. `seq` must be a real number because it becomes the durable cursor, and
+ * `ops` must be iterable because `applyCommit` loops it. Non-object bodies need
+ * no arm of their own: indexing a scalar yields `undefined` and fails the field
+ * checks anyway, so only `null`/`undefined` — which throw on index — have to be
+ * turned away up front.
+ */
+function isCommitFrameBody(value: unknown): value is CommitFrameBody {
+  if (!value) return false
+  const body = value as Record<string, unknown>
+  return (
+    Number.isFinite(body['seq']) &&
+    typeof body['time'] === 'string' &&
+    Array.isArray(body['ops'])
+  )
 }
 
 function buildWsUrl(

--- a/stratos-feedgen/src/subscription/service-stream.ts
+++ b/stratos-feedgen/src/subscription/service-stream.ts
@@ -26,6 +26,7 @@ export interface ServiceStreamConfig {
   baseDelayMs?: number
   maxDelayMs?: number
   jitterRatio?: number
+  maxQueueSize?: number
   /**
    * How long a connection must stay open before its backoff counter is reset.
    * Prevents an accept-then-immediately-close loop from reconnecting forever at
@@ -96,6 +97,7 @@ export class ServiceStream {
   private readonly baseDelayMs: number
   private readonly maxDelayMs: number
   private readonly jitterRatio: number
+  private readonly maxQueueSize: number
   private readonly stabilityResetMs: number
   private readonly wsCtor: WebSocketCtor
   private readonly rng: () => number
@@ -109,6 +111,7 @@ export class ServiceStream {
     this.baseDelayMs = config.baseDelayMs ?? DEFAULT_BASE_DELAY_MS
     this.maxDelayMs = config.maxDelayMs ?? DEFAULT_MAX_DELAY_MS
     this.jitterRatio = config.jitterRatio ?? DEFAULT_JITTER_RATIO
+    this.maxQueueSize = config.maxQueueSize ?? DEFAULT_MAX_QUEUE_SIZE
     this.stabilityResetMs =
       config.stabilityResetMs ?? DEFAULT_STABILITY_RESET_MS
     this.wsCtor = deps?.wsCtor ?? (NodeWebSocket as unknown as WebSocketCtor)
@@ -245,29 +248,40 @@ export class ServiceStream {
   }
 
   /**
+   * Abandon the current connection and everything still buffered. Discarding is
+   * lossless for enroll and boundary changes: this stream has no cursor, and
+   * the upstream replays every current enrollment on connect
+   * (`createServiceSubscriptionHandler` in the service's `subscribe-records`),
+   * so the reconnect restores the full set.
+   */
+  private failConnection(): void {
+    this.queue = []
+    if (this.ws) {
+      try {
+        this.ws.close()
+      } catch {
+        // ignore
+      }
+      this.ws = null
+    }
+    this.scheduleReconnect()
+  }
+
+  /**
    * Buffer a frame for sequential processing. Enrollment events are
    * order-sensitive — an `unenroll` overtaking its `enroll` would leave the
    * pool and the boundary cache disagreeing about whether an actor syncs — so
    * frames are drained one at a time rather than dispatched concurrently.
    */
   private enqueue(data: Uint8Array): void {
-    if (this.queue.length >= DEFAULT_MAX_QUEUE_SIZE) {
+    if (this.queue.length >= this.maxQueueSize) {
       this.onError?.(
         new StratosError(
           'enrollment stream queue overflow; dropping connection',
           'SERVICE_STREAM_OVERFLOW',
         ),
       )
-      this.queue = []
-      if (this.ws) {
-        try {
-          this.ws.close()
-        } catch {
-          // ignore
-        }
-        this.ws = null
-      }
-      this.scheduleReconnect()
+      this.failConnection()
       return
     }
     this.queue.push(data)

--- a/stratos-feedgen/src/subscription/service-stream.ts
+++ b/stratos-feedgen/src/subscription/service-stream.ts
@@ -135,14 +135,7 @@ export class ServiceStream {
       clearTimeout(this.reconnectTimer)
       this.reconnectTimer = null
     }
-    if (this.ws) {
-      try {
-        this.ws.close()
-      } catch {
-        // ignore close errors
-      }
-      this.ws = null
-    }
+    this.detachSocket()
     // `draining` belongs to drain(): clearing it here while a handler is still
     // in flight would let a later start() launch a second concurrent drain.
     // The drain loop already exits on `!running` and clears the flag itself.
@@ -205,6 +198,10 @@ export class ServiceStream {
     }
 
     ws.onclose = () => {
+      // A socket we already gave up on closes on its own schedule, which can be
+      // later than the reconnect that replaced it. Acting on that close would
+      // detach the live socket instead.
+      if (this.ws !== ws) return
       this.ws = null
       this.clearStabilityTimer()
       if (this.running) {
@@ -248,6 +245,24 @@ export class ServiceStream {
   }
 
   /**
+   * Close the current socket and give up ownership of it at once. `close()`
+   * only starts the closing handshake — the close event can land well after the
+   * reconnect that follows — so ownership is dropped here rather than in
+   * `onclose`, and the detached socket's own close is then ignored.
+   */
+  private detachSocket(): void {
+    const ws = this.ws
+    if (!ws) return
+    this.ws = null
+    this.clearStabilityTimer()
+    try {
+      ws.close()
+    } catch {
+      // ignore close errors
+    }
+  }
+
+  /**
    * Abandon the current connection and everything still buffered. Discarding is
    * lossless for enroll and boundary changes: this stream has no cursor, and
    * the upstream replays every current enrollment on connect
@@ -256,14 +271,7 @@ export class ServiceStream {
    */
   private failConnection(): void {
     this.queue = []
-    if (this.ws) {
-      try {
-        this.ws.close()
-      } catch {
-        // ignore
-      }
-      this.ws = null
-    }
+    this.detachSocket()
     this.scheduleReconnect()
   }
 

--- a/stratos-feedgen/src/subscription/service-stream.ts
+++ b/stratos-feedgen/src/subscription/service-stream.ts
@@ -74,6 +74,7 @@ const DEFAULT_BASE_DELAY_MS = 5_000
 const DEFAULT_MAX_DELAY_MS = 60_000
 const DEFAULT_JITTER_RATIO = 0.2
 const DEFAULT_STABILITY_RESET_MS = 30_000
+const DEFAULT_MAX_QUEUE_SIZE = 1_000
 const WS_OPEN = 1
 
 /**
@@ -90,6 +91,8 @@ export class ServiceStream {
   private reconnectAttempt = 0
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null
   private stabilityTimer: ReturnType<typeof setTimeout> | null = null
+  private queue: Uint8Array[] = []
+  private draining = false
   private readonly baseDelayMs: number
   private readonly maxDelayMs: number
   private readonly jitterRatio: number
@@ -137,6 +140,8 @@ export class ServiceStream {
       }
       this.ws = null
     }
+    this.queue = []
+    this.draining = false
   }
 
   private async connect(): Promise<void> {
@@ -171,8 +176,10 @@ export class ServiceStream {
     })
 
     ws.onmessage = (e: MessageEventLike) => {
+      // A superseded socket must not refill a queue that was just cleared.
+      if (this.ws !== ws) return
       const buf = e.data instanceof Uint8Array ? e.data : new Uint8Array(e.data)
-      void this.handleMessage(buf)
+      this.enqueue(buf)
     }
 
     ws.onerror = (e: ErrorEventLike) => {
@@ -233,6 +240,52 @@ export class ServiceStream {
       this.reconnectTimer = null
       void this.connect()
     }, delay)
+  }
+
+  /**
+   * Buffer a frame for sequential processing. Enrollment events are
+   * order-sensitive — an `unenroll` overtaking its `enroll` would leave the
+   * pool and the boundary cache disagreeing about whether an actor syncs — so
+   * frames are drained one at a time rather than dispatched concurrently.
+   */
+  private enqueue(data: Uint8Array): void {
+    if (this.queue.length >= DEFAULT_MAX_QUEUE_SIZE) {
+      this.onError?.(
+        new StratosError(
+          'enrollment stream queue overflow; dropping connection',
+          'SERVICE_STREAM_OVERFLOW',
+        ),
+      )
+      this.queue = []
+      if (this.ws) {
+        try {
+          this.ws.close()
+        } catch {
+          // ignore
+        }
+        this.ws = null
+      }
+      this.scheduleReconnect()
+      return
+    }
+    this.queue.push(data)
+    if (!this.draining) {
+      void this.drain()
+    }
+  }
+
+  private async drain(): Promise<void> {
+    if (this.draining) return
+    this.draining = true
+    try {
+      while (this.queue.length > 0 && this.running) {
+        const data = this.queue.shift()
+        if (!data) continue
+        await this.handleMessage(data)
+      }
+    } finally {
+      this.draining = false
+    }
   }
 
   private async handleMessage(data: Uint8Array): Promise<void> {

--- a/stratos-feedgen/src/subscription/service-stream.ts
+++ b/stratos-feedgen/src/subscription/service-stream.ts
@@ -140,8 +140,10 @@ export class ServiceStream {
       }
       this.ws = null
     }
+    // `draining` belongs to drain(): clearing it here while a handler is still
+    // in flight would let a later start() launch a second concurrent drain.
+    // The drain loop already exits on `!running` and clears the flag itself.
     this.queue = []
-    this.draining = false
   }
 
   private async connect(): Promise<void> {

--- a/stratos-feedgen/tests/actor-syncer.test.ts
+++ b/stratos-feedgen/tests/actor-syncer.test.ts
@@ -620,6 +620,46 @@ describe('ActorSyncer', () => {
     syncer.stop()
   })
 
+  it('ignores a close event that arrives after the socket was detached', async () => {
+    const { indexer: failing } = wrapIndexer(indexer, (seq) => seq === 1)
+    const syncer = new ActorSyncer(
+      {
+        did: DID,
+        stratosServiceUrl: 'http://stratos.test',
+        mintToken: async () => 'tok',
+        baseDelayMs: 1_000,
+        maxDelayMs: 1_000,
+        jitterRatio: 0,
+      },
+      { store, indexer: failing, wsCtor: FakeWebSocket as never, rng: () => 0 },
+    )
+    syncer.start()
+    await vi.waitFor(() => expect(FakeWebSocket.instances).toHaveLength(1))
+    const first = FakeWebSocket.instances[0]
+    first.open()
+    // The apply failure abandons this socket and schedules the reconnect.
+    first.send(commitFrame(1))
+    await vi.advanceTimersByTimeAsync(1_500)
+    await vi.waitFor(() => expect(FakeWebSocket.instances).toHaveLength(2))
+    const second = FakeWebSocket.instances[1]
+    second.open()
+
+    // `close()` only starts the handshake, so the abandoned socket's close can
+    // land here — after its replacement is already live.
+    first.onclose?.()
+
+    // Ownership stayed with the live socket, so no second reconnect fires...
+    await vi.advanceTimersByTimeAsync(5_000)
+    expect(FakeWebSocket.instances).toHaveLength(2)
+    // ...and its frames are still consumed, rather than being discarded by the
+    // superseded-socket guard against a `ws` the stale close had nulled.
+    second.send(commitFrame(2))
+    await vi.waitFor(async () => {
+      expect(await store.getCursor(DID)).toBe(2)
+    })
+    syncer.stop()
+  })
+
   it('reports the store error as the cause of the apply failure', async () => {
     const errors: Error[] = []
     const diskFull = new Error('SQLITE_FULL: database or disk is full')

--- a/stratos-feedgen/tests/actor-syncer.test.ts
+++ b/stratos-feedgen/tests/actor-syncer.test.ts
@@ -584,7 +584,7 @@ describe('ActorSyncer', () => {
     syncer.stop()
   })
 
-  it('survives an apply failure with no onError sink wired', async () => {
+  it('keeps consuming undecodable frames with no onError sink wired', async () => {
     const syncer = new ActorSyncer(
       {
         did: DID,
@@ -601,7 +601,14 @@ describe('ActorSyncer', () => {
     await vi.waitFor(() => expect(FakeWebSocket.instances).toHaveLength(1))
     const ws = FakeWebSocket.instances[0]
     ws.open()
+    // Garbage header, then a valid header with a garbage body: both decode
+    // catches must tolerate the absent sink.
     ws.send(new Uint8Array([0xff, 0xff, 0xff, 0xff]))
+    const header = cborEncode({ op: 1, t: '#commit' })
+    const badBody = new Uint8Array(header.length + 3)
+    badBody.set(header, 0)
+    badBody.set([0xff, 0xff, 0xff], header.length)
+    ws.send(badBody)
     await vi.advanceTimersByTimeAsync(50)
 
     expect(ws.readyState).toBe(WS_OPEN)
@@ -609,6 +616,38 @@ describe('ActorSyncer', () => {
     await vi.waitFor(async () => {
       expect(await store.getCursor(DID)).toBe(3)
     })
+    syncer.stop()
+  })
+
+  it('stalls on an apply failure with no onError sink wired', async () => {
+    const { calls, indexer: failing } = wrapIndexer(indexer, (seq) => seq === 1)
+    const syncer = new ActorSyncer(
+      {
+        did: DID,
+        stratosServiceUrl: 'http://stratos.test',
+        mintToken: async () => 'tok',
+        baseDelayMs: 1_000,
+        maxDelayMs: 1_000,
+        jitterRatio: 0,
+      },
+      // onError omitted: durability must not depend on a reporting sink being
+      // wired, so the reconnect and the cursor hold regardless.
+      { store, indexer: failing, wsCtor: FakeWebSocket as never, rng: () => 0 },
+    )
+    syncer.start()
+    await vi.waitFor(() => expect(FakeWebSocket.instances).toHaveLength(1))
+    const ws = FakeWebSocket.instances[0]
+    ws.open()
+    ws.send(commitFrame(1))
+    ws.send(commitFrame(2))
+
+    await vi.waitFor(() => expect(calls).toEqual([1]))
+    expect(ws.readyState).toBe(WS_CLOSED)
+    expect(await store.getCursor(DID)).toBeNull()
+
+    await vi.advanceTimersByTimeAsync(1_500)
+    await vi.waitFor(() => expect(FakeWebSocket.instances).toHaveLength(2))
+    expect(FakeWebSocket.instances[1].url).not.toContain('cursor=')
     syncer.stop()
   })
 

--- a/stratos-feedgen/tests/actor-syncer.test.ts
+++ b/stratos-feedgen/tests/actor-syncer.test.ts
@@ -1,4 +1,5 @@
 import { encode as cborEncode } from '@atcute/cbor'
+import { StratosError } from '@northskysocial/stratos-core'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
@@ -9,7 +10,11 @@ import {
   migrateSqliteDb,
   SqliteFeedgenStore,
 } from '../src/db/index.js'
-import { ActorSyncer, SubscriptionIndexer } from '../src/subscription/index.js'
+import {
+  ActorSyncer,
+  type IndexCommitArgs,
+  SubscriptionIndexer,
+} from '../src/subscription/index.js'
 
 // ---- Fake WebSocket ----------------------------------------------------
 
@@ -81,6 +86,45 @@ function postRecord(text: string): Record<string, unknown> {
     createdAt: '2024-01-01T00:00:00.000Z',
     boundary: { values: [{ value: 'example.com/eng' }] },
   }
+}
+
+/**
+ * Wrap the real indexer so a chosen sequence throws before it reaches the
+ * store. Delegating on success keeps the cursor behaviour real, which is what
+ * the durability assertions turn on.
+ */
+function wrapIndexer(
+  real: SubscriptionIndexer,
+  shouldFail: (seq: number) => boolean,
+): { calls: number[]; indexer: SubscriptionIndexer } {
+  const calls: number[] = []
+  const wrapped = {
+    applyCommit: async (args: IndexCommitArgs): Promise<void> => {
+      calls.push(args.seq)
+      if (shouldFail(args.seq)) throw new Error('sqlite is busy')
+      await real.applyCommit(args)
+    },
+  }
+  return { calls, indexer: wrapped as unknown as SubscriptionIndexer }
+}
+
+function commitFrame(seq: number): Uint8Array {
+  return encodeCommitFrame({
+    seq,
+    time: '2024-02-01T00:00:00.000Z',
+    ops: [
+      {
+        action: 'create',
+        path: `zone.stratos.feed.post/r${seq}`,
+        cid: `bafy${seq}`,
+        record: postRecord(`post ${seq}`),
+      },
+    ],
+  })
+}
+
+function codesOf(errors: Error[]): string[] {
+  return errors.map((err) => (err as StratosError).code)
 }
 
 const tmpDirs: string[] = []
@@ -360,6 +404,478 @@ describe('ActorSyncer', () => {
     await vi.advanceTimersByTimeAsync(1)
     await vi.waitFor(() => expect(FakeWebSocket.instances).toHaveLength(4))
 
+    syncer.stop()
+  })
+
+  it('does not apply frames buffered behind a failed commit', async () => {
+    const errors: Error[] = []
+    const { calls, indexer: failing } = wrapIndexer(indexer, (seq) => seq === 1)
+    const syncer = new ActorSyncer(
+      {
+        did: DID,
+        stratosServiceUrl: 'http://stratos.test',
+        mintToken: async () => 'tok',
+        baseDelayMs: 60_000,
+        maxDelayMs: 60_000,
+        jitterRatio: 0,
+      },
+      {
+        store,
+        indexer: failing,
+        wsCtor: FakeWebSocket as never,
+        rng: () => 0,
+        onError: (err) => errors.push(err),
+      },
+    )
+    syncer.start()
+    await vi.waitFor(() => expect(FakeWebSocket.instances).toHaveLength(1))
+    const ws = FakeWebSocket.instances[0]
+    ws.open()
+
+    // One synchronous burst: seq 2 and 3 are sitting in the queue when seq 1
+    // fails. Applying either of them would carry the cursor past seq 1.
+    ws.send(commitFrame(1))
+    ws.send(commitFrame(2))
+    ws.send(commitFrame(3))
+
+    await vi.waitFor(() =>
+      expect(codesOf(errors)).toContain('ACTOR_SYNC_APPLY_FAILED'),
+    )
+    expect(calls).toEqual([1])
+    expect(ws.readyState).toBe(WS_CLOSED)
+    expect(await store.getCursor(DID)).toBeNull()
+    // The queue is emptied, not merely abandoned: nothing else is drained, so
+    // the failure reports exactly once and produces no downstream noise.
+    expect(codesOf(errors)).toEqual(['ACTOR_SYNC_APPLY_FAILED'])
+    syncer.stop()
+  })
+
+  it('does not accumulate failures at different sequences toward the alarm', async () => {
+    const errors: Error[] = []
+    const { calls, indexer: failing } = wrapIndexer(indexer, () => true)
+    const syncer = new ActorSyncer(
+      {
+        did: DID,
+        stratosServiceUrl: 'http://stratos.test',
+        mintToken: async () => 'tok',
+        baseDelayMs: 1_000,
+        maxDelayMs: 1_000,
+        jitterRatio: 0,
+        stabilityResetMs: 60_000,
+      },
+      {
+        store,
+        indexer: failing,
+        wsCtor: FakeWebSocket as never,
+        rng: () => 0,
+        onError: (err) => errors.push(err),
+      },
+    )
+    syncer.start()
+
+    // Three failures, each at a DIFFERENT sequence. The counter tracks a stuck
+    // sequence, not a flaky store, so this must not trip the alarm.
+    for (let cycle = 0; cycle < 3; cycle++) {
+      await vi.waitFor(() =>
+        expect(FakeWebSocket.instances).toHaveLength(cycle + 1),
+      )
+      FakeWebSocket.instances[cycle].open()
+      FakeWebSocket.instances[cycle].send(commitFrame(cycle + 1))
+      await vi.waitFor(() => expect(calls).toHaveLength(cycle + 1))
+      await vi.advanceTimersByTimeAsync(1_500)
+    }
+
+    expect(calls).toEqual([1, 2, 3])
+    expect(codesOf(errors)).not.toContain('ACTOR_SYNC_STALLED')
+    syncer.stop()
+  })
+
+  it('reports undecodable frames without dropping the connection', async () => {
+    const errors: Error[] = []
+    const syncer = new ActorSyncer(
+      {
+        did: DID,
+        stratosServiceUrl: 'http://stratos.test',
+        mintToken: async () => 'tok',
+      },
+      {
+        store,
+        indexer,
+        wsCtor: FakeWebSocket as never,
+        rng: () => 0,
+        onError: (err) => errors.push(err),
+      },
+    )
+    syncer.start()
+    await vi.waitFor(() => expect(FakeWebSocket.instances).toHaveLength(1))
+    const ws = FakeWebSocket.instances[0]
+    ws.open()
+
+    // Garbage header.
+    ws.send(new Uint8Array([0xff, 0xff, 0xff, 0xff]))
+    // Valid header, garbage body.
+    const header = cborEncode({ op: 1, t: '#commit' })
+    const badBody = new Uint8Array(header.length + 3)
+    badBody.set(header, 0)
+    badBody.set([0xff, 0xff, 0xff], header.length)
+    ws.send(badBody)
+
+    await vi.waitFor(() =>
+      expect(
+        codesOf(errors).filter((c) => c === 'ACTOR_SYNC_FRAME_UNDECODABLE'),
+      ).toHaveLength(2),
+    )
+    // Both report the actor and keep the decoder's own error as the cause.
+    for (const err of errors) {
+      expect(err.message).toContain(DID)
+      expect(err.cause).toBeDefined()
+    }
+    // Undecodable frames are not retryable, so the stream stays up and keeps
+    // consuming rather than wedging the actor.
+    expect(ws.readyState).toBe(WS_OPEN)
+    ws.send(commitFrame(4))
+    await vi.waitFor(async () => {
+      expect(await store.getCursor(DID)).toBe(4)
+    })
+    syncer.stop()
+  })
+
+  it('reports the store error as the cause of the apply failure', async () => {
+    const errors: Error[] = []
+    const diskFull = new Error('SQLITE_FULL: database or disk is full')
+    const failing = {
+      applyCommit: async (): Promise<void> => {
+        throw diskFull
+      },
+    } as unknown as SubscriptionIndexer
+    const syncer = new ActorSyncer(
+      {
+        did: DID,
+        stratosServiceUrl: 'http://stratos.test',
+        mintToken: async () => 'tok',
+        baseDelayMs: 60_000,
+        maxDelayMs: 60_000,
+        jitterRatio: 0,
+      },
+      {
+        store,
+        indexer: failing,
+        wsCtor: FakeWebSocket as never,
+        rng: () => 0,
+        onError: (err) => errors.push(err),
+      },
+    )
+    syncer.start()
+    await vi.waitFor(() => expect(FakeWebSocket.instances).toHaveLength(1))
+    FakeWebSocket.instances[0].open()
+    FakeWebSocket.instances[0].send(commitFrame(11))
+
+    await vi.waitFor(() =>
+      expect(codesOf(errors)).toContain('ACTOR_SYNC_APPLY_FAILED'),
+    )
+    const reported = errors.find(
+      (err) => (err as StratosError).code === 'ACTOR_SYNC_APPLY_FAILED',
+    )
+    // An operator triaging a stalled actor needs both the sequence and the
+    // original store error, so neither may be dropped.
+    expect(reported?.message).toContain('seq 11')
+    expect(reported?.message).toContain(DID)
+    expect(reported?.cause).toBe(diskFull)
+    syncer.stop()
+  })
+
+  it('survives an apply failure with no onError sink wired', async () => {
+    const syncer = new ActorSyncer(
+      {
+        did: DID,
+        stratosServiceUrl: 'http://stratos.test',
+        mintToken: async () => 'tok',
+        baseDelayMs: 60_000,
+        maxDelayMs: 60_000,
+        jitterRatio: 0,
+      },
+      // onError deliberately omitted — reporting is optional, durability is not.
+      { store, indexer, wsCtor: FakeWebSocket as never, rng: () => 0 },
+    )
+    syncer.start()
+    await vi.waitFor(() => expect(FakeWebSocket.instances).toHaveLength(1))
+    const ws = FakeWebSocket.instances[0]
+    ws.open()
+    ws.send(new Uint8Array([0xff, 0xff, 0xff, 0xff]))
+    await vi.advanceTimersByTimeAsync(50)
+
+    expect(ws.readyState).toBe(WS_OPEN)
+    ws.send(commitFrame(3))
+    await vi.waitFor(async () => {
+      expect(await store.getCursor(DID)).toBe(3)
+    })
+    syncer.stop()
+  })
+
+  it('overflows at exactly maxQueueSize and drops the connection', async () => {
+    const errors: Error[] = []
+    const gate: { release: (() => void) | null } = { release: null }
+    const blocking = {
+      applyCommit: async (): Promise<void> => {
+        await new Promise<void>((resolve) => (gate.release = resolve))
+      },
+    } as unknown as SubscriptionIndexer
+    const syncer = new ActorSyncer(
+      {
+        did: DID,
+        stratosServiceUrl: 'http://stratos.test',
+        mintToken: async () => 'tok',
+        maxQueueSize: 3,
+        baseDelayMs: 60_000,
+        maxDelayMs: 60_000,
+        jitterRatio: 0,
+      },
+      {
+        store,
+        indexer: blocking,
+        wsCtor: FakeWebSocket as never,
+        rng: () => 0,
+        onError: (err) => errors.push(err),
+      },
+    )
+    syncer.start()
+    await vi.waitFor(() => expect(FakeWebSocket.instances).toHaveLength(1))
+    const ws = FakeWebSocket.instances[0]
+    ws.open()
+
+    // First frame occupies the drain; the next three fill the queue exactly.
+    ws.send(commitFrame(1))
+    await vi.waitFor(() => expect(gate.release).not.toBeNull())
+    for (let i = 2; i <= 4; i++) ws.send(commitFrame(i))
+    expect(codesOf(errors)).not.toContain('ACTOR_SYNC_OVERFLOW')
+
+    ws.send(commitFrame(5))
+    expect(codesOf(errors)).toContain('ACTOR_SYNC_OVERFLOW')
+    expect(ws.readyState).toBe(WS_CLOSED)
+
+    gate.release?.()
+    syncer.stop()
+  })
+
+  it('re-applies the failed sequence after reconnect and lands the cursor on it', async () => {
+    const errors: Error[] = []
+    let failuresLeft = 1
+    const { calls, indexer: flaky } = wrapIndexer(indexer, () => {
+      if (failuresLeft > 0) {
+        failuresLeft--
+        return true
+      }
+      return false
+    })
+    const syncer = new ActorSyncer(
+      {
+        did: DID,
+        stratosServiceUrl: 'http://stratos.test',
+        mintToken: async () => 'tok',
+        baseDelayMs: 1_000,
+        maxDelayMs: 1_000,
+        jitterRatio: 0,
+      },
+      {
+        store,
+        indexer: flaky,
+        wsCtor: FakeWebSocket as never,
+        rng: () => 0,
+        onError: (err) => errors.push(err),
+      },
+    )
+    syncer.start()
+    await vi.waitFor(() => expect(FakeWebSocket.instances).toHaveLength(1))
+    FakeWebSocket.instances[0].open()
+    FakeWebSocket.instances[0].send(commitFrame(7))
+
+    await vi.waitFor(() =>
+      expect(codesOf(errors)).toContain('ACTOR_SYNC_APPLY_FAILED'),
+    )
+    expect(await store.getCursor(DID)).toBeNull()
+
+    await vi.advanceTimersByTimeAsync(1_500)
+    await vi.waitFor(() => expect(FakeWebSocket.instances).toHaveLength(2))
+    const second = FakeWebSocket.instances[1]
+    // The cursor never advanced, so the reconnect asks for the same ground.
+    expect(second.url).not.toContain('cursor=')
+    second.open()
+    second.send(commitFrame(7))
+
+    await vi.waitFor(async () => {
+      expect(await store.getCursor(DID)).toBe(7)
+    })
+    expect(calls).toEqual([7, 7])
+    syncer.stop()
+  })
+
+  it('alarms once and never advances past a deterministically failing commit', async () => {
+    const errors: Error[] = []
+    const { calls, indexer: failing } = wrapIndexer(indexer, (seq) => seq === 5)
+    const syncer = new ActorSyncer(
+      {
+        did: DID,
+        stratosServiceUrl: 'http://stratos.test',
+        mintToken: async () => 'tok',
+        baseDelayMs: 1_000,
+        maxDelayMs: 1_000,
+        jitterRatio: 0,
+        stabilityResetMs: 60_000,
+      },
+      {
+        store,
+        indexer: failing,
+        wsCtor: FakeWebSocket as never,
+        rng: () => 0,
+        onError: (err) => errors.push(err),
+      },
+    )
+    syncer.start()
+
+    const stallsAfter: number[] = []
+    for (let cycle = 0; cycle < 4; cycle++) {
+      await vi.waitFor(() =>
+        expect(FakeWebSocket.instances).toHaveLength(cycle + 1),
+      )
+      const ws = FakeWebSocket.instances[cycle]
+      ws.open()
+      ws.send(commitFrame(5))
+      await vi.waitFor(() => expect(calls).toHaveLength(cycle + 1))
+      stallsAfter.push(
+        codesOf(errors).filter((code) => code === 'ACTOR_SYNC_STALLED').length,
+      )
+      await vi.advanceTimersByTimeAsync(1_500)
+    }
+
+    expect(calls).toEqual([5, 5, 5, 5])
+    // Silent for the first two failures, one alarm on the third, silent after.
+    expect(stallsAfter).toEqual([0, 0, 1, 1])
+    // Never stepped over: no later sequence was ever attempted.
+    expect(await store.getCursor(DID)).toBeNull()
+    syncer.stop()
+  })
+
+  it('escalates reconnect backoff while a commit keeps failing', async () => {
+    const { indexer: failing } = wrapIndexer(indexer, (seq) => seq === 5)
+    const syncer = new ActorSyncer(
+      {
+        did: DID,
+        stratosServiceUrl: 'http://stratos.test',
+        mintToken: async () => 'tok',
+        baseDelayMs: 1_000,
+        maxDelayMs: 60_000,
+        jitterRatio: 0,
+        stabilityResetMs: 60_000,
+      },
+      { store, indexer: failing, wsCtor: FakeWebSocket as never, rng: () => 0 },
+    )
+    syncer.start()
+
+    // Each failure kills the connection well inside the stability window, so
+    // the attempt counter never resets and the delay must double.
+    let idx = 0
+    for (const expectedDelay of [1_000, 2_000, 4_000]) {
+      await vi.waitFor(() =>
+        expect(FakeWebSocket.instances).toHaveLength(idx + 1),
+      )
+      const ws = FakeWebSocket.instances[idx]
+      ws.open()
+      ws.send(commitFrame(5))
+      // The apply failure closes the socket in microtasks, which advancing
+      // flushes; the reconnect timer itself is still short of firing.
+      await vi.advanceTimersByTimeAsync(expectedDelay - 1)
+      expect(ws.readyState).toBe(WS_CLOSED)
+      expect(FakeWebSocket.instances).toHaveLength(idx + 1)
+      await vi.advanceTimersByTimeAsync(1)
+      idx++
+    }
+    await vi.waitFor(() => expect(FakeWebSocket.instances).toHaveLength(4))
+
+    syncer.stop()
+  })
+
+  it('resets the failure counter after a successful apply', async () => {
+    const errors: Error[] = []
+    let failuresAtNine = 0
+    const { calls, indexer: flaky } = wrapIndexer(indexer, (seq) => {
+      if (seq === 9) {
+        failuresAtNine++
+        return failuresAtNine <= 2
+      }
+      return seq === 10
+    })
+    const syncer = new ActorSyncer(
+      {
+        did: DID,
+        stratosServiceUrl: 'http://stratos.test',
+        mintToken: async () => 'tok',
+        baseDelayMs: 1_000,
+        maxDelayMs: 1_000,
+        jitterRatio: 0,
+        stabilityResetMs: 60_000,
+      },
+      {
+        store,
+        indexer: flaky,
+        wsCtor: FakeWebSocket as never,
+        rng: () => 0,
+        onError: (err) => errors.push(err),
+      },
+    )
+    syncer.start()
+
+    // Two failures at seq 9 — one short of the alarm.
+    for (let cycle = 0; cycle < 2; cycle++) {
+      await vi.waitFor(() =>
+        expect(FakeWebSocket.instances).toHaveLength(cycle + 1),
+      )
+      FakeWebSocket.instances[cycle].open()
+      FakeWebSocket.instances[cycle].send(commitFrame(9))
+      await vi.waitFor(() => expect(calls).toHaveLength(cycle + 1))
+      await vi.advanceTimersByTimeAsync(1_500)
+    }
+
+    // Third attempt succeeds, which must clear the counter.
+    await vi.waitFor(() => expect(FakeWebSocket.instances).toHaveLength(3))
+    FakeWebSocket.instances[2].open()
+    FakeWebSocket.instances[2].send(commitFrame(9))
+    await vi.waitFor(async () => {
+      expect(await store.getCursor(DID)).toBe(9)
+    })
+
+    // A fresh failure at seq 10 is failure #1, not #3 — no alarm.
+    FakeWebSocket.instances[2].send(commitFrame(10))
+    await vi.waitFor(() => expect(calls).toEqual([9, 9, 9, 10]))
+    expect(codesOf(errors)).not.toContain('ACTOR_SYNC_STALLED')
+    syncer.stop()
+  })
+
+  it('ignores frames from a socket that was already dropped', async () => {
+    const { calls, indexer: failing } = wrapIndexer(indexer, (seq) => seq === 1)
+    const syncer = new ActorSyncer(
+      {
+        did: DID,
+        stratosServiceUrl: 'http://stratos.test',
+        mintToken: async () => 'tok',
+        baseDelayMs: 60_000,
+        maxDelayMs: 60_000,
+        jitterRatio: 0,
+      },
+      { store, indexer: failing, wsCtor: FakeWebSocket as never, rng: () => 0 },
+    )
+    syncer.start()
+    await vi.waitFor(() => expect(FakeWebSocket.instances).toHaveLength(1))
+    const ws = FakeWebSocket.instances[0]
+    ws.open()
+    ws.send(commitFrame(1))
+    await vi.waitFor(() => expect(calls).toEqual([1]))
+
+    // A late delivery from the abandoned socket must not refill the queue that
+    // failConnection just cleared.
+    ws.send(commitFrame(2))
+    await vi.advanceTimersByTimeAsync(50)
+    expect(calls).toEqual([1])
+    expect(await store.getCursor(DID)).toBeNull()
     syncer.stop()
   })
 })

--- a/stratos-feedgen/tests/actor-syncer.test.ts
+++ b/stratos-feedgen/tests/actor-syncer.test.ts
@@ -123,6 +123,16 @@ function commitFrame(seq: number): Uint8Array {
   })
 }
 
+/** A `#commit` frame whose body is whatever the caller supplies, valid or not. */
+function rawCommitFrame(body: unknown): Uint8Array {
+  const header = cborEncode({ op: 1, t: '#commit' })
+  const bodyBuf = cborEncode(body as never)
+  const out = new Uint8Array(header.length + bodyBuf.length)
+  out.set(header, 0)
+  out.set(bodyBuf, header.length)
+  return out
+}
+
 function codesOf(errors: Error[]): string[] {
   return errors.map((err) => (err as StratosError).code)
 }
@@ -540,6 +550,76 @@ describe('ActorSyncer', () => {
     syncer.stop()
   })
 
+  it('treats a decodable but malformed commit body as an undecodable frame', async () => {
+    const errors: Error[] = []
+    const applied: number[] = []
+    const recording = {
+      applyCommit: async (args: IndexCommitArgs): Promise<void> => {
+        applied.push(args.seq)
+        await indexer.applyCommit(args)
+      },
+    } as unknown as SubscriptionIndexer
+    const syncer = new ActorSyncer(
+      {
+        did: DID,
+        stratosServiceUrl: 'http://stratos.test',
+        mintToken: async () => 'tok',
+        baseDelayMs: 60_000,
+        maxDelayMs: 60_000,
+        jitterRatio: 0,
+      },
+      {
+        store,
+        indexer: recording,
+        wsCtor: FakeWebSocket as never,
+        rng: () => 0,
+        onError: (err) => errors.push(err),
+      },
+    )
+    syncer.start()
+    await vi.waitFor(() => expect(FakeWebSocket.instances).toHaveLength(1))
+    const ws = FakeWebSocket.instances[0]
+    ws.open()
+
+    const time = '2024-02-01T00:00:00.000Z'
+    // `ops` is not iterable. Handing this to applyCommit would throw and be
+    // misread as a transient store fault, stalling the actor forever on a
+    // frame that can never succeed.
+    ws.send(rawCommitFrame({ seq: 1, time, ops: 'nope' }))
+    // `seq` is not a number, and applyCommit writes it straight to the cursor.
+    ws.send(rawCommitFrame({ seq: 'nope', time, ops: [] }))
+    // `time` is absent, and applyCommit stores it as `indexedAt`.
+    ws.send(rawCommitFrame({ seq: 2, ops: [] }))
+    // Not a map. `null` and a bare scalar are distinct hazards: indexing into
+    // `null` throws, and that throw would escape drain() as an unhandled
+    // rejection instead of being reported.
+    ws.send(rawCommitFrame(['not', 'a', 'commit']))
+    ws.send(rawCommitFrame(null))
+    ws.send(rawCommitFrame(42))
+
+    await vi.waitFor(() =>
+      expect(
+        codesOf(errors).filter((c) => c === 'ACTOR_SYNC_FRAME_UNDECODABLE'),
+      ).toHaveLength(6),
+    )
+    for (const err of errors) {
+      expect(err.message).toContain(DID)
+      expect(err.message).toContain('malformed commit body')
+    }
+    // None of them reached the apply path, so no garbage cursor landed.
+    expect(applied).toEqual([])
+    expect(await store.getCursor(DID)).toBeNull()
+    // Deterministic frame faults follow the decode policy: report and continue.
+    expect(ws.readyState).toBe(WS_OPEN)
+    expect(FakeWebSocket.instances).toHaveLength(1)
+
+    ws.send(commitFrame(7))
+    await vi.waitFor(async () => {
+      expect(await store.getCursor(DID)).toBe(7)
+    })
+    syncer.stop()
+  })
+
   it('reports the store error as the cause of the apply failure', async () => {
     const errors: Error[] = []
     const diskFull = new Error('SQLITE_FULL: database or disk is full')
@@ -601,9 +681,11 @@ describe('ActorSyncer', () => {
     await vi.waitFor(() => expect(FakeWebSocket.instances).toHaveLength(1))
     const ws = FakeWebSocket.instances[0]
     ws.open()
-    // Garbage header, then a valid header with a garbage body: both decode
-    // catches must tolerate the absent sink.
+    // Garbage header, a valid header with a garbage body, then a body that
+    // decodes but is malformed: all three reject paths must tolerate the
+    // absent sink.
     ws.send(new Uint8Array([0xff, 0xff, 0xff, 0xff]))
+    ws.send(rawCommitFrame({ seq: 1, time: '2024-02-01T00:00:00.000Z' }))
     const header = cborEncode({ op: 1, t: '#commit' })
     const badBody = new Uint8Array(header.length + 3)
     badBody.set(header, 0)

--- a/stratos-feedgen/tests/service-stream.test.ts
+++ b/stratos-feedgen/tests/service-stream.test.ts
@@ -746,6 +746,53 @@ describe('ServiceStream', () => {
     stream.stop()
   })
 
+  it('overflows at the configured maxQueueSize', async () => {
+    const mint = makeMintToken()
+    const errors: Error[] = []
+    const gate = makeGate()
+    const stream = new ServiceStream(
+      {
+        stratosServiceUrl: 'http://stratos.test',
+        mintToken: mint.fn,
+        maxQueueSize: 2,
+      },
+      {
+        onEnroll: async () => {
+          await gate.wait()
+        },
+        onUnenroll: () => {},
+      },
+      (err) => {
+        errors.push(err)
+      },
+      { wsCtor: FakeWebSocket as never, rng: () => 0.5 },
+    )
+
+    stream.start()
+    await vi.waitFor(() => expect(FakeWebSocket.instances).toHaveLength(1))
+    const ws = FakeWebSocket.instances[0]
+    ws.open()
+
+    const frame = encodeEnrollmentFrame({
+      did: 'did:plc:vash',
+      action: 'enroll',
+    })
+    // First frame occupies the drain; the next two fill the configured cap.
+    ws.send(frame)
+    await vi.waitFor(() => expect(gate.release).not.toBeNull())
+    ws.send(frame)
+    ws.send(frame)
+    expect(codesOf(errors)).not.toContain('SERVICE_STREAM_OVERFLOW')
+
+    // One past the configured cap, far below the 1000-frame default.
+    ws.send(frame)
+    expect(codesOf(errors)).toContain('SERVICE_STREAM_OVERFLOW')
+    expect(ws.readyState).toBe(WS_CLOSED)
+
+    gate.release?.()
+    stream.stop()
+  })
+
   it('ignores frames from a socket that was already dropped', async () => {
     const mint = makeMintToken()
     const enrolls: string[] = []

--- a/stratos-feedgen/tests/service-stream.test.ts
+++ b/stratos-feedgen/tests/service-stream.test.ts
@@ -619,6 +619,42 @@ describe('ServiceStream', () => {
     stream.stop()
   })
 
+  it('keeps draining across separate deliveries', async () => {
+    const mint = makeMintToken()
+    const enrolls: string[] = []
+    const stream = new ServiceStream(
+      { stratosServiceUrl: 'http://stratos.test', mintToken: mint.fn },
+      {
+        onEnroll: (did) => {
+          enrolls.push(did)
+        },
+        onUnenroll: () => {},
+      },
+      undefined,
+      { wsCtor: FakeWebSocket as never, rng: () => 0.5 },
+    )
+
+    stream.start()
+    await vi.waitFor(() => expect(FakeWebSocket.instances).toHaveLength(1))
+    const ws = FakeWebSocket.instances[0]
+    ws.open()
+
+    // A drain that finishes must release its claim, or every frame after the
+    // first batch queues forever and the stream goes quiet without erroring.
+    ws.send(encodeEnrollmentFrame({ did: 'did:plc:trigun', action: 'enroll' }))
+    await vi.waitFor(() => expect(enrolls).toEqual(['did:plc:trigun']))
+    // Let the first drain fully settle, so the second frame arrives with no
+    // drain in flight and has to start one of its own.
+    await vi.advanceTimersByTimeAsync(10)
+    ws.send(
+      encodeEnrollmentFrame({ did: 'did:plc:wolfwood', action: 'enroll' }),
+    )
+    await vi.waitFor(() =>
+      expect(enrolls).toEqual(['did:plc:trigun', 'did:plc:wolfwood']),
+    )
+    stream.stop()
+  })
+
   it('keeps an unenroll behind the enroll it follows', async () => {
     const mint = makeMintToken()
     const order: string[] = []
@@ -700,7 +736,9 @@ describe('ServiceStream', () => {
     await vi.advanceTimersByTimeAsync(100)
     expect(codesOf(errors)).toEqual(['SERVICE_STREAM_OVERFLOW'])
 
-    // Reconnect replays every enrollment from scratch, so the drop is lossless.
+    // Reconnect replays every CURRENT enrollment from scratch, which restores
+    // dropped enrolls and boundary sets. A dropped `unenroll` is not restored —
+    // the actor is simply absent from the replay — and waits for reconcile.
     await vi.advanceTimersByTimeAsync(6_000)
     await vi.waitFor(() =>
       expect(FakeWebSocket.instances.length).toBeGreaterThan(1),

--- a/stratos-feedgen/tests/service-stream.test.ts
+++ b/stratos-feedgen/tests/service-stream.test.ts
@@ -1,4 +1,5 @@
 import { encode as cborEncode } from '@atcute/cbor'
+import { StratosError } from '@northskysocial/stratos-core'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ServiceStream } from '../src/subscription/service-stream.js'
 
@@ -77,6 +78,25 @@ function encodeEnrollmentFrame(body: {
   out.set(header, 0)
   out.set(bodyBuf, header.length)
   return out
+}
+
+function codesOf(errors: Error[]): string[] {
+  return errors.map((err) => (err as StratosError).code)
+}
+
+/**
+ * A promise the test can hold open, used to keep one handler in flight while
+ * further frames are delivered.
+ */
+function makeGate(): {
+  release: (() => void) | null
+  wait: () => Promise<void>
+} {
+  const gate: { release: (() => void) | null; wait: () => Promise<void> } = {
+    release: null,
+    wait: () => new Promise<void>((resolve) => (gate.release = resolve)),
+  }
+  return gate
 }
 
 function makeMintToken(): { fn: () => Promise<string>; calls: number } {
@@ -560,6 +580,168 @@ describe('ServiceStream', () => {
     await vi.advanceTimersByTimeAsync(1000)
     expect(FakeWebSocket.instances).toHaveLength(2)
 
+    stream.stop()
+  })
+
+  it('processes frames in delivery order when a handler is slow', async () => {
+    const mint = makeMintToken()
+    const order: string[] = []
+    const gate = makeGate()
+    const stream = new ServiceStream(
+      { stratosServiceUrl: 'http://stratos.test', mintToken: mint.fn },
+      {
+        onEnroll: async (did) => {
+          if (did === 'did:plc:kenshin') await gate.wait()
+          order.push(did)
+        },
+        onUnenroll: () => {},
+      },
+      undefined,
+      { wsCtor: FakeWebSocket as never, rng: () => 0.5 },
+    )
+
+    stream.start()
+    await vi.waitFor(() => expect(FakeWebSocket.instances).toHaveLength(1))
+    const ws = FakeWebSocket.instances[0]
+    ws.open()
+
+    ws.send(encodeEnrollmentFrame({ did: 'did:plc:kenshin', action: 'enroll' }))
+    ws.send(encodeEnrollmentFrame({ did: 'did:plc:kaoru', action: 'enroll' }))
+
+    await vi.waitFor(() => expect(gate.release).not.toBeNull())
+    // The second frame must still be queued, not racing the first.
+    expect(order).toEqual([])
+
+    gate.release?.()
+    await vi.waitFor(() =>
+      expect(order).toEqual(['did:plc:kenshin', 'did:plc:kaoru']),
+    )
+    stream.stop()
+  })
+
+  it('keeps an unenroll behind the enroll it follows', async () => {
+    const mint = makeMintToken()
+    const order: string[] = []
+    const gate = makeGate()
+    const stream = new ServiceStream(
+      { stratosServiceUrl: 'http://stratos.test', mintToken: mint.fn },
+      {
+        onEnroll: async (did) => {
+          await gate.wait()
+          order.push(`enroll:${did}`)
+        },
+        onUnenroll: (did) => {
+          order.push(`unenroll:${did}`)
+        },
+      },
+      undefined,
+      { wsCtor: FakeWebSocket as never, rng: () => 0.5 },
+    )
+
+    stream.start()
+    await vi.waitFor(() => expect(FakeWebSocket.instances).toHaveLength(1))
+    const ws = FakeWebSocket.instances[0]
+    ws.open()
+
+    ws.send(encodeEnrollmentFrame({ did: 'did:plc:lina', action: 'enroll' }))
+    ws.send(encodeEnrollmentFrame({ did: 'did:plc:lina', action: 'unenroll' }))
+
+    await vi.waitFor(() => expect(gate.release).not.toBeNull())
+    gate.release?.()
+    // Unserialized dispatch would let the synchronous unenroll land first and
+    // leave the actor enrolled.
+    await vi.waitFor(() =>
+      expect(order).toEqual(['enroll:did:plc:lina', 'unenroll:did:plc:lina']),
+    )
+    stream.stop()
+  })
+
+  it('drops the connection when the enrollment queue overflows', async () => {
+    const mint = makeMintToken()
+    const errors: Error[] = []
+    const gate = makeGate()
+    const stream = new ServiceStream(
+      { stratosServiceUrl: 'http://stratos.test', mintToken: mint.fn },
+      {
+        onEnroll: async () => {
+          await gate.wait()
+        },
+        onUnenroll: () => {},
+      },
+      (err) => {
+        errors.push(err)
+      },
+      { wsCtor: FakeWebSocket as never, rng: () => 0.5 },
+    )
+
+    stream.start()
+    await vi.waitFor(() => expect(FakeWebSocket.instances).toHaveLength(1))
+    const ws = FakeWebSocket.instances[0]
+    ws.open()
+
+    const frame = encodeEnrollmentFrame({
+      did: 'did:plc:vash',
+      action: 'enroll',
+    })
+    // First frame occupies the drain; the next 1000 fill the queue exactly.
+    ws.send(frame)
+    await vi.waitFor(() => expect(gate.release).not.toBeNull())
+    for (let i = 0; i < 1_000; i++) ws.send(frame)
+    expect(codesOf(errors)).not.toContain('SERVICE_STREAM_OVERFLOW')
+
+    // One past the cap.
+    ws.send(frame)
+    expect(codesOf(errors)).toContain('SERVICE_STREAM_OVERFLOW')
+    expect(ws.readyState).toBe(WS_CLOSED)
+
+    gate.release?.()
+    // The queue is emptied on overflow, so nothing is drained afterwards and
+    // the overflow is the only thing reported.
+    await vi.advanceTimersByTimeAsync(100)
+    expect(codesOf(errors)).toEqual(['SERVICE_STREAM_OVERFLOW'])
+
+    // Reconnect replays every enrollment from scratch, so the drop is lossless.
+    await vi.advanceTimersByTimeAsync(6_000)
+    await vi.waitFor(() =>
+      expect(FakeWebSocket.instances.length).toBeGreaterThan(1),
+    )
+    stream.stop()
+  })
+
+  it('ignores frames from a socket that was already dropped', async () => {
+    const mint = makeMintToken()
+    const enrolls: string[] = []
+    const stream = new ServiceStream(
+      {
+        stratosServiceUrl: 'http://stratos.test',
+        mintToken: mint.fn,
+        baseDelayMs: 60_000,
+        maxDelayMs: 60_000,
+        jitterRatio: 0,
+      },
+      {
+        onEnroll: (did) => {
+          enrolls.push(did)
+        },
+        onUnenroll: () => {},
+      },
+      undefined,
+      { wsCtor: FakeWebSocket as never, rng: () => 0.5 },
+    )
+
+    stream.start()
+    await vi.waitFor(() => expect(FakeWebSocket.instances).toHaveLength(1))
+    const ws = FakeWebSocket.instances[0]
+    ws.open()
+    ws.send(encodeEnrollmentFrame({ did: 'did:plc:milly', action: 'enroll' }))
+    await vi.waitFor(() => expect(enrolls).toEqual(['did:plc:milly']))
+
+    ws.close()
+    // A late delivery from the abandoned socket belongs to a connection whose
+    // state has already been torn down.
+    ws.send(encodeEnrollmentFrame({ did: 'did:plc:meryl', action: 'enroll' }))
+    await vi.advanceTimersByTimeAsync(100)
+    expect(enrolls).toEqual(['did:plc:milly'])
     stream.stop()
   })
 })

--- a/stratos-feedgen/tests/service-stream.test.ts
+++ b/stratos-feedgen/tests/service-stream.test.ts
@@ -793,6 +793,67 @@ describe('ServiceStream', () => {
     stream.stop()
   })
 
+  it('ignores a close event that arrives after the socket was detached', async () => {
+    const mint = makeMintToken()
+    const enrolls: string[] = []
+    const gate = makeGate()
+    let gated = true
+    const stream = new ServiceStream(
+      {
+        stratosServiceUrl: 'http://stratos.test',
+        mintToken: mint.fn,
+        baseDelayMs: 1_000,
+        maxDelayMs: 1_000,
+        jitterRatio: 0,
+        maxQueueSize: 1,
+      },
+      {
+        onEnroll: async (did) => {
+          enrolls.push(did)
+          if (gated) {
+            gated = false
+            await gate.wait()
+          }
+        },
+        onUnenroll: () => {},
+      },
+      () => {},
+      { wsCtor: FakeWebSocket as never, rng: () => 0 },
+    )
+
+    stream.start()
+    await vi.waitFor(() => expect(FakeWebSocket.instances).toHaveLength(1))
+    const first = FakeWebSocket.instances[0]
+    first.open()
+
+    const frameFor = (did: string): Uint8Array =>
+      encodeEnrollmentFrame({ did, action: 'enroll' })
+    first.send(frameFor('did:plc:vash'))
+    await vi.waitFor(() => expect(gate.release).not.toBeNull())
+    first.send(frameFor('did:plc:wolfwood'))
+    // Overflow abandons this socket and schedules the reconnect.
+    first.send(frameFor('did:plc:meryl'))
+    gate.release?.()
+
+    await vi.advanceTimersByTimeAsync(1_500)
+    await vi.waitFor(() => expect(FakeWebSocket.instances).toHaveLength(2))
+    const second = FakeWebSocket.instances[1]
+    second.open()
+
+    // `close()` only starts the handshake, so the abandoned socket's close can
+    // land here — after its replacement is already live.
+    first.onclose?.()
+
+    // Ownership stayed with the live socket, so no second reconnect fires...
+    await vi.advanceTimersByTimeAsync(5_000)
+    expect(FakeWebSocket.instances).toHaveLength(2)
+    // ...and its frames are still dispatched, rather than being discarded by
+    // the superseded-socket guard against a `ws` the stale close had nulled.
+    second.send(frameFor('did:plc:milly'))
+    await vi.waitFor(() => expect(enrolls).toContain('did:plc:milly'))
+    stream.stop()
+  })
+
   it('ignores frames from a socket that was already dropped', async () => {
     const mint = makeMintToken()
     const enrolls: string[] = []


### PR DESCRIPTION
Executes `plans/008-feedgen-sync-durability.md` (rev 2).

## The bug

`ActorSyncer.handleFrame` reported an `applyCommit` failure to `onError` and let the frame loop continue. The next successful commit then wrote a cursor **past** the failed sequence, so those ops were never retried and never indexed.

That hole is permanent and invisible:

- `getFeed` serves entirely from the local index (`api/feed/getFeed.ts` → `listPostsByBoundary`, returning `record` verbatim). There is no read-time hydration fallback.
- The feedgen has no backfill, no `getRepo`, no repo resync. `reconcileEnrollments` only purges on boundary shrink — it never restores missing posts.

So a commit that failed to land was a post no viewer ever saw again, with nothing to heal it and nothing to signal it.

## The fix

**Clearing the queue is the fix; closing the socket is not.** `onclose` does not clear `this.queue` (only `stop()` does), so closing alone leaves the buffered successors to drain and advance the cursor anyway. `failConnection()` now empties the queue before closing, and the reconnect replays from the durable cursor.

**The failed sequence is retried indefinitely — never stepped over.** A bounded "poison skip" was considered and rejected: `applyCommit` can barely throw on a bad *record* (it skips non-post paths, missing `cid`/`record`, and wrong `$type` without throwing), so in practice every throw is store or disk failure. A 3-strike auto-skip would therefore never fire on one bad record — it would fire during a sustained SQLite outage and skip a whole run of commits, reproducing the original hole at the worst possible moment. `ActorPool` isolates per actor, so a wedged syncer costs one actor's freshness, and a stall is observable where a hole is not.

Three consecutive failures at the same sequence raise one `ACTOR_SYNC_STALLED` alarm. Backoff escalation is emergent and verified: the replayed frame fails within milliseconds of `open`, well inside the 30 s stability window, so `reconnectAttempt` never resets and the delay climbs to the 60 s ceiling on its own.

Also in scope:

- **Superseded-socket guard** — the old socket's `onmessage` would otherwise refill the queue that was just cleared.
- **Decode paths coded** — the two silent `return`s in `handleFrame` now carry `ACTOR_SYNC_FRAME_UNDECODABLE`. They stay non-retrying (deterministic; retrying would wedge the actor with no recovery) but are no longer invisible.
- **Enrollment stream serialized** — `void this.handleMessage(buf)` became queue+drain, so an `unenroll` can no longer overtake the `enroll` it followed. Its overflow drop is safe because that stream has no cursor and reconnect replays the full enrollment list.

## Preconditions verified

Retry-forever is only safe because all of these hold, each checked against the tree:

1. Reconnect resumes from the durable cursor (`actor-syncer.ts:181` → upstream `subscribe-records.ts:144` `getEventsSince`).
2. `applyCommit` is idempotent under replay (upsert + idempotent delete, cursor last).
3. `stratos_seq` is never pruned anywhere in the repo — so replay from any cursor, including 0, always succeeds. That also makes "clear the actor's cursor and resync from 0" a complete operator remedy for a stalled actor.

## Test plan

- [x] `pnpm --filter stratos-feedgen test` — 164 pass
- [x] `pnpm test` (monorepo) — 1561 pass, 0 fail
- [x] `pnpm run build && pnpm run lint && pnpm prettier --check .` — all exit 0
- [x] `pnpm --filter stratos-feedgen mutation` — 62.56 (threshold 60), up from 60.00; `subscription` module 60.23 → 67.75, `actor-syncer.ts` 56.02 → 67.02. Run with the incremental cache cleared: this config sets `incremental: true`, and cached verdicts had been masking one live survivor

**The regression test was verified to actually fail without the fix.** Temporarily removing `this.queue = []` makes `applyCommit` receive `[1, 2, 3]` instead of `[1]` — the buffered successors drain straight through and carry the cursor past the failure. A test asserting only "seq N is re-applied after reconnect" would have passed against the broken code.

New cases: buffered-successor suppression, transient heal with cursor landing on N, alarm fires exactly once on the third same-seq failure, failures at *different* sequences do not accumulate, backoff escalation while stalled, counter reset after success, stale-socket frames ignored, undecodable frames reported without dropping the connection, overflow at exactly `maxQueueSize`, cause-chain and sequence preserved in the reported error, no-`onError` safety; plus enrollment ordering, the enroll→unenroll hazard, and service-stream overflow.

## Known gaps — follow-ups, not this PR

1. **Revocation durability across reconnects.** The service stream has no cursor; reconnect replays every *current* enrollment. That restores a dropped `enroll`, and restores a dropped `boundaries` change (the replayed enroll carries current boundaries and `main.ts:216` routes `onEnroll` through the same `applyBoundarySet` that diffs and purges). It does **not** restore a dropped `unenroll` — the actor is simply absent from the replay, so nothing fires `purgeActor`. `reconcileEnrollments` is the only repair and `main.ts:151` runs it at startup only, with no interval. A revoked actor therefore keeps syncing and having its posts served until the process restarts, which is rare in practice. Pre-existing for any disconnect, not introduced here, but it needs fixing — likely reconcile-on-reconnect or a periodic reconcile.
2. **Gap recording for undecodable frames.** A frame whose body fails to decode is reported and skipped, and the next successful commit advances the cursor past it. The rationale for continuing rather than stalling is now documented in `handleFrame`. A dead-letter or skipped-sequence record would make the gap recoverable; that needs a new store table.
3. **No backfill / repo resync**, so holes created *before* this change do not self-heal. `reconcileEnrollments` only purges on boundary shrink — it never restores missing posts.
4. **`#info` / `OutdatedCursor` frames are still dropped** at `handleFrame`'s non-`#commit` filter. That warning is the failure signal for the very cursor-replay mechanism this PR depends on. Unreachable while nothing prunes `stratos_seq` — it becomes P1 the day seq retention is introduced.

## Review follow-ups applied

- **Malformed commit bodies are rejected before the apply.** The claim above — that `applyCommit` can only throw on store or disk failure — held for a bad *record* but not for a malformed *frame body*. The decoded body was cast straight to `CommitFrameBody` with nothing checking its shape, so a non-array `ops` threw inside the apply loop and was retried forever as a "transient store fault", wedging the actor permanently on a frame that can never succeed, and a non-numeric `seq` was written straight to the durable cursor. `isCommitFrameBody` now validates `seq`/`time`/`ops` first and routes failures down the decode path (`ACTOR_SYNC_FRAME_UNDECODABLE`), so the documented asymmetry actually holds: deterministic frame faults skip, only genuine store faults stall. Verified to fail without the guard.
- `ServiceStreamConfig` accepts `maxQueueSize` (the constant was named `DEFAULT_` but could not be overridden), and the close-clear-reconnect sequence is now a `failConnection()` helper mirroring `ActorSyncer`.
- `stop()` no longer clears `draining` in either `ServiceStream` or `ActorSyncer`. Clearing it while a handler was in flight let a later `start()` launch a second concurrent drain. `drain()` owns the flag; clearing the queue is sufficient.
- The decode-vs-apply asymmetry is documented in `handleFrame` rather than in an untracked plan file.
- Renamed a test that claimed to cover the apply path while exercising the decode path, and added the apply-failure-without-`onError` case it promised.

Remaining mutation survivors in the changed regions are equivalent mutants — the `!draining` / `draining` guard pair is redundant by construction, so mutating either alone leaves the other enforcing the invariant — plus `onError?.` optional-sink defensiveness that only matters for a consumer omitting the sink, which the production wiring never does.

🤖 Generated with Rommie Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enrollment events are processed sequentially to preserve ordering.
  * Failed synchronization attempts retry automatically, with stall alerts after repeated failures.
  * Connections recover from failures using the last durable position.
  * Queue limits can be configured to control buffering.

* **Bug Fixes**
  * Improved handling of malformed frames, connection failures, and shutdowns.
  * Stale connection messages are ignored.
  * Improved error reporting with clearer failure context.

* **Tests**
  * Added coverage for retries, reconnection, ordering, queue overflow, error reporting, and stale messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
