### PR TITLE
fix(subscription): drain event backlog per wake and stop masking store errors

### DIFF
--- a/stratos-service/src/subscription/sequence-paging.ts
+++ b/stratos-service/src/subscription/sequence-paging.ts
@@ -1,6 +1,9 @@
 import { decode as cborDecode } from '@atproto/lex-cbor'
 import type { AppContext } from '../context.js'
-import { type SeqEvent } from './index.js'
+// Import from the module, not the './index.js' barrel. subscribe-records
+// imports SEQUENCE_DB_PAGE_SIZE from this file, and the barrel re-exports
+// subscribe-records, so the barrel path closes an import cycle.
+import { type SeqEvent } from './subscribe-records.js'
 
 /**
  * The database page size used when reading from the actor sequence store.

--- a/stratos-service/src/subscription/subscribe-records.ts
+++ b/stratos-service/src/subscription/subscribe-records.ts
@@ -388,14 +388,25 @@ async function getLatestSeq(ctx: AppContext, did: string): Promise<number> {
   // Reading opens (and therefore creates) the actor SQLite file. Skip the read
   // for actors without a store so we never materialize an empty database.
   if (!(await ctx.actorStore.exists(did))) return 0
-  return await ctx.actorStore.read(did, async (store) => {
-    return store.sequence.getLatestSeq()
-  })
+  try {
+    return await ctx.actorStore.read(did, async (store) => {
+      return store.sequence.getLatestSeq()
+    })
+  } catch (err) {
+    // The rethrow ends the connection; the warn keeps the operator informed.
+    ctx.logger?.warn({ did, err }, 'getLatestSeq failed')
+    throw err
+  }
 }
 
 /**
- * Get oldest sequence number for a DID. Read failures propagate; see
- * {@link getLatestSeq}.
+ * Get oldest sequence number for a DID.
+ *
+ * Unlike {@link getLatestSeq}, a read failure here is caught and reported as
+ * 0. The only consumer uses this value to decide whether to send the advisory
+ * `#info OutdatedCursor` frame; a fabricated 0 suppresses that advisory and
+ * nothing else. Hardening it like its siblings would add a third independent
+ * way for a transient blip to kill the connection, with no correctness gain.
  *
  * @param ctx - Application context
  * @param did - Decentralized Identifier (DID) for which to get the oldest sequence number
@@ -403,9 +414,14 @@ async function getLatestSeq(ctx: AppContext, did: string): Promise<number> {
  */
 async function getOldestSeq(ctx: AppContext, did: string): Promise<number> {
   if (!(await ctx.actorStore.exists(did))) return 0
-  return await ctx.actorStore.read(did, async (store) => {
-    return store.sequence.getOldestSeq()
-  })
+  try {
+    return await ctx.actorStore.read(did, async (store) => {
+      return store.sequence.getOldestSeq()
+    })
+  } catch (err) {
+    ctx.logger?.warn({ did, err }, 'getOldestSeq failed')
+    return 0
+  }
 }
 
 /**
@@ -438,29 +454,35 @@ async function getEventsSince(
   // Avoid opening (and creating) a SQLite file for actors that have not written
   // yet; the streaming loop polls this until the store appears on first write.
   if (!(await ctx.actorStore.exists(did))) return []
-  return await ctx.actorStore.read(did, async (store) => {
-    const rows = await store.sequence.getEventsSince(
-      cursor,
-      SEQUENCE_DB_PAGE_SIZE,
-    )
+  try {
+    return await ctx.actorStore.read(did, async (store) => {
+      const rows = await store.sequence.getEventsSince(
+        cursor,
+        SEQUENCE_DB_PAGE_SIZE,
+      )
 
-    return rows.map((row): SeqEvent => {
-      let rev = ''
-      try {
-        const decoded = cborDecode(row.event) as Record<string, unknown>
-        rev = (decoded.rev as string) ?? ''
-      } catch {
-        // Ignore decode errors
-      }
-      return {
-        seq: row.seq,
-        did: row.did,
-        time: row.sequencedAt,
-        rev,
-        event: row.event,
-      }
+      return rows.map((row): SeqEvent => {
+        let rev = ''
+        try {
+          const decoded = cborDecode(row.event) as Record<string, unknown>
+          rev = (decoded.rev as string) ?? ''
+        } catch {
+          // Ignore decode errors
+        }
+        return {
+          seq: row.seq,
+          did: row.did,
+          time: row.sequencedAt,
+          rev,
+          event: row.event,
+        }
+      })
     })
-  })
+  } catch (err) {
+    // The rethrow ends the connection; the warn keeps the operator informed.
+    ctx.logger?.warn({ did, cursor, err }, 'getEventsSince failed')
+    throw err
+  }
 }
 
 /**

--- a/stratos-service/src/subscription/subscribe-records.ts
+++ b/stratos-service/src/subscription/subscribe-records.ts
@@ -4,6 +4,7 @@ import type { WebSocket } from 'ws'
 
 import type { AppContext, EnrollmentEvent } from '../context.js'
 import type { EnrollmentStoreReader } from '@northskysocial/stratos-core'
+import { SEQUENCE_DB_PAGE_SIZE } from './sequence-paging.js'
 
 const WS_PING_INTERVAL_MS = 30_000
 
@@ -141,12 +142,18 @@ function createActorSubscriptionHandler(ctx: AppContext) {
         }
       }
 
-      const catchUp = await getEventsSince(ctx, did, lastSeq)
-      for (const event of catchUp) {
-        if (signal.aborted) return
-        const message = emitEvent(ctx, event, callerBoundaries, domain)
-        if (message) yield message
-        lastSeq = event.seq
+      // Drain every retained page, not just the first: a single page would
+      // leave the rest of the backlog waiting on the next write signal or the
+      // 30 s timeout, pacing catch-up at one page per wake.
+      while (!signal.aborted) {
+        const catchUp = await getEventsSince(ctx, did, lastSeq)
+        for (const event of catchUp) {
+          if (signal.aborted) return
+          const message = emitEvent(ctx, event, callerBoundaries, domain)
+          if (message) yield message
+          lastSeq = event.seq
+        }
+        if (catchUp.length < SEQUENCE_DB_PAGE_SIZE) break
       }
     }
 
@@ -203,16 +210,21 @@ async function* streamNewEvents(
   let lastSeq = startSeq
   while (!signal.aborted) {
     await waitForSequenceEvent(ctx, did, signal, 30_000)
-    if (signal.aborted) return
 
-    const newEvents = await getEventsSince(ctx, did, lastSeq)
-    for (const event of newEvents) {
-      if (signal.aborted) return
-      const message = emitEvent(ctx, event, callerBoundaries, domain)
-      if (message) {
-        yield message
+    // One wake drains everything currently readable; the 30 s timeout is a
+    // safety net, never the pace at which a backlog is delivered. The drain
+    // loop's own guard covers a wake caused by the abort itself.
+    while (!signal.aborted) {
+      const newEvents = await getEventsSince(ctx, did, lastSeq)
+      for (const event of newEvents) {
+        if (signal.aborted) return
+        const message = emitEvent(ctx, event, callerBoundaries, domain)
+        if (message) {
+          yield message
+        }
+        lastSeq = event.seq
       }
-      lastSeq = event.seq
+      if (newEvents.length < SEQUENCE_DB_PAGE_SIZE) break
     }
   }
 }
@@ -361,7 +373,13 @@ export function createSubscribeRecordsHandler(ctx: AppContext) {
 // Helper functions
 
 /**
- * Get latest sequence number for a DID
+ * Get latest sequence number for a DID.
+ *
+ * A read failure propagates and ends the connection. Reporting 0 for a failed
+ * read is not a safe default: it makes any live cursor look "ahead of latest"
+ * and replays the client from sequence 0. Clients reconnect and resume from
+ * their own cursor, which is the protocol's answer to a transient failure.
+ *
  * @param ctx - Application context
  * @param did - Decentralized Identifier (DID) for which to get the latest sequence number
  * @returns Latest sequence number for the DID
@@ -370,36 +388,43 @@ async function getLatestSeq(ctx: AppContext, did: string): Promise<number> {
   // Reading opens (and therefore creates) the actor SQLite file. Skip the read
   // for actors without a store so we never materialize an empty database.
   if (!(await ctx.actorStore.exists(did))) return 0
-  try {
-    return await ctx.actorStore.read(did, async (store) => {
-      return store.sequence.getLatestSeq()
-    })
-  } catch (err) {
-    ctx.logger?.warn({ did, err }, 'getLatestSeq failed')
-    return 0
-  }
+  return await ctx.actorStore.read(did, async (store) => {
+    return store.sequence.getLatestSeq()
+  })
 }
 
 /**
- * Get oldest sequence number for a DID
+ * Get oldest sequence number for a DID. Read failures propagate; see
+ * {@link getLatestSeq}.
+ *
  * @param ctx - Application context
  * @param did - Decentralized Identifier (DID) for which to get the oldest sequence number
  * @returns Oldest sequence number for the DID
  */
 async function getOldestSeq(ctx: AppContext, did: string): Promise<number> {
   if (!(await ctx.actorStore.exists(did))) return 0
-  try {
-    return await ctx.actorStore.read(did, async (store) => {
-      return store.sequence.getOldestSeq()
-    })
-  } catch (err) {
-    ctx.logger?.warn({ did, err }, 'getOldestSeq failed')
-    return 0
-  }
+  return await ctx.actorStore.read(did, async (store) => {
+    return store.sequence.getOldestSeq()
+  })
 }
 
 /**
- * Get events since a given sequence number for a DID
+ * Get one page of events after a given sequence number for a DID.
+ *
+ * Returns at most {@link SEQUENCE_DB_PAGE_SIZE} events, so a short page is the
+ * drain loops' signal that the log is exhausted. A store read failure
+ * propagates rather than reporting an empty page, because "no events" and "the
+ * read failed" are different facts and the caller acts on the difference.
+ *
+ * Deliberately NOT `readSequencePage` from sequence-paging.ts: the two readers
+ * disagree on `rev`. Its `rowToSeqEvent` blanks any rev failing
+ * `/^[0-9a-z]{13}$/` because `getSequenceBounds` compares revs for truncation
+ * detection, where a malformed rev yields a wrong OplogTruncated verdict. Here
+ * `rev` is an opaque passthrough copied onto the `#commit` wire frame by
+ * `formatEvent`, and outgoing frames are never lexicon-validated — swapping
+ * readers would silently change emitted bytes. Unification is deferred to
+ * plan 015 (sync-library extraction).
+ *
  * @param ctx - Application context
  * @param did - Decentralized Identifier (DID) for which to get events
  * @param cursor - Sequence number to start from
@@ -413,31 +438,29 @@ async function getEventsSince(
   // Avoid opening (and creating) a SQLite file for actors that have not written
   // yet; the streaming loop polls this until the store appears on first write.
   if (!(await ctx.actorStore.exists(did))) return []
-  try {
-    return await ctx.actorStore.read(did, async (store) => {
-      const rows = await store.sequence.getEventsSince(cursor, 100)
+  return await ctx.actorStore.read(did, async (store) => {
+    const rows = await store.sequence.getEventsSince(
+      cursor,
+      SEQUENCE_DB_PAGE_SIZE,
+    )
 
-      return rows.map((row): SeqEvent => {
-        let rev = ''
-        try {
-          const decoded = cborDecode(row.event) as Record<string, unknown>
-          rev = (decoded.rev as string) ?? ''
-        } catch {
-          // Ignore decode errors
-        }
-        return {
-          seq: row.seq,
-          did: row.did,
-          time: row.sequencedAt,
-          rev,
-          event: row.event,
-        }
-      })
+    return rows.map((row): SeqEvent => {
+      let rev = ''
+      try {
+        const decoded = cborDecode(row.event) as Record<string, unknown>
+        rev = (decoded.rev as string) ?? ''
+      } catch {
+        // Ignore decode errors
+      }
+      return {
+        seq: row.seq,
+        did: row.did,
+        time: row.sequencedAt,
+        rev,
+        event: row.event,
+      }
     })
-  } catch (err) {
-    ctx.logger?.warn({ did, cursor, err }, 'getEventsSince failed')
-    return []
-  }
+  })
 }
 
 /**

--- a/stratos-service/tests/subscription-handlers.integration.test.ts
+++ b/stratos-service/tests/subscription-handlers.integration.test.ts
@@ -124,6 +124,107 @@ describe('Subscription Handlers', () => {
       })
     }
 
+    /**
+     * Append one event per entry of `boundaries`, so a drained page can mix
+     * in-scope and out-of-scope events.
+     */
+    async function appendEvents(did: string, boundaries: string[]) {
+      await actorStore.transact(did, async (store: any) => {
+        for (const [offset, boundary] of boundaries.entries()) {
+          const index = offset + 1
+          await store.sequence.appendEvent({
+            did,
+            eventType: 'append',
+            event: encodeRecord({
+              rev: `rev${index}`,
+              ops: [
+                {
+                  action: 'create',
+                  path: `zone.stratos.feed.post/${index}`,
+                  record: {
+                    text: `Angel sighting ${index}`,
+                    boundary: { values: [{ value: boundary }] },
+                  },
+                },
+              ],
+            }),
+            invalidated: 0,
+            sequencedAt: new Date().toISOString(),
+          })
+        }
+      })
+    }
+
+    async function collect(generator: any, count: number): Promise<any[]> {
+      const messages: any[] = []
+      for (let i = 0; i < count; i++) {
+        const next = await generator.next()
+        if (next.done) break
+        messages.push(next.value)
+      }
+      return messages
+    }
+
+    function paths(messages: any[]): string[] {
+      return messages.map((message) => message.ops[0].path)
+    }
+
+    /**
+     * `count` in-scope events with a single out-of-scope 'seele' event in the
+     * middle, so a filtered-out event inside a drained page would surface as an
+     * `undefined` frame rather than being silently skipped.
+     */
+    function backlogBoundaries(count: number, boundary: string): string[] {
+      const boundaries = Array.from({ length: count + 1 }, () => boundary)
+      boundaries[Math.floor(count / 2)] = 'seele'
+      return boundaries
+    }
+
+    function sleep(ms: number): Promise<void> {
+      return new Promise((resolve) => setTimeout(resolve, ms))
+    }
+
+    /**
+     * A ctx whose actor-store reads are counted, so a drain loop that never
+     * exits shows up as reads accruing while the stream should be parked.
+     */
+    function countingCtx() {
+      const counter = { reads: 0 }
+      return {
+        counter,
+        ctx: {
+          ...ctx,
+          actorStore: {
+            exists: (did: string) => actorStore.exists(did),
+            read: (did: string, fn: any) => {
+              counter.reads++
+              return actorStore.read(did, fn)
+            },
+          },
+        },
+      }
+    }
+
+    /**
+     * Assert the stream parked on the wake wait instead of spinning on the
+     * store: a fully drained stream issues no further reads until a new event,
+     * and closes cleanly when the connection aborts.
+     */
+    async function expectParkedOnWake(
+      generator: any,
+      counter: { reads: number },
+      abortController: AbortController,
+    ) {
+      const pending = generator.next()
+      await sleep(60)
+      const readsWhileIdle = counter.reads
+      await sleep(60)
+      expect(counter.reads).toBe(readsWhileIdle)
+
+      abortController.abort()
+      expect((await pending).done).toBe(true)
+    }
+
     it('streams in-boundary actor records to an enrolled service', async () => {
       await enrollService(['nerv'])
       await actorStore.create(testDid)
@@ -291,6 +392,162 @@ describe('Subscription Handlers', () => {
         expect.stringContaining('cursor ahead of latest'),
       )
     })
+
+    // The drain tests are bounded well under the stream's 30 s wake timeout: a
+    // regression that reverts to one page per wake must fail fast rather than
+    // stall CI for half a minute per page.
+    it('drains a backlog larger than one page on connect', async () => {
+      await enrollService(['nerv'])
+      await actorStore.create(testDid)
+      await appendEvents(testDid, backlogBoundaries(150, 'nerv'))
+
+      const { ctx: readCountingCtx, counter } = countingCtx()
+      const handler = createSubscribeRecordsHandler(readCountingCtx) as any
+      const abortController = new AbortController()
+      const generator = handler(
+        { did: testDid },
+        serviceCreds,
+        abortController.signal,
+      )
+
+      const messages = await collect(generator, 150)
+      // The backlog is exhausted, so the stream must park rather than keep
+      // re-reading the store.
+      await expectParkedOnWake(generator, counter, abortController)
+
+      expect(messages).toHaveLength(150)
+      expect(paths(messages).at(0)).toBe('zone.stratos.feed.post/1')
+      expect(paths(messages).at(-1)).toBe('zone.stratos.feed.post/151')
+      expect(paths(messages)).not.toContain('zone.stratos.feed.post/76')
+    }, 10_000)
+
+    it('drains more than one page per wake', async () => {
+      await enrollService(['nerv'])
+      await actorStore.create(testDid)
+
+      const { ctx: readCountingCtx, counter } = countingCtx()
+      const handler = createSubscribeRecordsHandler(readCountingCtx) as any
+      const abortController = new AbortController()
+      const generator = handler(
+        { did: testDid },
+        serviceCreds,
+        abortController.signal,
+      )
+
+      // Wait until the stream has actually parked on the wake wait before
+      // appending. If catch-up ever saw the events, the connect drain would
+      // serve them all and this test would silently stop covering the
+      // per-wake multi-page drain it is named for.
+      const parked = new Promise<void>((resolve) =>
+        sequenceEvents.once('newListener', (event) => {
+          if (event === testDid) resolve()
+        }),
+      )
+      const firstPromise = generator.next()
+      await parked
+      await appendEvents(testDid, backlogBoundaries(120, 'nerv'))
+      sequenceEvents.emit(testDid)
+      const first = await firstPromise
+
+      const rest = await collect(generator, 119)
+      await expectParkedOnWake(generator, counter, abortController)
+
+      const messages = [first.value, ...rest]
+      expect(messages).toHaveLength(120)
+      expect(paths(messages).at(0)).toBe('zone.stratos.feed.post/1')
+      expect(paths(messages).at(-1)).toBe('zone.stratos.feed.post/121')
+      expect(paths(messages)).not.toContain('zone.stratos.feed.post/61')
+    }, 10_000)
+
+    it('stops draining a backlog once the connection aborts', async () => {
+      await enrollService(['nerv'])
+      await actorStore.create(testDid)
+      await appendEvents(testDid, backlogBoundaries(150, 'nerv'))
+
+      const handler = createSubscribeRecordsHandler(ctx) as any
+      const abortController = new AbortController()
+      const generator = handler(
+        { did: testDid },
+        serviceCreds,
+        abortController.signal,
+      )
+
+      const first = await generator.next()
+      expect(first.done).toBe(false)
+
+      abortController.abort()
+      const afterAbort = await generator.next()
+      expect(afterAbort.done).toBe(true)
+    }, 10_000)
+
+    it('stops draining a post-wake page once the connection aborts', async () => {
+      await enrollService(['nerv'])
+      await actorStore.create(testDid)
+
+      const handler = createSubscribeRecordsHandler(ctx) as any
+      const abortController = new AbortController()
+      const generator = handler(
+        { did: testDid },
+        serviceCreds,
+        abortController.signal,
+      )
+
+      // Park before appending so the page is delivered by the post-wake
+      // drain, not the connect catch-up (see 'drains more than one page per
+      // wake' above).
+      const parked = new Promise<void>((resolve) =>
+        sequenceEvents.once('newListener', (event) => {
+          if (event === testDid) resolve()
+        }),
+      )
+      const firstPromise = generator.next()
+      await parked
+      await appendEvents(testDid, backlogBoundaries(120, 'nerv'))
+      sequenceEvents.emit(testDid)
+      const first = await firstPromise
+      expect(first.done).toBe(false)
+
+      // Aborting mid-page must end the stream, not deliver the page's tail.
+      abortController.abort()
+      const afterAbort = await generator.next()
+      expect(afterAbort.done).toBe(true)
+    }, 10_000)
+
+    it('ends the connection when a sequence read fails instead of replaying from zero', async () => {
+      await enrollService(['nerv'])
+      const failingCtx = {
+        ...ctx,
+        actorStore: {
+          exists: async () => true,
+          read: async () => {
+            throw new Error('MAGI sequence store unreachable')
+          },
+        },
+      }
+
+      const handler = createSubscribeRecordsHandler(failingCtx) as any
+      const abortController = new AbortController()
+      const generator = handler(
+        { did: testDid, cursor: 42 },
+        serviceCreds,
+        abortController.signal,
+      )
+
+      await expect(generator.next()).rejects.toThrow(
+        'MAGI sequence store unreachable',
+      )
+      abortController.abort()
+
+      // A swallowed read error used to report latestSeq 0, which made any
+      // live cursor look "ahead of latest" and silently replayed the client
+      // from the start of the log.
+      const resumedFromLatest = ctx.logger.warn.mock.calls.some(
+        ([, message]: [unknown, unknown]) =>
+          typeof message === 'string' &&
+          message.includes('cursor ahead of latest'),
+      )
+      expect(resumedFromLatest).toBe(false)
+    }, 5_000)
 
     it('rejects non-service credentials', async () => {
       const handler = createSubscribeRecordsHandler(ctx) as any

--- a/stratos-service/tests/subscription-handlers.integration.test.ts
+++ b/stratos-service/tests/subscription-handlers.integration.test.ts
@@ -541,12 +541,177 @@ describe('Subscription Handlers', () => {
       // A swallowed read error used to report latestSeq 0, which made any
       // live cursor look "ahead of latest" and silently replayed the client
       // from the start of the log.
-      const resumedFromLatest = ctx.logger.warn.mock.calls.some(
+      const resumedFromLatest = failingCtx.logger.warn.mock.calls.some(
         ([, message]: [unknown, unknown]) =>
           typeof message === 'string' &&
           message.includes('cursor ahead of latest'),
       )
       expect(resumedFromLatest).toBe(false)
+
+      // The failure must reach the operator log, not just the client, and
+      // must carry enough context to identify the actor.
+      const failureWarn = failingCtx.logger.warn.mock.calls.find(
+        ([, message]: [unknown, unknown]) => message === 'getLatestSeq failed',
+      )
+      expect(failureWarn?.[0]).toMatchObject({
+        did: testDid,
+        err: expect.any(Error),
+      })
+    }, 5_000)
+
+    it('rethrows a sequence read failure untouched when no logger is configured', async () => {
+      await enrollService(['nerv'])
+      const { logger: _logger, ...bareCtx } = ctx
+      const failingCtx = {
+        ...bareCtx,
+        actorStore: {
+          exists: async () => true,
+          read: async () => {
+            throw new Error('MAGI sequence store unreachable')
+          },
+        },
+      }
+
+      const handler = createSubscribeRecordsHandler(failingCtx) as any
+      const abortController = new AbortController()
+      const generator = handler(
+        { did: testDid, cursor: 42 },
+        serviceCreds,
+        abortController.signal,
+      )
+
+      // The warn hardening must not replace the store error with a crash on
+      // the missing logger.
+      await expect(generator.next()).rejects.toThrow(
+        'MAGI sequence store unreachable',
+      )
+      abortController.abort()
+    }, 5_000)
+
+    it('keeps the connection when only the oldest-seq probe fails, and warns', async () => {
+      await enrollService(['nerv'])
+      const flakyCtx = {
+        ...ctx,
+        actorStore: {
+          exists: async () => true,
+          read: async (_did: string, fn: (store: unknown) => unknown) =>
+            fn({
+              sequence: {
+                getLatestSeq: async () => 7,
+                getOldestSeq: async () => {
+                  throw new Error('MAGI oldest-seq probe offline')
+                },
+                getEventsSince: async () => [],
+              },
+            }),
+        },
+      }
+
+      const handler = createSubscribeRecordsHandler(flakyCtx) as any
+      const abortController = new AbortController()
+      // Pre-abort so the generator runs the connect sequence and returns
+      // without parking in the live-stream wait.
+      abortController.abort()
+      const generator = handler(
+        { did: testDid, cursor: 0 },
+        serviceCreds,
+        abortController.signal,
+      )
+
+      // A fabricated oldest of 0 suppresses the OutdatedCursor advisory
+      // (cursor 0 is not < 0), so the stream ends cleanly with no frames —
+      // it must not reject.
+      const first = await generator.next()
+      expect(first.done).toBe(true)
+
+      const oldestSeqWarn = flakyCtx.logger.warn.mock.calls.find(
+        ([, message]: [unknown, unknown]) => message === 'getOldestSeq failed',
+      )
+      expect(oldestSeqWarn?.[0]).toMatchObject({
+        did: testDid,
+        err: expect.any(Error),
+      })
+    }, 5_000)
+
+    it('ends the connection and warns when the catch-up page read fails', async () => {
+      await enrollService(['nerv'])
+      const failingCtx = {
+        ...ctx,
+        actorStore: {
+          exists: async () => true,
+          read: async (_did: string, fn: (store: unknown) => unknown) =>
+            fn({
+              sequence: {
+                getLatestSeq: async () => 5,
+                getOldestSeq: async () => 1,
+                getEventsSince: async () => {
+                  throw new Error('MAGI event page unreachable')
+                },
+              },
+            }),
+        },
+      }
+
+      const handler = createSubscribeRecordsHandler(failingCtx) as any
+      const abortController = new AbortController()
+      const generator = handler(
+        { did: testDid, cursor: 2 },
+        serviceCreds,
+        abortController.signal,
+      )
+
+      await expect(generator.next()).rejects.toThrow(
+        'MAGI event page unreachable',
+      )
+      abortController.abort()
+
+      const pageReadWarn = failingCtx.logger.warn.mock.calls.find(
+        ([, message]: [unknown, unknown]) =>
+          message === 'getEventsSince failed',
+      )
+      expect(pageReadWarn?.[0]).toMatchObject({
+        did: testDid,
+        cursor: 2,
+        err: expect.any(Error),
+      })
+    }, 5_000)
+
+    it('propagates benign and fatal read failures correctly with no logger', async () => {
+      await enrollService(['nerv'])
+      const { logger: _logger, ...bareCtx } = ctx
+      const failingCtx = {
+        ...bareCtx,
+        actorStore: {
+          exists: async () => true,
+          read: async (_did: string, fn: (store: unknown) => unknown) =>
+            fn({
+              sequence: {
+                getLatestSeq: async () => 7,
+                getOldestSeq: async () => {
+                  throw new Error('MAGI oldest-seq probe offline')
+                },
+                getEventsSince: async () => {
+                  throw new Error('MAGI event page unreachable')
+                },
+              },
+            }),
+        },
+      }
+
+      const handler = createSubscribeRecordsHandler(failingCtx) as any
+      const abortController = new AbortController()
+      const generator = handler(
+        { did: testDid, cursor: 0 },
+        serviceCreds,
+        abortController.signal,
+      )
+
+      // The oldest-seq failure stays benign (no crash on the missing logger)
+      // and the connection then dies on the page-read error, not a TypeError.
+      await expect(generator.next()).rejects.toThrow(
+        'MAGI event page unreachable',
+      )
+      abortController.abort()
     }, 5_000)
 
     it('rejects non-service credentials', async () => {


### PR DESCRIPTION
## Description

Two defects in the actor-mode `subscribeRecords` stream, both about honesty under load.

**It drained one page per wake.** The stream read a single page of ≤100 events, then waited for the next write signal or a 30-second timeout before reading again. An actor carrying a 10,000-event backlog drained at roughly 100 events per 30 seconds while writes were quiet — close to an hour of manufactured lag for the indexer and feedgen. A bucket brigade passing one bucket per shift change. Both the connect catch-up and the per-wake path now loop until a page comes back short.

**It fabricated zeros.** `getLatestSeq`/`getOldestSeq` swallowed store errors and returned `0`. A transient read failure made `getLatestSeq` report 0, which tripped the "cursor ahead of latest" branch and silently restarted the client from sequence 0 — a full replay storm the logs cheerfully recorded as "resuming from latest". An empty result and an error are different facts; collapsing them was the whole bug. Errors now end the connection, and clients resume by cursor, which is what the protocol is for.

The cursor-ahead reset branch itself is untouched — it is correct for genuine store resets. It just stopped being fed fabricated zeros.

Plan: `plans/011-subscription-drain-and-errors.md`

## :warning: A STOP condition fired — Step 1 was deliberately not done

The plan wanted the local `getEventsSince` replaced by the centralized `readSequencePage`. It was declined under the plan's own STOP condition, and an independent reviewer adjudicated and agreed.

The two readers disagree on `rev`: the local one passes it through unvalidated, while `rowToSeqEvent` blanks anything failing `/^[0-9a-z]{13}$/`. `rev` is copied onto the `#commit` wire frame, and **outgoing frames are never lexicon-validated** (`@atproto/xrpc-server` says so in a comment), so the swap would silently change emitted bytes.

The reviewer corrected the reasoning while upholding the outcome: there is no wire *contract* in the four fixture assertions that would have needed rewriting — no consumer reads `rev` at all (verified across feedgen, indexer and client). The reasons that do hold are risk-class separation (a P2 throughput fix should not change firehose bytes), and that the two readers have genuinely different requirements: `sequence-paging`'s validation exists because `getSequenceBounds` uses `rev` for truncation detection, where a malformed rev yields a wrong `OplogTruncated` verdict.

So the done-criterion `grep -c "store.sequence.getEventsSince" → 0` is **unmet by design**. In exchange, the divergence is now documented where the reader lives, so a later agent cannot dedupe it blind. Unification is deferred to plan 015 (#129).

## Testing

5 new cases. The drain tests assert the stream **parks** after draining (zero further store reads), not merely that events arrive — an `if (false) break` mutant delivers everything correctly while converting an idle subscription into a hot re-read spin, which delivery-only assertions cannot see. Timeouts are set well under 30s so a regression fails fast rather than hanging CI; the suite runs in ~460ms.

Scoped mutation: **zero survivors** on changed lines. Remaining nearby survivors sit on preserved code — the `exists()` guards the plan requires keeping, and the frozen `rev` mapping.

## Review notes (opus review: 0 critical, 2 major, 2 minor, 2 nit)

Major 1 (the undocumented divergence) is fixed above. Major 2 is an operational consequence rather than a defect in this diff, and it belongs on #128/#129's docket:

**The full-backlog burst will trip consumers' bounded queues.** The tightest bound is the **indexer's**, not the feedgen's: `ACTOR_SYNC_QUEUE_PER_ACTOR` defaults to **10** frames (`stratos-indexer/src/config.ts:36`, wired via `sync-manager.ts:89`, enforced at `actor-syncer.ts:266-272`); 1000 is the feedgen's `DEFAULT_MAX_QUEUE_SIZE`. Enqueue is synchronous on `onmessage` while the drain is async, so any actor with more retained events than the bound overflows routinely, where before connect delivered ≤100 frames. And it does not converge into a sawtooth: `reconnectAttempts` resets only after 30s of stable connection (`DEFAULT_STABILITY_RESET_MS`), each overflow cycle dies inside that window, and at `ACTOR_SYNC_RECONNECT_MAX_ATTEMPTS` (default 20) the syncer stops reconnecting — a **hard stall until process restart**. `plans/README.md` predicted the burst and required plan 008 to land first; it has. The recommended direction is backpressure rather than a bigger bound; see #129 §R2.

Also fixed here: a test that could silently stop testing its own property if catch-up ever won a race with the appending writer. It now waits for the generator to actually park.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Subscription streams now process all available backlog pages when connecting or waking.
  * Events outside the requested range are correctly filtered.
  * Sequence-store read failures now surface instead of appearing as empty results.
  * Aborted subscription drains are handled cleanly without replaying cursors.
  * Streams now correctly pause after all available events have been delivered.

* **Tests**
  * Added coverage for multi-page backlog draining, stream parking, filtering, abort handling, and read-failure propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
