### PR TITLE
fix(indexer): cool down and resume instead of abandoning actor sync

### DIFF
--- a/stratos-indexer/src/config.ts
+++ b/stratos-indexer/src/config.ts
@@ -71,6 +71,11 @@ const envSchema = z
       .int()
       .positive()
       .default(20),
+    ACTOR_SYNC_RECONNECT_COOLDOWN_MS: z.coerce
+      .number()
+      .int()
+      .positive()
+      .default(300000),
     BACKGROUND_QUEUE_CONCURRENCY: z.coerce
       .number()
       .int()
@@ -158,6 +163,8 @@ export interface WorkerConfig {
   actorSyncReconnectJitterMs: number
   /** Max attempts to reconnect an actor before giving up */
   actorSyncReconnectMaxAttempts: number
+  /** Cool-down before a fresh reconnect series after attempts are exhausted */
+  actorSyncReconnectCooldownMs: number
   /** Concurrency for the @atproto/bsky background indexer queue */
   backgroundQueueConcurrency: number
   /** Max size of the background indexer queue */
@@ -201,6 +208,7 @@ export function loadConfig(): IndexerConfig {
       actorSyncReconnectMaxDelayMs: env.ACTOR_SYNC_RECONNECT_MAX_DELAY_MS,
       actorSyncReconnectJitterMs: env.ACTOR_SYNC_RECONNECT_JITTER_MS,
       actorSyncReconnectMaxAttempts: env.ACTOR_SYNC_RECONNECT_MAX_ATTEMPTS,
+      actorSyncReconnectCooldownMs: env.ACTOR_SYNC_RECONNECT_COOLDOWN_MS,
       backgroundQueueConcurrency: env.BACKGROUND_QUEUE_CONCURRENCY,
       backgroundQueueMaxSize: env.BACKGROUND_QUEUE_MAX_SIZE,
     },

--- a/stratos-indexer/src/indexer.ts
+++ b/stratos-indexer/src/indexer.ts
@@ -1,6 +1,7 @@
 import {
   DefaultLexiconProvider,
   type LexiconProvider,
+  StratosError,
 } from '@northskysocial/stratos-core'
 import type { IndexerConfig } from './config.js'
 import type { Database } from '@atproto/bsky'
@@ -122,7 +123,13 @@ export class Indexer {
       onReferencedActorBackfill: (did: string, opts: BackfillOptions) =>
         this.backfillReferencedActor(did, opts),
       onError: (err: Error) =>
-        console.error({ err: err.message }, 'sync manager error'),
+        console.error(
+          {
+            err: err.message,
+            code: err instanceof StratosError ? err.code : undefined,
+          },
+          'sync manager error',
+        ),
     })
 
     await this.runAllBackfills(indexingService, background, backfillOpts)

--- a/stratos-indexer/src/sync/actor-syncer.ts
+++ b/stratos-indexer/src/sync/actor-syncer.ts
@@ -8,7 +8,6 @@ import type { PostTable, StratosIndexerSchema } from '../storage/schema.ts'
 const STRATOS_POST_COLLECTION = 'zone.stratos.feed.post'
 const INDEX_TRACE_WARN_LAG_MS = 5_000
 const DEFAULT_STABILITY_RESET_MS = 30_000
