### PR TITLE
fix(service): fail closed on domainless records in repo read path

### DIFF
--- a/stratos-service/src/api/records/read.ts
+++ b/stratos-service/src/api/records/read.ts
@@ -1,7 +1,8 @@
 import { InvalidRequestError } from '@atproto/xrpc-server'
 import { AtUri as AtUriSyntax } from '@atproto/syntax'
-import { StratosValidator } from '@northskysocial/stratos-core'
+import { canAccessRecord, StratosValidator } from '@northskysocial/stratos-core'
 import type { AppContext } from '../../context-types.js'
+import { logDomainlessInvariant } from '../../shared/domainless-invariant.js'
 import type { ListRecordsResult, RecordResult } from './types.js'
 
 export interface GetRecordInput {
@@ -52,17 +53,23 @@ export async function getRecord(
       throw new InvalidRequestError('Record not found', 'RecordNotFound')
     }
 
-    // Check domain boundary if caller is not the owner
-    if (callerDid !== repo) {
-      const boundary = StratosValidator.extractBoundaryDomains(record.value)
-      if (boundary.length > 0 && callerDomains) {
-        const allowed = boundary.some((domain) =>
-          callerDomains.includes(domain),
-        )
-        if (!allowed) {
-          throw new InvalidRequestError('Record not found', 'RecordNotFound')
-        }
-      }
+    const recordBoundaries = StratosValidator.extractBoundaryDomains(
+      record.value,
+    )
+    logDomainlessInvariant(ctx.logger, recordBoundaries, {
+      uri,
+      ownerDid: repo,
+    })
+    const hasAccess = canAccessRecord({
+      recordBoundaries,
+      ownerDid: repo,
+      context: {
+        viewerDid: callerDid ?? null,
+        viewerDomains: callerDomains ?? [],
+      },
+    })
+    if (!hasAccess) {
+      throw new InvalidRequestError('Record not found', 'RecordNotFound')
     }
 
     return {
@@ -106,14 +113,21 @@ export async function listRecords(
 
     const records = list
       .filter((record) => {
-        // Check domain boundary if caller is not the owner
-        if (callerDid !== repo) {
-          const boundary = StratosValidator.extractBoundaryDomains(record.value)
-          if (boundary.length > 0 && callerDomains) {
-            return boundary.some((domain) => callerDomains.includes(domain))
-          }
-        }
-        return true
+        const recordBoundaries = StratosValidator.extractBoundaryDomains(
+          record.value,
+        )
+        logDomainlessInvariant(ctx.logger, recordBoundaries, {
+          uri: record.uri.toString(),
+          ownerDid: repo,
+        })
+        return canAccessRecord({
+          recordBoundaries,
+          ownerDid: repo,
+          context: {
+            viewerDid: callerDid ?? null,
+            viewerDomains: callerDomains ?? [],
+          },
+        })
       })
       .map((record) => ({
         uri: record.uri.toString(),

--- a/stratos-service/src/api/records/read.ts
+++ b/stratos-service/src/api/records/read.ts
@@ -1,6 +1,10 @@
 import { InvalidRequestError } from '@atproto/xrpc-server'
 import { AtUri as AtUriSyntax } from '@atproto/syntax'
-import { canAccessRecord, StratosValidator } from '@northskysocial/stratos-core'
+import {
+  canAccessRecord,
+  isDomainlessRecord,
+  StratosValidator,
+} from '@northskysocial/stratos-core'
 import type { AppContext } from '../../context-types.js'
 import { logDomainlessInvariant } from '../../shared/domainless-invariant.js'
 import type { ListRecordsResult, RecordResult } from './types.js'
@@ -111,15 +115,15 @@ export async function listRecords(
       reverse,
     })
 
+    let domainlessCount = 0
     const records = list
       .filter((record) => {
         const recordBoundaries = StratosValidator.extractBoundaryDomains(
           record.value,
         )
-        logDomainlessInvariant(ctx.logger, recordBoundaries, {
-          uri: record.uri.toString(),
-          ownerDid: repo,
-        })
+        if (isDomainlessRecord(recordBoundaries)) {
+          domainlessCount += 1
+        }
         return canAccessRecord({
           recordBoundaries,
           ownerDid: repo,
@@ -134,6 +138,13 @@ export async function listRecords(
         cid: record.cid,
         value: record.value,
       }))
+
+    if (domainlessCount > 0) {
+      ctx.logger?.warn(
+        { ownerDid: repo, collection, domainlessCount },
+        'invariant violation: records have no domain; treating as fail-closed inaccessible',
+      )
+    }
 
     return {
       records,

--- a/stratos-service/tests/records-read.integration.test.ts
+++ b/stratos-service/tests/records-read.integration.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { mkdir, rm } from 'node:fs/promises'
 import { join } from 'path'
 import { tmpdir } from 'os'
@@ -322,6 +322,48 @@ describe('Record Read Handlers', () => {
       expect(uris).not.toContain(
         `at://${testDid}/app.bsky.feed.post/postNoBoundary`,
       )
+    })
+
+    it('should warn once with the domainless count for a non-owner', async () => {
+      await seedDomainlessRecord('postNoBoundary1')
+      await seedDomainlessRecord('postNoBoundary2')
+      const warn = vi.fn()
+
+      await listRecords(
+        { ...ctx, logger: { warn } },
+        {
+          repo: testDid,
+          collection: 'app.bsky.feed.post',
+        },
+        otherDid,
+        [boundary],
+      )
+
+      expect(warn).toHaveBeenCalledTimes(1)
+      expect(warn).toHaveBeenCalledWith(
+        {
+          ownerDid: testDid,
+          collection: 'app.bsky.feed.post',
+          domainlessCount: 2,
+        },
+        expect.stringContaining('no domain'),
+      )
+    })
+
+    it('should not warn when every record declares a domain', async () => {
+      const warn = vi.fn()
+
+      await listRecords(
+        { ...ctx, logger: { warn } },
+        {
+          repo: testDid,
+          collection: 'app.bsky.feed.post',
+        },
+        otherDid,
+        [boundary],
+      )
+
+      expect(warn).not.toHaveBeenCalled()
     })
 
     it('should include a domainless record for the owner', async () => {

--- a/stratos-service/tests/records-read.integration.test.ts
+++ b/stratos-service/tests/records-read.integration.test.ts
@@ -78,6 +78,23 @@ describe('Record Read Handlers', () => {
     })
   })
 
+  async function seedDomainlessRecord(rkey: string) {
+    await actorStore.transact(testDid, async (store) => {
+      const record = {
+        $type: 'app.bsky.feed.post',
+        text: 'No boundary declared',
+        createdAt: new Date().toISOString(),
+      }
+      const cid = await createTestCid(record)
+      await store.record.putRecord({
+        uri: `at://${testDid}/app.bsky.feed.post/${rkey}`,
+        cid,
+        value: record,
+        content: new TextEncoder().encode(JSON.stringify(record)),
+      })
+    })
+  }
+
   afterEach(async () => {
     await closeServiceDb(db)
     await rm(dataDir, { recursive: true, force: true })
@@ -163,6 +180,67 @@ describe('Record Read Handlers', () => {
       )
       expect(result.value).toBeDefined()
     })
+
+    it('should deny a domainless record to a non-owner', async () => {
+      await seedDomainlessRecord('postNoBoundary')
+
+      await expect(
+        getRecord(
+          ctx,
+          {
+            repo: testDid,
+            collection: 'app.bsky.feed.post',
+            rkey: 'postNoBoundary',
+          },
+          otherDid,
+          [],
+        ),
+      ).rejects.toThrow('Record not found')
+
+      await expect(
+        getRecord(
+          ctx,
+          {
+            repo: testDid,
+            collection: 'app.bsky.feed.post',
+            rkey: 'postNoBoundary',
+          },
+          otherDid,
+          [boundary],
+        ),
+      ).rejects.toThrow('Record not found')
+    })
+
+    it('should deny a domainless record to an unauthenticated caller', async () => {
+      await seedDomainlessRecord('postNoBoundary')
+
+      await expect(
+        getRecord(ctx, {
+          repo: testDid,
+          collection: 'app.bsky.feed.post',
+          rkey: 'postNoBoundary',
+        }),
+      ).rejects.toThrow('Record not found')
+    })
+
+    it('should still return a domainless record to its owner', async () => {
+      await seedDomainlessRecord('postNoBoundary')
+
+      const result = await getRecord(
+        ctx,
+        {
+          repo: testDid,
+          collection: 'app.bsky.feed.post',
+          rkey: 'postNoBoundary',
+        },
+        testDid,
+      )
+
+      expect(result.uri).toBe(
+        `at://${testDid}/app.bsky.feed.post/postNoBoundary`,
+      )
+      expect(result.value).toMatchObject({ text: 'No boundary declared' })
+    })
   })
 
   describe('listRecords', () => {
@@ -224,6 +302,45 @@ describe('Record Read Handlers', () => {
       expect(result.records).toHaveLength(1)
       expect(result.records[0].uri).toContain('post1')
       expect(result.records[0].uri).not.toContain('post2')
+    })
+
+    it('should omit a domainless record for a non-owner', async () => {
+      await seedDomainlessRecord('postNoBoundary')
+
+      const result = await listRecords(
+        ctx,
+        {
+          repo: testDid,
+          collection: 'app.bsky.feed.post',
+        },
+        otherDid,
+        [boundary],
+      )
+
+      const uris = result.records.map((record) => record.uri)
+      expect(uris).toContain(`at://${testDid}/app.bsky.feed.post/post1`)
+      expect(uris).not.toContain(
+        `at://${testDid}/app.bsky.feed.post/postNoBoundary`,
+      )
+    })
+
+    it('should include a domainless record for the owner', async () => {
+      await seedDomainlessRecord('postNoBoundary')
+
+      const result = await listRecords(
+        ctx,
+        {
+          repo: testDid,
+          collection: 'app.bsky.feed.post',
+        },
+        testDid,
+      )
+
+      const uris = result.records.map((record) => record.uri)
+      expect(uris).toContain(`at://${testDid}/app.bsky.feed.post/post1`)
+      expect(uris).toContain(
+        `at://${testDid}/app.bsky.feed.post/postNoBoundary`,
+      )
     })
   })
 })

--- a/stratos-service/tests/records-read.integration.test.ts
+++ b/stratos-service/tests/records-read.integration.test.ts
@@ -209,6 +209,18 @@ describe('Record Read Handlers', () => {
           [boundary],
         ),
       ).rejects.toThrow('Record not found')
+
+      await expect(
+        getRecord(
+          ctx,
+          {
+            repo: testDid,
+            collection: 'app.bsky.feed.post',
+            rkey: 'postNoBoundary',
+          },
+          otherDid,
+        ),
+      ).rejects.toThrow('Record not found')
     })
 
     it('should deny a domainless record to an unauthenticated caller', async () => {
@@ -320,6 +332,19 @@ describe('Record Read Handlers', () => {
       const uris = result.records.map((record) => record.uri)
       expect(uris).toContain(`at://${testDid}/app.bsky.feed.post/post1`)
       expect(uris).not.toContain(
+        `at://${testDid}/app.bsky.feed.post/postNoBoundary`,
+      )
+
+      const withoutDomains = await listRecords(
+        ctx,
+        {
+          repo: testDid,
+          collection: 'app.bsky.feed.post',
+        },
+        otherDid,
+      )
+
+      expect(withoutDomains.records.map((record) => record.uri)).not.toContain(
         `at://${testDid}/app.bsky.feed.post/postNoBoundary`,
       )
     })

--- a/stratos-service/tests/records-read.integration.test.ts
+++ b/stratos-service/tests/records-read.integration.test.ts
@@ -27,6 +27,10 @@ describe('Record Read Handlers', () => {
   const otherDid = 'did:plc:rei-ayanami'
   const serviceDid = 'did:web:nerv.tokyo.jp'
   const boundary = 'did:web:nerv.tokyo.jp/engineering'
+  const recordNotFound = {
+    message: 'Record not found',
+    customErrorName: 'RecordNotFound',
+  }
 
   async function createTestCid(data: any) {
     const bytes = new TextEncoder().encode(JSON.stringify(data))
@@ -195,7 +199,7 @@ describe('Record Read Handlers', () => {
           otherDid,
           [],
         ),
-      ).rejects.toThrow('Record not found')
+      ).rejects.toMatchObject(recordNotFound)
 
       await expect(
         getRecord(
@@ -208,7 +212,7 @@ describe('Record Read Handlers', () => {
           otherDid,
           [boundary],
         ),
-      ).rejects.toThrow('Record not found')
+      ).rejects.toMatchObject(recordNotFound)
 
       await expect(
         getRecord(
@@ -220,7 +224,7 @@ describe('Record Read Handlers', () => {
           },
           otherDid,
         ),
-      ).rejects.toThrow('Record not found')
+      ).rejects.toMatchObject(recordNotFound)
     })
 
     it('should deny a domainless record to an unauthenticated caller', async () => {
@@ -232,7 +236,7 @@ describe('Record Read Handlers', () => {
           collection: 'app.bsky.feed.post',
           rkey: 'postNoBoundary',
         }),
-      ).rejects.toThrow('Record not found')
+      ).rejects.toMatchObject(recordNotFound)
     })
 
     it('should still return a domainless record to its owner', async () => {


### PR DESCRIPTION
## Description

The repo read path treated a record with **no boundary domains** as world-readable. `getRecord` and `listRecords` returned such records to any caller, including unauthenticated ones. A domainless record is a data-integrity anomaly, not a public record, so the read path now fails closed.

Both handlers route the decision through the canonical `canAccessRecord` gate and log the invariant violation via `logDomainlessInvariant`, mirroring the exemplar already used by the hydration path. Denials surface as `RecordNotFound` rather than a distinguishable "forbidden", so the endpoint does not become an existence oracle.

Plan: `plans/020-read-path-fail-closed-boundary.md`

## Testing

- 5 new domainless regression cases in `stratos-service/tests/records-read.integration.test.ts`
- Full workspace suite green

## Review notes (opus review: 0 critical, 0 major, 4 minor, 3 nit)

Nothing blocking. Recorded for follow-up rather than fixed here:

- **minor** — `src/features/space-read/handler.ts:110-112` still carries a comment claiming the repo read path is fail-open. Stale as of this PR; out of scope per the plan's fence.
- **minor** — the new `logDomainlessInvariant` calls are themselves untested.
- **minor (pre-existing)** — `listRecords` derives its cursor from the pre-filter page, so an empty filtered result still leaks rkey existence. Predates this change.
- **nit** — the fix is slightly broader than the title suggests: it also closes a fail-open on boundaried records when `callerDomains` was `undefined`.

Plan Step 3 (add `read.ts` to the Stryker `mutate` list) was **obsolete on arrival** — the existing glob `src/api/records/**/*.ts` already covers it, so `stryker.config.json` is untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved access control for individual record reads and record listings.
  * Restricted records now return no results when accessed without permission and are excluded from collection listings.
  * Domainless records are consistently handled as inaccessible.
  * Added clearer safeguards and coverage for owner, non-owner, and unauthenticated access scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->