### PR TITLE
fix(records): emit batch sequence event only after commit persists

### DIFF
--- a/stratos-service/src/api/records/batch.ts
+++ b/stratos-service/src/api/records/batch.ts
@@ -381,7 +381,7 @@ export async function applyWritesBatch(
     ops,
   )
   const mstOps: MstWriteOp[] = buildMstOps(precomputed)
-  const result: Promise<CommitResult> = buildCommitWithRetry(
+  const result = await buildCommitWithRetry(
     ctx,
     callerDid,
     sequenceTrace,

--- a/stratos-service/tests/records-move-sync.integration.test.ts
+++ b/stratos-service/tests/records-move-sync.integration.test.ts
@@ -292,4 +292,68 @@ describe('Record move sync contract', () => {
       (await pullOpsFor([THIRD_DOMAIN])).filter((o) => o.rkey === rkey),
     ).toHaveLength(0)
   })
+
+  it('batch: emit fires only after the commit is durable', async () => {
+    // Wrap the real transact() so we know — synchronously, at the instant
+    // emit fires — whether the write transaction has actually resolved.
+    // Firing emit before this flag flips true is exactly the bug: subscribers
+    // would wake and find nothing new yet.
+    const originalTransact = actorStore.transact.bind(actorStore)
+    let transactionDurable = false
+    ;(
+      actorStore as unknown as { transact: typeof actorStore.transact }
+    ).transact = (async (...args: Parameters<typeof actorStore.transact>) => {
+      const outcome = await (originalTransact as any)(...args)
+      transactionDurable = true
+      return outcome
+    }) as typeof actorStore.transact
+
+    let durableAtEmitTime = false
+    let seqReadStartedAtEmitTime: Promise<SeqEvent[]> | undefined
+    ctx.sequenceEvents.emit = vi.fn(() => {
+      durableAtEmitTime = transactionDurable
+      // Kick off the log read from inside the listener itself — the same
+      // thing a real subscribeRecords consumer does on wake — and capture
+      // the promise synchronously so we can inspect what it saw.
+      seqReadStartedAtEmitTime = readAllSeqEvents()
+    })
+
+    const batchRkey = 'asuka-langley-post'
+    await applyWritesBatch(ctx, testDid, [
+      {
+        action: 'create',
+        collection,
+        rkey: batchRkey,
+        record: post(NEW_DOMAIN, 'Batch durability check'),
+      },
+    ])
+
+    expect(ctx.sequenceEvents.emit).toHaveBeenCalledTimes(1)
+    expect(durableAtEmitTime).toBe(true)
+
+    const seqEventsAtEmitTime = await seqReadStartedAtEmitTime!
+    const observedForBatchRecord = seqEventsAtEmitTime.some((event) => {
+      const decoded = decodeEvent(event)
+      return decoded.ops.some((op) => op.path === `${collection}/${batchRkey}`)
+    })
+    expect(observedForBatchRecord).toBe(true)
+  })
+
+  it('batch: a rejected commit emits nothing', async () => {
+    const keyVaultError = new Error('key vault offline')
+    ctx.actorSigner.getSignFn = vi.fn().mockRejectedValue(keyVaultError)
+
+    await expect(
+      applyWritesBatch(ctx, testDid, [
+        {
+          action: 'create',
+          collection,
+          rkey: 'misato-katsuragi-post',
+          record: post(NEW_DOMAIN, 'Should never land'),
+        },
+      ]),
+    ).rejects.toThrow('key vault offline')
+
+    expect(ctx.sequenceEvents.emit).not.toHaveBeenCalled()
+  })
 })

--- a/stratos-service/tests/records-move-sync.integration.test.ts
+++ b/stratos-service/tests/records-move-sync.integration.test.ts
@@ -300,13 +300,13 @@ describe('Record move sync contract', () => {
     // would wake and find nothing new yet.
     const originalTransact = actorStore.transact.bind(actorStore)
     let transactionDurable = false
-    ;(
-      actorStore as unknown as { transact: typeof actorStore.transact }
-    ).transact = (async (...args: Parameters<typeof actorStore.transact>) => {
-      const outcome = await (originalTransact as any)(...args)
+    const wrappedTransact: typeof actorStore.transact = async (did, fn) => {
+      const outcome = await originalTransact(did, fn)
       transactionDurable = true
       return outcome
-    }) as typeof actorStore.transact
+    }
+    ;(actorStore as { transact: typeof actorStore.transact }).transact =
+      wrappedTransact
 
     let durableAtEmitTime = false
     let seqReadStartedAtEmitTime: Promise<SeqEvent[]> | undefined


### PR DESCRIPTION
## Description

`applyWritesBatch` sounded the "new data aboard" horn before the crate was in the hold: it emitted the in-process subscriber notification while `buildCommitWithRetry` was still an unawaited promise. Subscribers woke, read the sequence log, found nothing new, and settled back into a 30-second wait — so batch-written records reached the indexer and feedgen **up to half a minute late**.

Create, update and delete all transact first and emit second. Batch was the sibling that drifted. One line: await the commit, then emit.

Scope honesty: this closes the **self-inflicted** case (emit before commit) completely, but it narrows rather than eliminates the 30-second worst case. `waitForSequenceEvent` is edge-triggered — between a subscriber's page read and its next listener registration no listener exists, so a commit emitting in that gap still waits out the timeout. That interleaving is a different defect and survives this diff.

A second-order effect goes away too — a rejected commit no longer announces a write that never happened.

Plan: `plans/010-batch-emit-after-commit.md`

## Testing

Two cases in `records-move-sync.integration.test.ts`, chosen over `repo-write-handlers.test.ts` because that file mocks `applyWritesBatch` entirely and so cannot observe real commit-durability timing.

The load-bearing assertion inspects real state at emit time rather than merely spying on call order: a wrapper flips a `transactionDurable` flag only once the underlying transaction resolves, and the emit mock reads it **synchronously**. Under the old code the emit fires before `buildCommitWithRetry`'s first internal `await` yields, so the flag is provably still false — deterministic, no timing luck. Verified by reverting: both new tests fail against the old code.

## A note on the mutation gate

StrykerJS generates **zero mutants** on the changed lines. Its default mutator set has no mutator that removes an `await` or reorders statements, so mutation testing structurally cannot validate this fix — confirmed by inspecting the installed mutator inventory. The stash/revert check above is the substitute, and it is the stronger signal here.

## Review notes (opus review: 0 critical, 0 major, 4 minor, 3 nit)

Nothing blocking. The reviewer traced `buildCommitWithRetry` to the storage layer to confirm its resolution implies real durability (COMMIT, not merely a settled promise), and confirmed the latency claim — the sole caller already awaited the same work, so only the emit moved.

Recorded, not fixed: the rejection test only covers a pre-transaction failure (a mid-transaction rollback case would be stronger); the "emits once" assertion does not actually force the retry path; and the sequence-log read inside the listener is decorative rather than a point-in-time snapshot, though the durability flag beside it is sound.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Record batch notifications now occur only after changes are durably committed.
  * Prevented notifications from being sent when a batch commit fails.
  * Improved consistency for subscribers reading newly committed records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