-const RECONNECT_COOLDOWN_MS = 300_000
 
 export interface ActorQueue {
   pending: Uint8Array[]
@@ -34,6 +33,7 @@ export interface ActorSyncerOptions {
   reconnectMaxDelayMs: number
   reconnectJitterMs: number
   reconnectMaxAttempts: number
+  reconnectCooldownMs: number
   onReferencedActor?: (did: string) => void
   onHandleNeeded?: (did: string) => void
   onError?: (err: Error) => void
@@ -82,6 +82,7 @@ export class ActorSyncer {
   private stabilityTimer: ReturnType<typeof setTimeout> | null = null
   private reconnectAttempts = 0
   private intentionallyClosed = false
+  private coolingDown = false
   private queue: ActorQueue = { pending: [], draining: false }
   private lastMessageAt = Date.now()
 
@@ -120,6 +121,17 @@ export class ActorSyncer {
   }
 
   /**
+   * Check if the syncer is serving its reconnect cool-down.
+   * A cooling syncer receives no messages by design; idle eviction must not
+   * mistake that silence for a stale connection.
+   *
+   * @returns True while the cool-down timer is pending.
+   */
+  public isCoolingDown(): boolean {
+    return this.coolingDown
+  }
+
+  /**
    * Start the actor synchronization process.
    * Initiates the WebSocket connection and begins processing messages.
    */
@@ -134,6 +146,7 @@ export class ActorSyncer {
    */
   public stop(): void {
     this.intentionallyClosed = true
+    this.coolingDown = false
     this.clearStabilityTimer()
     if (this.reconnectTimer) {
       clearTimeout(this.reconnectTimer)
@@ -220,10 +233,21 @@ export class ActorSyncer {
         ),
       )
       this.reconnectAttempts = 0
+      this.coolingDown = true
+      // Jitter spreads the resumes so cooled actors do not reconnect in
+      // lockstep after a shared outage.
+      const cooldownDelay =
+        this.options.reconnectCooldownMs +
+        Math.random() * this.options.reconnectJitterMs
       this.reconnectTimer = setTimeout(() => {
         this.reconnectTimer = null
+        this.coolingDown = false
+        console.info(
+          { did: this.did },
+          'actor sync cool-down ended; resuming connection attempts',
+        )
         this.connect()
-      }, RECONNECT_COOLDOWN_MS)
+      }, cooldownDelay)
       return
     }
 

--- a/stratos-indexer/src/sync/actor-syncer.ts
+++ b/stratos-indexer/src/sync/actor-syncer.ts
@@ -8,6 +8,7 @@ import type { PostTable, StratosIndexerSchema } from '../storage/schema.ts'
 const STRATOS_POST_COLLECTION = 'zone.stratos.feed.post'
 const INDEX_TRACE_WARN_LAG_MS = 5_000
 const DEFAULT_STABILITY_RESET_MS = 30_000
+const RECONNECT_COOLDOWN_MS = 300_000
 
 export interface ActorQueue {
   pending: Uint8Array[]
@@ -210,9 +211,19 @@ export class ActorSyncer {
 
     this.reconnectAttempts++
     if (this.reconnectAttempts > this.options.reconnectMaxAttempts) {
+      // Abandoning the actor would strand it until a process restart: nothing
+      // else revives a stopped syncer. Back off hard, then start over.
       this.options.onError?.(
-        new Error(`Max reconnect attempts reached for actor ${this.did}`),
+        new StratosError(
+          `Max reconnect attempts reached for actor ${this.did}; cooling down`,
+          'ACTOR_SYNC_COOLDOWN',
+        ),
       )
+      this.reconnectAttempts = 0
+      this.reconnectTimer = setTimeout(() => {
+        this.reconnectTimer = null
+        this.connect()
+      }, RECONNECT_COOLDOWN_MS)
       return
     }
 

--- a/stratos-indexer/src/sync/stratos-sync.ts
+++ b/stratos-indexer/src/sync/stratos-sync.ts
@@ -17,6 +17,7 @@ export interface StratosActorSyncOptions {
   reconnectMaxDelayMs: number
   reconnectJitterMs: number
   reconnectMaxAttempts: number
+  reconnectCooldownMs: number
 }
 
 export interface StratosSyncConfig {
@@ -49,6 +50,7 @@ const DEFAULT_ACTOR_SYNC_OPTIONS: StratosActorSyncOptions = {
   reconnectMaxDelayMs: 60000,
   reconnectJitterMs: 500,
   reconnectMaxAttempts: 10,
+  reconnectCooldownMs: 300_000,
 }
 
 const SERVICE_RECONNECT_BASE_DELAY_MS = 1000
@@ -488,6 +490,7 @@ export class StratosActorSync {
       reconnectMaxDelayMs: this.options.reconnectMaxDelayMs,
       reconnectJitterMs: this.options.reconnectJitterMs,
       reconnectMaxAttempts: this.options.reconnectMaxAttempts,
+      reconnectCooldownMs: this.options.reconnectCooldownMs,
       onReferencedActor: this.onReferencedActor,
       onHandleNeeded: this.onHandleNeeded,
       onError: this.onError,
@@ -530,9 +533,13 @@ export class StratosActorSync {
     const now = Date.now()
     const entries = Array.from(this.syncers.entries())
     // Find connections that haven't received a message in a while
+    // A cooling syncer is silent by design and holds no socket. Evicting it
+    // would discard the served cool-down and rebuild it with a fresh attempt
+    // counter, so the cool-down would never complete under connection pressure.
     const idle = entries
       .filter(
         ([, syncer]) =>
+          !syncer.isCoolingDown() &&
           now - syncer.getLastMessageAt() > this.options.idleEvictionMs,
       )
       .sort((a, b) => a[1].getLastMessageAt() - b[1].getLastMessageAt())

--- a/stratos-indexer/src/sync/stratos-sync.ts
+++ b/stratos-indexer/src/sync/stratos-sync.ts
@@ -2,7 +2,7 @@ import { decodeFirst } from '@atcute/cbor'
 import { Kysely } from 'kysely'
 import { StratosError } from '@northskysocial/stratos-core'
 import type { CursorManager } from '../storage/cursor-manager.ts'
-import { ActorSyncer } from './actor-syncer.ts'
+import { ActorSyncer, type ActorQueue } from './actor-syncer.ts'
 import type { StratosIndexerSchema } from '../storage/schema.ts'
 
 export interface StratosActorSyncOptions {
@@ -54,6 +54,7 @@ const DEFAULT_ACTOR_SYNC_OPTIONS: StratosActorSyncOptions = {
 const SERVICE_RECONNECT_BASE_DELAY_MS = 1000
 const SERVICE_RECONNECT_MAX_DELAY_MS = 30000
 const SERVICE_STABILITY_RESET_MS = 30000
+const SERVICE_STREAM_MAX_QUEUE = 1_000
 
 // --- Service-level enrollment stream ---
 
@@ -66,6 +67,7 @@ export class StratosServiceSubscription {
   private reconnectAttempt = 0
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null
   private stabilityTimer: ReturnType<typeof setTimeout> | null = null
+  private queue: ActorQueue = { pending: [], draining: false }
 
   constructor(
     private config: StratosSyncConfig,
@@ -95,6 +97,7 @@ export class StratosServiceSubscription {
   stop(): void {
     this.running = false
     this.clearStabilityTimer()
+    this.resetQueue()
     if (this.reconnectTimer) {
       clearTimeout(this.reconnectTimer)
       this.reconnectTimer = null
@@ -112,6 +115,8 @@ export class StratosServiceSubscription {
   private connect(): void {
     if (!this.running) return
 
+    this.resetQueue()
+
     const wsUrl = buildWsUrl(this.config.stratosServiceUrl, {
       syncToken: this.config.syncToken,
     })
@@ -124,7 +129,7 @@ export class StratosServiceSubscription {
     })
 
     this.ws.onmessage = (e: MessageEvent) => {
-      void this.handleMessage(new Uint8Array(e.data as ArrayBuffer))
+      this.enqueueMessage(new Uint8Array(e.data as ArrayBuffer))
     }
 
     this.ws.onerror = (e: Event & { error?: unknown }) => {
@@ -147,10 +152,68 @@ export class StratosServiceSubscription {
     this.ws.onclose = () => {
       this.ws = null
       this.clearStabilityTimer()
+      this.resetQueue()
       if (this.running) {
         this.scheduleReconnect()
       }
     }
+  }
+
+  /**
+   * Queue an enrollment frame and start draining if no drain is in flight.
+   * Enrollment events are order-sensitive (enroll → unenroll, boundary
+   * changes), so frames are applied one at a time rather than dispatched
+   * concurrently off the socket callback.
+   * @param data - The raw frame data.
+   * @private
+   */
+  private enqueueMessage(data: Uint8Array): void {
+    const queue = this.queue
+    if (queue.pending.length >= SERVICE_STREAM_MAX_QUEUE) {
+      this.onError?.(
+        new StratosError(
+          'enrollment stream queue overflow',
+          'SERVICE_STREAM_OVERFLOW',
+        ),
+      )
+      this.resetQueue()
+      this.ws?.close()
+      return
+    }
+
+    queue.pending.push(data)
+    if (!queue.draining) {
+      void this.drainQueue(queue)
+    }
+  }
+
+  /**
+   * Apply queued enrollment frames in arrival order.
+   * @param queue - The queue generation this drain owns.
+   * @private
+   */
+  private async drainQueue(queue: ActorQueue): Promise<void> {
+    queue.draining = true
+    try {
+      while (queue.pending.length > 0) {
+        const data = queue.pending.shift()
+        if (!data) continue
+        await this.handleMessage(data)
+      }
+    } finally {
+      queue.draining = false
+    }
+  }
+
+  /**
+   * Abandon the current queue generation. An in-flight drain keeps draining
+   * the object it captured, which is now empty, so a fresh socket never
+   * replays frames the previous one already queued.
+   * @private
+   */
+  private resetQueue(): void {
+    this.queue.pending = []
+    this.queue = { pending: [], draining: false }
   }
 
   /**

--- a/stratos-indexer/src/sync/stratos-sync.ts
+++ b/stratos-indexer/src/sync/stratos-sync.ts
@@ -123,18 +123,19 @@ export class StratosServiceSubscription {
       syncToken: this.config.syncToken,
     })
 
-    this.ws = new WebSocket(wsUrl)
-    this.ws.binaryType = 'arraybuffer'
+    const ws = new WebSocket(wsUrl)
+    this.ws = ws
+    ws.binaryType = 'arraybuffer'
 
-    this.ws.addEventListener('open', () => {
+    ws.addEventListener('open', () => {
       this.armStabilityReset()
     })
 
-    this.ws.onmessage = (e: MessageEvent) => {
+    ws.onmessage = (e: MessageEvent) => {
       this.enqueueMessage(new Uint8Array(e.data as ArrayBuffer))
     }
 
-    this.ws.onerror = (e: Event & { error?: unknown }) => {
+    ws.onerror = (e: Event & { error?: unknown }) => {
       const errorMsg =
         e.error instanceof Error
           ? e.error.message
@@ -151,7 +152,10 @@ export class StratosServiceSubscription {
       )
     }
 
-    this.ws.onclose = () => {
+    ws.onclose = () => {
+      // A close event from a replaced socket must not tear down the
+      // active socket, its queue, or schedule an extra reconnect.
+      if (this.ws !== ws) return
       this.ws = null
       this.clearStabilityTimer()
       this.resetQueue()

--- a/stratos-indexer/src/sync/sync-manager.ts
+++ b/stratos-indexer/src/sync/sync-manager.ts
@@ -33,6 +33,7 @@ export interface StratosSyncManagerOptions {
       actorSyncReconnectMaxDelayMs: number
       actorSyncReconnectJitterMs: number
       actorSyncReconnectMaxAttempts: number
+      actorSyncReconnectCooldownMs: number
     }
     pds: {
       enrolledOnly: boolean
@@ -96,6 +97,7 @@ export class StratosSyncManager {
         reconnectMaxDelayMs: opts.config.worker.actorSyncReconnectMaxDelayMs,
         reconnectJitterMs: opts.config.worker.actorSyncReconnectJitterMs,
         reconnectMaxAttempts: opts.config.worker.actorSyncReconnectMaxAttempts,
+        reconnectCooldownMs: opts.config.worker.actorSyncReconnectCooldownMs,
       },
       (did) => {
         const background = opts.background as unknown as {

--- a/stratos-indexer/tests/actor-syncer.test.ts
+++ b/stratos-indexer/tests/actor-syncer.test.ts
@@ -53,6 +53,7 @@ function createSyncer(overrides: Partial<ActorSyncerOptions> = {}) {
     reconnectMaxDelayMs: 60_000,
     reconnectJitterMs: 0,
     reconnectMaxAttempts: MAX_ATTEMPTS,
+    reconnectCooldownMs: RECONNECT_COOLDOWN_MS,
     onError: (err) => errors.push(err),
     canStartSync: () => true,
     onSyncStarted: () => {},
@@ -124,6 +125,47 @@ describe('ActorSyncer reconnect cool-down', () => {
 
     vi.advanceTimersByTime(RECONNECT_COOLDOWN_MS * 3)
     expect(FakeWebSocket.instances).toHaveLength(connectionsBeforeStop)
+  })
+
+  it('reports isCoolingDown only while the cool-down timer is pending', () => {
+    const { syncer } = createSyncer()
+    syncer.start()
+    expect(syncer.isCoolingDown()).toBe(false)
+
+    exhaustAttempts()
+    expect(syncer.isCoolingDown()).toBe(true)
+
+    vi.advanceTimersByTime(RECONNECT_COOLDOWN_MS)
+    expect(syncer.isCoolingDown()).toBe(false)
+
+    syncer.stop()
+  })
+
+  it('clears isCoolingDown on stop', () => {
+    const { syncer } = createSyncer()
+    syncer.start()
+
+    exhaustAttempts()
+    expect(syncer.isCoolingDown()).toBe(true)
+
+    syncer.stop()
+    expect(syncer.isCoolingDown()).toBe(false)
+  })
+
+  it('honors a configured cool-down duration', () => {
+    const { syncer } = createSyncer({ reconnectCooldownMs: 5_000 })
+    syncer.start()
+
+    exhaustAttempts()
+    const connectionsBeforeCooldown = FakeWebSocket.instances.length
+
+    vi.advanceTimersByTime(4_999)
+    expect(FakeWebSocket.instances).toHaveLength(connectionsBeforeCooldown)
+
+    vi.advanceTimersByTime(1)
+    expect(FakeWebSocket.instances).toHaveLength(connectionsBeforeCooldown + 1)
+
+    syncer.stop()
   })
 
   it('restarts the backoff series at the base delay after a cool-down', () => {

--- a/stratos-indexer/tests/actor-syncer.test.ts
+++ b/stratos-indexer/tests/actor-syncer.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { StratosError } from '@northskysocial/stratos-core'
+import type { CursorManager } from '../src/index.js'
+import {
+  ActorSyncer,
+  type ActorSyncerOptions,
+} from '../src/sync/actor-syncer.js'
+
+const RECONNECT_COOLDOWN_MS = 300_000
+const RECONNECT_BASE_DELAY_MS = 1_000
+const MAX_ATTEMPTS = 3
+
+class FakeWebSocket {
+  static instances: FakeWebSocket[] = []
+  static OPEN = 1
+  readyState = 0
+  binaryType = ''
+  onopen: (() => void) | null = null
+  onmessage: ((e: { data: ArrayBuffer }) => void) | null = null
+  onerror: ((e: Event & { error?: unknown }) => void) | null = null
+  onclose: (() => void) | null = null
+
+  constructor(public url: string) {
+    FakeWebSocket.instances.push(this)
+  }
+
+  close(): void {
+    if (this.readyState === 3) return
+    this.readyState = 3
+    this.onclose?.()
+  }
+
+  open(): void {
+    this.readyState = 1
+    this.onopen?.()
+  }
+}
+
+function createSyncer(overrides: Partial<ActorSyncerOptions> = {}) {
+  const errors: Error[] = []
+  const cursorManager = {
+    getStratosCursor: vi.fn(() => undefined),
+    updateStratosCursor: vi.fn(),
+    removeStratosCursor: vi.fn(),
+  } as unknown as CursorManager
+
+  const syncer = new ActorSyncer('did:plc:usagi', {} as never, cursorManager, {
+    stratosServiceUrl: 'http://localhost:2583',
+    syncToken: 'moon-prism-power',
+    maxActorQueueSize: 10,
+    drainDelayMs: 1,
+    reconnectBaseDelayMs: RECONNECT_BASE_DELAY_MS,
+    reconnectMaxDelayMs: 60_000,
+    reconnectJitterMs: 0,
+    reconnectMaxAttempts: MAX_ATTEMPTS,
+    onError: (err) => errors.push(err),
+    canStartSync: () => true,
+    onSyncStarted: () => {},
+    onSyncFinished: () => {},
+    ...overrides,
+  })
+
+  return { syncer, errors }
+}
+
+/** Fail every connection until the attempt cap is exhausted. */
+function exhaustAttempts(): void {
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    FakeWebSocket.instances.at(-1)!.close()
+    vi.advanceTimersByTime(RECONNECT_BASE_DELAY_MS * Math.pow(2, attempt - 1))
+  }
+  FakeWebSocket.instances.at(-1)!.close()
+}
+
+describe('ActorSyncer reconnect cool-down', () => {
+  let originalWebSocket: typeof globalThis.WebSocket
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    FakeWebSocket.instances = []
+    originalWebSocket = globalThis.WebSocket
+    globalThis.WebSocket = FakeWebSocket as unknown as typeof WebSocket
+  })
+
+  afterEach(() => {
+    globalThis.WebSocket = originalWebSocket
+    vi.useRealTimers()
+  })
+
+  it('reports a coded cool-down error and reconnects instead of giving up', () => {
+    const { syncer, errors } = createSyncer()
+    syncer.start()
+
+    exhaustAttempts()
+
+    const cooldownErrors = errors.filter(
+      (err) =>
+        err instanceof StratosError && err.code === 'ACTOR_SYNC_COOLDOWN',
+    )
+    expect(cooldownErrors).toHaveLength(1)
+    expect(cooldownErrors[0].message).toContain('did:plc:usagi')
+
+    const connectionsBeforeCooldown = FakeWebSocket.instances.length
+    expect(connectionsBeforeCooldown).toBe(MAX_ATTEMPTS + 1)
+
+    vi.advanceTimersByTime(RECONNECT_COOLDOWN_MS - 1)
+    expect(FakeWebSocket.instances).toHaveLength(connectionsBeforeCooldown)
+
+    vi.advanceTimersByTime(1)
+    expect(FakeWebSocket.instances).toHaveLength(connectionsBeforeCooldown + 1)
+
+    syncer.stop()
+  })
+
+  it('cancels the cool-down timer on stop', () => {
+    const { syncer } = createSyncer()
+    syncer.start()
+
+    exhaustAttempts()
+    const connectionsBeforeStop = FakeWebSocket.instances.length
+
+    syncer.stop()
+    expect(vi.getTimerCount()).toBe(0)
+
+    vi.advanceTimersByTime(RECONNECT_COOLDOWN_MS * 3)
+    expect(FakeWebSocket.instances).toHaveLength(connectionsBeforeStop)
+  })
+
+  it('restarts the backoff series at the base delay after a cool-down', () => {
+    const { syncer } = createSyncer()
+    syncer.start()
+
+    exhaustAttempts()
+    vi.advanceTimersByTime(RECONNECT_COOLDOWN_MS)
+
+    const connectionsAfterCooldown = FakeWebSocket.instances.length
+    FakeWebSocket.instances.at(-1)!.close()
+
+    vi.advanceTimersByTime(RECONNECT_BASE_DELAY_MS - 1)
+    expect(FakeWebSocket.instances).toHaveLength(connectionsAfterCooldown)
+
+    vi.advanceTimersByTime(1)
+    expect(FakeWebSocket.instances).toHaveLength(connectionsAfterCooldown + 1)
+
+    syncer.stop()
+  })
+})

--- a/stratos-indexer/tests/stratos-sync.test.ts
+++ b/stratos-indexer/tests/stratos-sync.test.ts
@@ -1,6 +1,8 @@
 import { StratosError } from '@northskysocial/stratos-core'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { CursorManager } from '../src/index.js'
 import { StratosServiceSubscription } from '../src/index.js'
+import { StratosActorSync } from '../src/sync/stratos-sync.js'
 
 const SERVICE_STREAM_MAX_QUEUE = 1_000
 
@@ -173,5 +175,76 @@ describe('StratosServiceSubscription enrollment stream', () => {
     expect(FakeWebSocket.instances.length).toBeGreaterThan(1)
 
     subscription.stop()
+  })
+})
+
+describe('StratosActorSync idle eviction', () => {
+  let originalWebSocket: typeof globalThis.WebSocket
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    FakeWebSocket.instances = []
+    originalWebSocket = globalThis.WebSocket
+    globalThis.WebSocket = FakeWebSocket as unknown as typeof WebSocket
+  })
+
+  afterEach(() => {
+    globalThis.WebSocket = originalWebSocket
+    vi.useRealTimers()
+  })
+
+  function createActorSync() {
+    const cursorManager = {
+      getStratosCursor: vi.fn(() => undefined),
+      updateStratosCursor: vi.fn(),
+      removeStratosCursor: vi.fn(),
+    } as unknown as CursorManager
+
+    return new StratosActorSync(
+      {} as never,
+      { stratosServiceUrl: 'http://localhost:2583', syncToken: 'lain-navi' },
+      cursorManager,
+      () => {},
+      undefined,
+      {
+        maxConnections: 2,
+        connectDelayMs: 1,
+        idleEvictionMs: 100,
+        reconnectBaseDelayMs: 1,
+        reconnectMaxDelayMs: 1,
+        reconnectJitterMs: 0,
+        reconnectMaxAttempts: 1,
+        reconnectCooldownMs: 300_000,
+      },
+    )
+  }
+
+  it('spares a cooling syncer and evicts a genuinely idle one instead', () => {
+    const sync = createActorSync()
+    sync.start()
+
+    // Fill both connection slots, then queue a waiter to arm eviction.
+    sync.addActor('did:plc:motoko')
+    vi.advanceTimersByTime(1)
+    sync.addActor('did:plc:batou')
+    vi.advanceTimersByTime(1)
+    sync.addActor('did:plc:togusa')
+    expect(FakeWebSocket.instances).toHaveLength(2)
+
+    // Exhaust motoko's single reconnect attempt to start its cool-down.
+    FakeWebSocket.instances[0].close()
+    vi.advanceTimersByTime(1)
+    FakeWebSocket.instances.at(-1)!.close()
+
+    // The eviction sweep runs at 10s. Motoko is the oldest-silent syncer,
+    // but it is cooling; the fence must divert eviction to idle batou.
+    vi.advanceTimersByTime(10_000)
+
+    const active = sync.getActiveActors()
+    expect(active).toContain('did:plc:motoko')
+    expect(active).toContain('did:plc:togusa')
+    expect(active).not.toContain('did:plc:batou')
+
+    sync.stop()
   })
 })

--- a/stratos-indexer/tests/stratos-sync.test.ts
+++ b/stratos-indexer/tests/stratos-sync.test.ts
@@ -1,0 +1,177 @@
+import { StratosError } from '@northskysocial/stratos-core'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { StratosServiceSubscription } from '../src/index.js'
+
+const SERVICE_STREAM_MAX_QUEUE = 1_000
+
+const ACTORS = ['did:plc:motoko', 'did:plc:batou', 'did:plc:togusa']
+
+class FakeWebSocket {
+  static instances: FakeWebSocket[] = []
+  static OPEN = 1
+  readyState = 0
+  binaryType = ''
+  onmessage: ((e: { data: ArrayBuffer }) => void) | null = null
+  onerror: ((e: Event & { error?: unknown }) => void) | null = null
+  onclose: (() => void) | null = null
+  close = vi.fn(() => {
+    if (this.readyState === 3) return
+    this.readyState = 3
+    this.onclose?.()
+  })
+  private openListeners: Array<() => void> = []
+
+  constructor(public url: string) {
+    FakeWebSocket.instances.push(this)
+  }
+
+  addEventListener(type: string, cb: () => void): void {
+    if (type === 'open') this.openListeners.push(cb)
+  }
+
+  open(): void {
+    this.readyState = 1
+    for (const cb of this.openListeners) cb()
+  }
+
+  deliver(frame: Uint8Array): void {
+    this.onmessage?.({ data: frame.buffer as ArrayBuffer })
+  }
+}
+
+/** A frame the stubbed handler can identify by its actor index. */
+function frameFor(actorIndex: number): Uint8Array {
+  return new Uint8Array([actorIndex])
+}
+
+function createSubscription() {
+  const errors: Error[] = []
+  const subscription = new StratosServiceSubscription(
+    { stratosServiceUrl: 'http://localhost:2583', syncToken: 'lain-navi' },
+    { onEnroll: vi.fn(), onUnenroll: vi.fn() },
+    (err) => errors.push(err),
+  )
+  return { subscription, errors }
+}
+
+/** Replace the frame handler so a test can control when a frame finishes. */
+function stubHandler(
+  subscription: StratosServiceSubscription,
+  handler: (data: Uint8Array) => Promise<void>,
+): void {
+  ;(subscription as unknown as Record<string, unknown>).handleMessage = handler
+}
+
+function pendingFrames(subscription: StratosServiceSubscription): Uint8Array[] {
+  const queue = (subscription as unknown as Record<string, unknown>).queue as {
+    pending: Uint8Array[]
+  }
+  return queue.pending
+}
+
+describe('StratosServiceSubscription enrollment stream', () => {
+  let originalWebSocket: typeof globalThis.WebSocket
+
+  beforeEach(() => {
+    FakeWebSocket.instances = []
+    originalWebSocket = globalThis.WebSocket
+    globalThis.WebSocket = FakeWebSocket as unknown as typeof WebSocket
+  })
+
+  afterEach(() => {
+    globalThis.WebSocket = originalWebSocket
+    vi.useRealTimers()
+  })
+
+  it('applies frames in arrival order even when earlier frames are slower', async () => {
+    const { subscription } = createSubscription()
+    const applied: string[] = []
+    const handlerDelaysMs = [30, 10, 0]
+
+    stubHandler(subscription, async (data) => {
+      const actorIndex = data[0]
+      await new Promise((resolve) =>
+        setTimeout(resolve, handlerDelaysMs[actorIndex]),
+      )
+      applied.push(ACTORS[actorIndex])
+    })
+
+    subscription.start()
+    const socket = FakeWebSocket.instances[0]
+    for (let i = 0; i < ACTORS.length; i++) {
+      socket.deliver(frameFor(i))
+    }
+
+    await vi.waitFor(() => expect(applied).toHaveLength(ACTORS.length))
+    expect(applied).toEqual(ACTORS)
+
+    subscription.stop()
+  })
+
+  it('does not start a frame before the previous one settles', async () => {
+    const { subscription } = createSubscription()
+    const started: number[] = []
+    const finished: number[] = []
+    let releaseFirst: (() => void) | undefined
+
+    stubHandler(subscription, async (data) => {
+      const actorIndex = data[0]
+      started.push(actorIndex)
+      if (actorIndex === 0) {
+        await new Promise<void>((resolve) => {
+          releaseFirst = resolve
+        })
+      }
+      finished.push(actorIndex)
+    })
+
+    subscription.start()
+    const socket = FakeWebSocket.instances[0]
+    socket.deliver(frameFor(0))
+    socket.deliver(frameFor(1))
+    await Promise.resolve()
+
+    expect(started).toEqual([0])
+    expect(finished).toEqual([])
+
+    releaseFirst?.()
+    await vi.waitFor(() => expect(finished).toHaveLength(2))
+    expect(started).toEqual([0, 1])
+    expect(finished).toEqual([0, 1])
+
+    subscription.stop()
+  })
+
+  it('drops the queue and closes the socket on overflow', async () => {
+    vi.useFakeTimers()
+    const { subscription, errors } = createSubscription()
+    stubHandler(subscription, () => new Promise<void>(() => {}))
+
+    subscription.start()
+    const socket = FakeWebSocket.instances[0]
+
+    // The first frame is shifted into the stalled handler; the rest pile up.
+    for (let i = 0; i <= SERVICE_STREAM_MAX_QUEUE; i++) {
+      socket.deliver(frameFor(0))
+    }
+    await Promise.resolve()
+    expect(pendingFrames(subscription)).toHaveLength(SERVICE_STREAM_MAX_QUEUE)
+    expect(errors).toHaveLength(0)
+    expect(socket.close).not.toHaveBeenCalled()
+
+    socket.deliver(frameFor(1))
+
+    expect(errors).toHaveLength(1)
+    expect(errors[0]).toBeInstanceOf(StratosError)
+    expect((errors[0] as StratosError).code).toBe('SERVICE_STREAM_OVERFLOW')
+    expect(socket.close).toHaveBeenCalled()
+    expect(pendingFrames(subscription)).toHaveLength(0)
+
+    // The service-level reconnect is uncapped, so the stream resumes.
+    expect(vi.getTimerCount()).toBe(1)
+    vi.advanceTimersByTime(60_000)
+    expect(FakeWebSocket.instances.length).toBeGreaterThan(1)
+
+    subscription.stop()
+  })
+})

--- a/stratos-indexer/tests/stratos-sync.test.ts
+++ b/stratos-indexer/tests/stratos-sync.test.ts
@@ -176,6 +176,39 @@ describe('StratosServiceSubscription enrollment stream', () => {
 
     subscription.stop()
   })
+
+  it('ignores a late close event from a replaced socket', () => {
+    vi.useFakeTimers()
+    const { subscription } = createSubscription()
+    stubHandler(subscription, () => new Promise<void>(() => {}))
+
+    subscription.start()
+    const staleSocket = FakeWebSocket.instances[0]
+    // A real socket delivers its close event asynchronously. Detach the
+    // callback so stop() cannot fire it, then fire it late by hand.
+    const staleClose = staleSocket.onclose
+    staleSocket.onclose = null
+
+    subscription.stop()
+    subscription.start()
+    const activeSocket = FakeWebSocket.instances[1]
+    activeSocket.open()
+
+    // The first frame is shifted into the stalled handler; one stays pending.
+    activeSocket.deliver(frameFor(0))
+    activeSocket.deliver(frameFor(1))
+    expect(pendingFrames(subscription)).toHaveLength(1)
+
+    staleClose?.()
+
+    // The active socket, its queue, and the timer set must be untouched.
+    expect(subscription.isConnected()).toBe(true)
+    expect(pendingFrames(subscription)).toHaveLength(1)
+    vi.advanceTimersByTime(60_000)
+    expect(FakeWebSocket.instances).toHaveLength(2)
+
+    subscription.stop()
+  })
 })
 
 describe('StratosActorSync idle eviction', () => {


### PR DESCRIPTION
## Description

Two defects in the indexer's sync layer.

**A sentry that deserted its post.** The per-actor syncer gave up permanently after `reconnectMaxAttempts` — effectively **20**, not the module default of 10: `StratosSyncManager` always overrides it with `ACTOR_SYNC_RECONNECT_MAX_ATTEMPTS` (`config.ts:69-73`, wired in `sync-manager.ts:98`), giving a pre-surrender retry window of roughly 15 minutes. A Stratos outage outlasting that window exhausted the attempts, `onError` fired once, and that actor was **never indexed again until the process restarted**. The pool guaranteed the silence: its disconnect callback is a no-op commented "handled by ActorSyncer internal reconnect" — a comment that was simply untrue, because nothing revived a dead syncer. Exhausting the attempts now raises a loud `ACTOR_SYNC_COOLDOWN`, waits five minutes, and starts a fresh backoff series. That comment is true for the first time.

**An unserialized enrollment stream.** `void this.handleMessage(...)` straight off `onmessage`, so enroll→unenroll pairs and rapid boundary changes could apply out of order. It now queues and drains serially, using the queue idiom this package already had and tested. Overflow drops the queue *before* closing the socket, and the reset swaps in a fresh queue generation — so a drain wedged on a never-settling handler cannot leave every future socket enqueueing into a queue nobody drains.

Plan: `plans/016-indexer-sync-resilience.md`

## :rotating_light: While in these files we found the indexer has never worked

Out of scope for this PR, tracked for its own plan, and reported to the operator. Three independent breaks, each verified twice:

1. **Auth** — the indexer sends `syncToken` as a query param with no headers (`actor-syncer.ts:155-162`), but `createSubscribeAuthVerifier` requires a `Bearer` JWT and documents that query-param tokens "have been removed" (`stratos-service/src/infra/auth/verifiers.ts:620,633-634`). The WebSocket upgrade is rejected before any frame arrives.
2. **CBOR decode** — `@atcute/cbor`'s `decodeFirst` returns a `[value, remainder]` **tuple**; the indexer reads `.t` off the array (`actor-syncer.ts:448`, `stratos-sync.ts:269`), so `processCommit` is unreachable and enrollment frames are ignored. Hidden from `tsc` by `as unknown as`. It was correct once — see `git show 84df95a^:stratos-indexer/src/stratos-sync.ts` (910-929).
3. **Read-path schema mismatch** — the indexer writes `post`/`stratos_record`; the AppView reads `stratos_post`/`stratos_post_boundary`.

`updateStratosCursor` is only reached from `processCommit`, so **no cursor has ever advanced**. The failure is completely silent: the indexer reports `isConnected() === true` and does nothing.

**Repair order matters.** Fixing auth + decode without the read path would write private, boundary-scoped post plaintext into bsky's public `post` table — same database, no boundary column, and a public search path matching on `post.text`. Full evidence chain and disposition in #129.

Note this PR's own ordering tests had to stub `handleMessage`, because a real enrollment frame cannot be delivered today. That is the clearest argument for prioritizing the repair.

## Also reported, not fixed (fenced by the plan)

The indexer shares the feedgen's pre-008 swallow-and-continue on commit-apply failures, **plus** an amplifier the feedgen no longer has: a failure skips its `updateStratosCursor`, but the next success advances the cursor *past* the failed seq. Permanently lost, with one `onError` to show for it. Same defect the feedgen fixed in `0b464db`. #129 §7 rules it needs its own plan.

## Testing

6 new tests across two new files; 5 verified failing against the old code (the sixth is a timer-leak guard). The indexer has **no Stryker config**, so the AGENTS.md mutation gate could not run for this package; none was created, as that is a separate decision.

## Review notes (opus review: 1 critical + 1 major, both pre-existing and out of scope; 3 minor, 2 nit)

The in-scope change is sound — both objectives met, every invariant the plan named preserved, and the reviewer judged the generation-swap reset a better answer to the overflow-vs-reconnect race than the plan's letter required.

Recorded: the cool-down timer is not `unref`'d where its sibling stability timer is, so a permanently-broken actor now always has one pending timer where it previously had none; serialization holds *within* a queue generation but not across one (unreachable here since the indexer's callbacks are synchronous — but live the moment a shared library inherits the feedgen's awaited ones, so #129 records it as an invariant); and the tests re-declare the source constants rather than importing them, so changing a constant would not fail them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection recovery after repeated synchronization failures with a five-minute cooldown and automatic retry.
  * Ensured incoming service messages are processed sequentially and in arrival order.
  * Added safeguards for excessive queued messages, including error reporting and connection reset.
* **Tests**
  * Added coverage for cooldown recovery, retry cancellation, ordered message processing, and queue overflow handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
