### PR TITLE
fix(service): unify admin membership check across verifier and whoami

### DIFF
--- a/stratos-service/src/index.ts
+++ b/stratos-service/src/index.ts
@@ -425,6 +425,7 @@ export class StratosServer {
     const adminRoutes = createAdminAuthRoutes({
       oauthClient: ctx.oauthClient,
       adminSessionStore: ctx.adminSessionStore,
+      adminUserStore: ctx.adminUserStore,
       adminDids: cfg.adminDids,
       baseUrl: cfg.service.publicUrl,
       devMode: cfg.stratos.devMode === true,

--- a/stratos-service/src/infra/auth/verifiers.ts
+++ b/stratos-service/src/infra/auth/verifiers.ts
@@ -21,7 +21,10 @@ import { ExternalAllowListProvider } from '../../features/enrollment/internal/al
 import { verifyEnrolled } from '../../features'
 import { readAdminSessionCookie } from '../../oauth/admin-routes.js'
 import type { AdminSessionStore } from '../../oauth/admin-session-store.js'
-import type { AdminUserStore } from '../../oauth/admin-user-store.js'
+import {
+  isEffectiveAdmin,
+  type AdminUserStore,
+} from '../../oauth/admin-user-store.js'
 
 /**
  * Auth verifier collection for different auth scenarios
@@ -597,10 +600,7 @@ function createAdminVerifier(deps: {
       throw new AuthRequiredError('Admin session invalid or expired')
     }
 
-    // Config admins are the recovery floor; granted admins live in the DB.
-    const authorized =
-      deps.adminDids.includes(session.did) ||
-      (await deps.adminUserStore.has(session.did))
+    const authorized = await isEffectiveAdmin(session.did, deps)
     if (!authorized) {
       deps.logger?.warn(
         { did: session.did },

--- a/stratos-service/src/oauth/admin-routes.ts
+++ b/stratos-service/src/oauth/admin-routes.ts
@@ -14,6 +14,17 @@ import { handleAdminCallback } from './handlers/admin-callback.js'
 export const ADMIN_SESSION_COOKIE = 'stratos_admin_session'
 
 /**
+ * The part of a request the admin session helpers read.
+ *
+ * Both `express.Request` and a raw `IncomingMessage` satisfy this, and it names
+ * the whole contract, so a caller needs no cast to supply one.
+ */
+export type RequestWithHeaders = Pick<
+  import('node:http').IncomingMessage,
+  'headers'
+>
+
+/**
  * Read the opaque admin session id straight from the request's `Cookie`
  * header.
  *
@@ -25,7 +36,7 @@ export const ADMIN_SESSION_COOKIE = 'stratos_admin_session'
  * routes here and the raw `IncomingMessage` admin auth verifier.
  */
 export function readAdminSessionCookie(
-  req: import('node:http').IncomingMessage,
+  req: RequestWithHeaders,
 ): string | undefined {
   const cookieHeader = req.headers?.cookie
   if (!cookieHeader) return undefined
@@ -63,7 +74,7 @@ export interface AdminAuthRoutesConfig {
  * no valid, unexpired session whose DID is still an effective admin.
  */
 export async function resolveAdminSession(
-  req: express.Request,
+  req: RequestWithHeaders,
   config: Pick<
     AdminAuthRoutesConfig,
     'adminSessionStore' | 'adminDids' | 'adminUserStore'

--- a/stratos-service/src/oauth/admin-routes.ts
+++ b/stratos-service/src/oauth/admin-routes.ts
@@ -2,6 +2,7 @@ import express from 'express'
 import type { NodeOAuthClient } from '@atproto/oauth-client-node'
 import type { Logger } from '@northskysocial/stratos-core'
 import type { AdminSessionStore } from './admin-session-store.js'
+import { isEffectiveAdmin, type AdminUserStore } from './admin-user-store.js'
 import { passesAdminCsrfCheck } from '../config.js'
 import { handleAdminAuthorize } from './handlers/admin-authorize.js'
 import { handleAdminCallback } from './handlers/admin-callback.js'
@@ -50,6 +51,7 @@ export const ADMIN_SESSION_TTL_MS = 12 * 60 * 60 * 1000
 export interface AdminAuthRoutesConfig {
   oauthClient: NodeOAuthClient
   adminSessionStore: AdminSessionStore
+  adminUserStore: AdminUserStore
   adminDids: string[]
   baseUrl: string
   devMode?: boolean
@@ -58,18 +60,21 @@ export interface AdminAuthRoutesConfig {
 
 /**
  * Resolve the admin DID from the request's session cookie, or null if there is
- * no valid, unexpired session whose DID is still on the allowlist.
+ * no valid, unexpired session whose DID is still an effective admin.
  */
 export async function resolveAdminSession(
   req: express.Request,
-  config: Pick<AdminAuthRoutesConfig, 'adminSessionStore' | 'adminDids'>,
+  config: Pick<
+    AdminAuthRoutesConfig,
+    'adminSessionStore' | 'adminDids' | 'adminUserStore'
+  >,
 ): Promise<string | null> {
   const sessionKey = readAdminSessionCookie(req)
   if (!sessionKey) return null
 
   const session = await config.adminSessionStore.get(sessionKey)
   if (!session) return null
-  if (!config.adminDids.includes(session.did)) return null
+  if (!(await isEffectiveAdmin(session.did, config))) return null
 
   return session.did
 }

--- a/stratos-service/src/oauth/admin-user-store.ts
+++ b/stratos-service/src/oauth/admin-user-store.ts
@@ -29,6 +29,19 @@ export interface AdminUserStore {
 }
 
 /**
+ * The effective admin set is the union of the config allowlist (recovery
+ * floor, un-revocable) and the runtime grants in the store. Both the
+ * request-time `.admin` verifier and the `/whoami` session resolver MUST
+ * decide membership through this predicate so the two can never drift.
+ */
+export async function isEffectiveAdmin(
+  did: string,
+  deps: { adminDids: string[]; adminUserStore: Pick<AdminUserStore, 'has'> },
+): Promise<boolean> {
+  return deps.adminDids.includes(did) || (await deps.adminUserStore.has(did))
+}
+
+/**
  * SQLite-backed admin user store.
  */
 export class SqliteAdminUserStore implements AdminUserStore {

--- a/stratos-service/src/oauth/handlers/admin-callback.ts
+++ b/stratos-service/src/oauth/handlers/admin-callback.ts
@@ -3,6 +3,28 @@ import type { AdminAuthRoutesConfig } from '../admin-routes.js'
 import { ADMIN_SESSION_COOKIE, ADMIN_SESSION_TTL_MS } from '../admin-routes.js'
 
 /**
+ * The part of a request this handler reads.
+ *
+ * `express.Request` satisfies it, and the contract is small enough for a caller
+ * to supply one without a cast.
+ */
+export type AdminCallbackRequest = Pick<express.Request, 'url'>
+
+/**
+ * The response methods this handler calls.
+ *
+ * `express.Response` satisfies this. Declaring the methods rather than picking
+ * them from `express.Response` keeps `status()` returning only what the handler
+ * chains onto, so a test double needs no cast either.
+ */
+export interface AdminCallbackResponse {
+  cookie(name: string, value: string, options: express.CookieOptions): unknown
+  redirect(url: string): unknown
+  status(code: number): { json(body: unknown): unknown }
+  json(body: unknown): unknown
+}
+
+/**
  * Completes the admin OAuth flow.
  *
  * Unlike the enrollment callback, this performs no repo init, signing-key
@@ -16,7 +38,7 @@ export const handleAdminCallback = (config: AdminAuthRoutesConfig) => {
   const isSecure = baseUrl.startsWith('https://')
   const adminRedirectUri = `${baseUrl}/admin/oauth/callback`
 
-  return async (req: express.Request, res: express.Response) => {
+  return async (req: AdminCallbackRequest, res: AdminCallbackResponse) => {
     try {
       const params = new URLSearchParams(req.url.split('?')[1] || '')
 

--- a/stratos-service/stryker.config.json
+++ b/stratos-service/stryker.config.json
@@ -18,6 +18,8 @@
     "src/features/pull-sync/**/*.ts",
     "src/infra/auth/**/*.ts",
     "src/infra/signing/**/*.ts",
+    "src/oauth/admin-routes.ts",
+    "src/oauth/admin-user-store.ts",
     "src/oauth/handlers/authorize.ts",
     "src/oauth/handlers/callback.ts",
     "src/oauth/redirect-target.ts",

--- a/stratos-service/tests/admin-auth.integration.test.ts
+++ b/stratos-service/tests/admin-auth.integration.test.ts
@@ -120,7 +120,7 @@ describe('SqliteAdminSessionStore', () => {
     expect(removed).toBe(1)
     expect(await store.get(live)).toBeDefined()
     // The expired row is gone; a direct del would have been a no-op.
-    const req: any = {
+    const req = {
       headers: { cookie: `${ADMIN_SESSION_COOKIE}=${expired}` },
     }
     const did = await resolveAdminSession(req, {
@@ -606,7 +606,7 @@ describe('resolveAdminSession (whoami / logout)', () => {
 
   it('returns the DID for a live, allowlisted session', async () => {
     const key = await store.create(ADMIN_DID, 60_000)
-    const req: any = { headers: { cookie: `${ADMIN_SESSION_COOKIE}=${key}` } }
+    const req = { headers: { cookie: `${ADMIN_SESSION_COOKIE}=${key}` } }
     const did = await resolveAdminSession(req, {
       adminSessionStore: store,
       adminDids: [ADMIN_DID],
@@ -618,7 +618,7 @@ describe('resolveAdminSession (whoami / logout)', () => {
   it('returns null once the session is deleted (logout)', async () => {
     const key = await store.create(ADMIN_DID, 60_000)
     await store.del(key)
-    const req: any = { headers: { cookie: `${ADMIN_SESSION_COOKIE}=${key}` } }
+    const req = { headers: { cookie: `${ADMIN_SESSION_COOKIE}=${key}` } }
     const did = await resolveAdminSession(req, {
       adminSessionStore: store,
       adminDids: [ADMIN_DID],
@@ -628,7 +628,7 @@ describe('resolveAdminSession (whoami / logout)', () => {
   })
 
   it('returns null when there is no session cookie', async () => {
-    const req: any = { headers: {} }
+    const req = { headers: {} }
     const did = await resolveAdminSession(req, {
       adminSessionStore: store,
       adminDids: [ADMIN_DID],
@@ -640,7 +640,7 @@ describe('resolveAdminSession (whoami / logout)', () => {
   it('resolves a session for a runtime-granted admin not on the allowlist', async () => {
     const grantedDid = 'did:plc:spike-spiegel'
     const key = await store.create(grantedDid, 60_000)
-    const req: any = { headers: { cookie: `${ADMIN_SESSION_COOKIE}=${key}` } }
+    const req = { headers: { cookie: `${ADMIN_SESSION_COOKIE}=${key}` } }
     const did = await resolveAdminSession(req, {
       adminSessionStore: store,
       adminDids: [ADMIN_DID],
@@ -651,7 +651,7 @@ describe('resolveAdminSession (whoami / logout)', () => {
 
   it('returns null for a session DID that is neither allowlisted nor granted', async () => {
     const key = await store.create(INTRUDER_DID, 60_000)
-    const req: any = { headers: { cookie: `${ADMIN_SESSION_COOKIE}=${key}` } }
+    const req = { headers: { cookie: `${ADMIN_SESSION_COOKIE}=${key}` } }
     const did = await resolveAdminSession(req, {
       adminSessionStore: store,
       adminDids: [ADMIN_DID],

--- a/stratos-service/tests/admin-auth.integration.test.ts
+++ b/stratos-service/tests/admin-auth.integration.test.ts
@@ -11,7 +11,11 @@ import {
   type ServiceDb,
 } from '../src/db'
 import { SqliteAdminSessionStore } from '../src/oauth/admin-session-store.js'
-import { SqliteAdminUserStore } from '../src/oauth/admin-user-store.js'
+import {
+  isEffectiveAdmin,
+  SqliteAdminUserStore,
+  type AdminUserStore,
+} from '../src/oauth/admin-user-store.js'
 import {
   ADMIN_SESSION_COOKIE,
   resolveAdminSession,
@@ -30,6 +34,17 @@ import { createTestConfig } from './utils'
 const ADMIN_DID = 'did:plc:usagi'
 const INTRUDER_DID = 'did:plc:mamoru'
 const PUBLIC_URL = 'https://stratos.test'
+
+/** Store stub for cases that exercise the config allowlist alone. */
+const NO_GRANTED_ADMINS = {
+  has: async () => false,
+} as unknown as AdminUserStore
+
+function grantedAdminStore(granted: string): AdminUserStore {
+  return {
+    has: async (did: string) => did === granted,
+  } as unknown as AdminUserStore
+}
 
 function makeAdminCtx(headers: Record<string, string | undefined>): {
   req: import('node:http').IncomingMessage
@@ -111,6 +126,7 @@ describe('SqliteAdminSessionStore', () => {
     const did = await resolveAdminSession(req, {
       adminSessionStore: store,
       adminDids: [ADMIN_DID],
+      adminUserStore: NO_GRANTED_ADMINS,
     })
     expect(did).toBeNull()
   })
@@ -510,6 +526,7 @@ describe('admin OAuth callback', () => {
       oauthClient: oauthClient as never,
       adminSessionStore: store,
       adminDids: [ADMIN_DID],
+      adminUserStore: NO_GRANTED_ADMINS,
       baseUrl: PUBLIC_URL,
     }
   }
@@ -593,6 +610,7 @@ describe('resolveAdminSession (whoami / logout)', () => {
     const did = await resolveAdminSession(req, {
       adminSessionStore: store,
       adminDids: [ADMIN_DID],
+      adminUserStore: NO_GRANTED_ADMINS,
     })
     expect(did).toBe(ADMIN_DID)
   })
@@ -604,6 +622,7 @@ describe('resolveAdminSession (whoami / logout)', () => {
     const did = await resolveAdminSession(req, {
       adminSessionStore: store,
       adminDids: [ADMIN_DID],
+      adminUserStore: NO_GRANTED_ADMINS,
     })
     expect(did).toBeNull()
   })
@@ -613,7 +632,71 @@ describe('resolveAdminSession (whoami / logout)', () => {
     const did = await resolveAdminSession(req, {
       adminSessionStore: store,
       adminDids: [ADMIN_DID],
+      adminUserStore: NO_GRANTED_ADMINS,
     })
     expect(did).toBeNull()
+  })
+
+  it('resolves a session for a runtime-granted admin not on the allowlist', async () => {
+    const grantedDid = 'did:plc:spike-spiegel'
+    const key = await store.create(grantedDid, 60_000)
+    const req: any = { headers: { cookie: `${ADMIN_SESSION_COOKIE}=${key}` } }
+    const did = await resolveAdminSession(req, {
+      adminSessionStore: store,
+      adminDids: [ADMIN_DID],
+      adminUserStore: grantedAdminStore(grantedDid),
+    })
+    expect(did).toBe(grantedDid)
+  })
+
+  it('returns null for a session DID that is neither allowlisted nor granted', async () => {
+    const key = await store.create(INTRUDER_DID, 60_000)
+    const req: any = { headers: { cookie: `${ADMIN_SESSION_COOKIE}=${key}` } }
+    const did = await resolveAdminSession(req, {
+      adminSessionStore: store,
+      adminDids: [ADMIN_DID],
+      adminUserStore: grantedAdminStore('did:plc:spike-spiegel'),
+    })
+    expect(did).toBeNull()
+  })
+})
+
+describe('isEffectiveAdmin (shared by the .admin verifier and /whoami)', () => {
+  const GRANTED_DID = 'did:plc:faye-valentine'
+
+  it('admits a DID on the config allowlist with no runtime grant', async () => {
+    expect(
+      await isEffectiveAdmin(ADMIN_DID, {
+        adminDids: [ADMIN_DID],
+        adminUserStore: NO_GRANTED_ADMINS,
+      }),
+    ).toBe(true)
+  })
+
+  it('admits a DID granted at runtime but absent from the allowlist', async () => {
+    expect(
+      await isEffectiveAdmin(GRANTED_DID, {
+        adminDids: [ADMIN_DID],
+        adminUserStore: grantedAdminStore(GRANTED_DID),
+      }),
+    ).toBe(true)
+  })
+
+  it('admits a DID that is both allowlisted and granted', async () => {
+    expect(
+      await isEffectiveAdmin(ADMIN_DID, {
+        adminDids: [ADMIN_DID],
+        adminUserStore: grantedAdminStore(ADMIN_DID),
+      }),
+    ).toBe(true)
+  })
+
+  it('rejects a DID in neither set', async () => {
+    expect(
+      await isEffectiveAdmin(INTRUDER_DID, {
+        adminDids: [ADMIN_DID],
+        adminUserStore: grantedAdminStore(GRANTED_DID),
+      }),
+    ).toBe(false)
   })
 })

--- a/stratos-service/tests/admin-auth.integration.test.ts
+++ b/stratos-service/tests/admin-auth.integration.test.ts
@@ -20,7 +20,10 @@ import {
   ADMIN_SESSION_COOKIE,
   resolveAdminSession,
 } from '../src/oauth/admin-routes.js'
-import { handleAdminCallback } from '../src/oauth/handlers/admin-callback.js'
+import {
+  handleAdminCallback,
+  type AdminCallbackResponse,
+} from '../src/oauth/handlers/admin-callback.js'
 import { createAuthVerifiers } from '../src/infra/auth/verifiers.js'
 import {
   envToConfig,
@@ -491,6 +494,21 @@ describe('admin auth verifier', () => {
   })
 })
 
+/**
+ * A response double carrying only the methods the admin callback calls.
+ *
+ * The mock functions stay visible for assertions, and the object satisfies
+ * `AdminCallbackResponse`, so a method the handler starts using fails the build
+ * here rather than at run time.
+ */
+function makeAdminRes() {
+  const cookie = vi.fn()
+  const redirect = vi.fn()
+  const json = vi.fn()
+  const status = vi.fn(() => ({ json }))
+  return { cookie, redirect, status, json } satisfies AdminCallbackResponse
+}
+
 describe('admin OAuth callback', () => {
   let dataDir: string
   let db: ServiceDb
@@ -535,13 +553,8 @@ describe('admin OAuth callback', () => {
     oauthClient.callback.mockResolvedValue({ session: { sub: ADMIN_DID } })
     const handler = handleAdminCallback(makeConfig())
 
-    const req: any = { url: '/admin/oauth/callback?code=foo&state=bar' }
-    const res: any = {
-      cookie: vi.fn(),
-      redirect: vi.fn(),
-      status: vi.fn().mockReturnThis(),
-      json: vi.fn(),
-    }
+    const req = { url: '/admin/oauth/callback?code=foo&state=bar' }
+    const res = makeAdminRes()
 
     await handler(req, res)
 
@@ -566,13 +579,8 @@ describe('admin OAuth callback', () => {
     const createSpy = vi.spyOn(store, 'create')
     const handler = handleAdminCallback(makeConfig())
 
-    const req: any = { url: '/admin/oauth/callback?code=foo&state=bar' }
-    const res: any = {
-      cookie: vi.fn(),
-      redirect: vi.fn(),
-      status: vi.fn().mockReturnThis(),
-      json: vi.fn(),
-    }
+    const req = { url: '/admin/oauth/callback?code=foo&state=bar' }
+    const res = makeAdminRes()
 
     await handler(req, res)
 


### PR DESCRIPTION
## Description

Two guards answered "is this DID an admin?" from different rosters. The request-time XRPC `.admin` verifier authorized on the **union** of the config allow-list and the runtime `adminUserStore`; `resolveAdminSession` (backing `GET /admin/whoami`) checked the config allow-list **only**. A runtime-granted admin therefore held full admin privilege while `/whoami` told them they were not an admin.

The drift was **fail-closed** — `/whoami` under-reported; nobody escalated through it. The fix is not to copy the union expression into the second call site but to remove the second source of truth: one exported `isEffectiveAdmin` predicate that both guards call. The effective admin set is unchanged; only `/whoami`'s answer is corrected to match what the verifier already enforced.

Plan: `plans/022-admin-membership-drift.md`

## Testing

- `isEffectiveAdmin` 2x2 truth table (allow-list x store)
- `resolveAdminSession` union regression (`did:plc:spike-spiegel` granted at runtime, absent from the allow-list, now resolves) plus the mirror negative
- Bite-check: reverting the `admin-routes.ts` edit fails exactly the union regression case
- 860 service tests green

## Review notes (opus review: 0 critical, 1 major, 2 minor, 1 nit)

- **major, fixed** — `createTestConfig`'s sibling helper `makeConfig()` was not updated for the newly-required `adminUserStore`, producing two real `TS2345` errors. They stayed invisible because `tsconfig.build.json` excludes `tests/`, the package has no `typecheck` script, and vitest does not typecheck.

Recorded, not fixed:

- **minor** — `/whoami` now carries a DB dependency: a store failure yields 500 where it previously yielded a fast 401. Still fail-closed, and a config-allow-list admin short-circuits past the store, so the recovery floor keeps answering during a DB outage.
- **minor** — a *third* roster remains at the login gate. `handlers/admin-callback.ts:35` gates session creation on `adminDids` alone, so a runtime-granted admin cannot mint a session at all; the symptom this PR fixes is reachable mainly when a DID is dropped from the allow-list after login. Routing that through `isEffectiveAdmin` changes *who can log in*, which is an authorization decision deserving its own plan rather than a consistency cleanup.
- **nit** — `createAdminVerifier`'s docstring still says membership is "on the configured allowlist".

**Tooling gap worth a follow-up:** `stratos-service` has no `typecheck` script, so the root `pnpm -r --if-present run typecheck` skips it entirely, and `tsconfig.build.json` excludes tests. There are 13 pre-existing type errors in `admin-*` test files that nothing currently catches.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Administrators granted access at runtime can now authenticate and use admin routes without being added to the static configuration.
  * Admin access consistently recognizes both configured and runtime-approved administrators.

* **Bug Fixes**
  * Prevented unapproved identities from establishing admin sessions, including identities previously accepted through incomplete checks.

* **Tests**
  * Expanded coverage for configured, runtime-granted, overlapping, and unauthorized administrator access scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->