### PR TITLE
spaces/dpop credential binding

### DIFF
--- a/docs/client/api-reference.md
+++ b/docs/client/api-reference.md
@@ -147,15 +147,19 @@ Authorization: Bearer <access_token>
 
 ```http
 GET /xrpc/zone.stratos.space.getRecord?space=<at-uri>&repo=<did>&collection=<nsid>&rkey=<rkey>
-Authorization: Bearer <access_token> | Bearer <space-credential>
+Authorization: Bearer <access_token> | DPoP <space-credential>
+DPoP: <proof>   (required when presenting a space credential)
 Response: { "uri": "...", "cid": "...", "value": { ... } }
 ```
 
 Get a single record from a permissioned space (spec-shaped mirror of
 `com.atproto.space.getRecord`). Callable with standard user auth - the caller
 must be a member of the space - or with a space credential for that space (for
-syncing services). The record must belong to the requested space; records
-outside it (including records with no space) resolve to `RecordNotFound`.
+syncing services). A space credential is DPoP-key-bound (`cnf.jkt`): present it
+under the `DPoP` scheme with a per-request proof signed by the bound key and
+hash-bound to the credential (`ath`). The record must belong to the requested
+space; records outside it (including records with no space) resolve to
+`RecordNotFound`.
 
 ### Export Repository
 
@@ -220,6 +224,7 @@ enumerate paths, diff locally, and fetch misses.
 ```http
 POST /xrpc/zone.stratos.space.getSpaceCredential
 Authorization: DPoP <access_token>
+DPoP: <proof>
 Content-Type: application/json
 Body: { "space": "at://<space-did>/space/<type>/<skey>"[, "delegationToken": "<jwt>"][, "clientAttestation": "<jwt>"] }
 Response: { "credential": "<jwt>", "expiresAt": "<datetime>" }
@@ -229,7 +234,12 @@ Issues a multi-use space credential (JWT) for a space the caller is a member of.
 comes from the delegation token when supplied, otherwise from the DPoP session; membership
 is checked live against the enrollment store. Spaces configured with an app allow-list
 additionally require a valid client attestation whose attested `client_id` is listed. The
-credential is then accepted on read/sync endpoints as an alternative to standard auth.
+credential is bound to the caller's DPoP key (`cnf.jkt`, RFC 9449): on the delegation path
+the key comes from a standalone DPoP proof in the `DPoP` header, otherwise from the session
+proof key. When no key is available the request fails with `ProofRequired` (unbound
+credentials are minted only in development mode). The credential is then accepted on
+read/sync endpoints as an alternative to standard auth, presented under the `DPoP` scheme
+with a fresh proof per request.
 
 ## Record Types
 

--- a/lexicons/zone/stratos/space/getSpaceCredential.json
+++ b/lexicons/zone/stratos/space/getSpaceCredential.json
@@ -4,7 +4,7 @@
   "defs": {
     "main": {
       "type": "procedure",
-      "description": "Issue a space credential (JWT) for a space the caller is a member of. The credential is bearer-shaped and multi-use until it expires; it is signed by the space authority's signing key so any repo host can verify it without contacting the authority. Identity is resolved from a delegation token when provided, otherwise from the DPoP-authenticated user. Membership is checked live against the enrollment store. App-axis (client attestation) gating is enforced here: spaces configured with an app allow-list require a valid client attestation whose attested client_id is listed; spaces that are open ignore any attestation supplied.",
+      "description": "Issue a space credential (JWT) for a space the caller is a member of. The credential is multi-use until it expires and is bound to the caller's DPoP key (cnf.jkt, RFC 9449): it must be presented under the DPoP auth scheme with a per-request proof signed by that key. It is signed by the space authority's signing key so any repo host can verify it without contacting the authority. Identity is resolved from a delegation token when provided (a standalone DPoP proof in the DPoP header supplies the key to bind), otherwise from the DPoP-authenticated user (the session proof key is bound). Membership is checked live against the enrollment store. App-axis (client attestation) gating is enforced here: spaces configured with an app allow-list require a valid client attestation whose attested client_id is listed; spaces that are open ignore any attestation supplied.",
       "input": {
         "encoding": "application/json",
         "schema": {
@@ -64,6 +64,10 @@
         {
           "name": "ClientNotAllowed",
           "description": "A valid client attestation was supplied but its attested client_id is not in the space's app allow-list."
+        },
+        {
+          "name": "ProofRequired",
+          "description": "No DPoP key was available to bind the credential to: the delegation path requires a standalone DPoP proof in the DPoP header, and unbound credentials are refused outside development mode."
         }
       ]
     }

--- a/stratos-client/README.md
+++ b/stratos-client/README.md
@@ -242,23 +242,23 @@ URL. Record creation/deletion always has the corresponding action to the PDS rec
 
 ### Routing applies to
 
-| Operation                               | Routes to Stratos?                                                    |
-| --------------------------------------- | --------------------------------------------------------------------- |
-| `com.atproto.repo.getRecord`            | Yes (reads private records)                                           |
-| `com.atproto.repo.listRecords`          | Yes (lists private collections)                                       |
-| `com.atproto.repo.describeRepo`         | Yes (describes private repo)                                          |
-| `com.atproto.repo.createRecord`         | Yes (writes to Stratos)                                               |
-| `com.atproto.repo.deleteRecord`         | Yes (deletes from Stratos)                                            |
-| `com.atproto.repo.applyWrites`          | Yes (batch writes)                                                    |
-| `com.atproto.sync.getRecord`            | Yes (CAR export for verification)                                     |
-| `com.atproto.sync.listBlobs`            | Yes (lists blob CIDs)                                                 |
-| `zone.stratos.sync.getRepo`             | Yes (full repo export as CAR)                                         |
-| `zone.stratos.repo.importRepo`          | Yes (import repo from CAR)                                            |
-| `zone.stratos.sync.subscribeRecords`    | Yes (WebSocket firehose)                                              |
-| `zone.stratos.sync.listRepoOps`         | Yes (pull oplog; falls back to `listRecordPaths` on `OplogTruncated`) |
-| `zone.stratos.sync.listRecordPaths`     | Yes (full-state recovery enumeration)                                 |
-| `zone.stratos.space.getSpaceCredential` | Yes (mints a space credential accepted on read/sync endpoints)        |
-| `com.atproto.sync.getBlob`              | Yes (downloads blob content)                                          |
+| Operation                               | Routes to Stratos?                                                            |
+| --------------------------------------- | ----------------------------------------------------------------------------- |
+| `com.atproto.repo.getRecord`            | Yes (reads private records)                                                   |
+| `com.atproto.repo.listRecords`          | Yes (lists private collections)                                               |
+| `com.atproto.repo.describeRepo`         | Yes (describes private repo)                                                  |
+| `com.atproto.repo.createRecord`         | Yes (writes to Stratos)                                                       |
+| `com.atproto.repo.deleteRecord`         | Yes (deletes from Stratos)                                                    |
+| `com.atproto.repo.applyWrites`          | Yes (batch writes)                                                            |
+| `com.atproto.sync.getRecord`            | Yes (CAR export for verification)                                             |
+| `com.atproto.sync.listBlobs`            | Yes (lists blob CIDs)                                                         |
+| `zone.stratos.sync.getRepo`             | Yes (full repo export as CAR)                                                 |
+| `zone.stratos.repo.importRepo`          | Yes (import repo from CAR)                                                    |
+| `zone.stratos.sync.subscribeRecords`    | Yes (WebSocket firehose)                                                      |
+| `zone.stratos.sync.listRepoOps`         | Yes (pull oplog; falls back to `listRecordPaths` on `OplogTruncated`)         |
+| `zone.stratos.sync.listRecordPaths`     | Yes (full-state recovery enumeration)                                         |
+| `zone.stratos.space.getSpaceCredential` | Yes (mints a DPoP-key-bound space credential accepted on read/sync endpoints) |
+| `com.atproto.sync.getBlob`              | Yes (downloads blob content)                                                  |
 
 ---
 

--- a/stratos-client/src/lexicons.gen.ts
+++ b/stratos-client/src/lexicons.gen.ts
@@ -1076,7 +1076,7 @@ export const stratosLexicons: LexiconDoc[] = [
   "defs": {
     "main": {
       "type": "procedure",
-      "description": "Issue a space credential (JWT) for a space the caller is a member of. The credential is bearer-shaped and multi-use until it expires; it is signed by the space authority's signing key so any repo host can verify it without contacting the authority. Identity is resolved from a delegation token when provided, otherwise from the DPoP-authenticated user. Membership is checked live against the enrollment store. App-axis (client attestation) gating is enforced here: spaces configured with an app allow-list require a valid client attestation whose attested client_id is listed; spaces that are open ignore any attestation supplied.",
+      "description": "Issue a space credential (JWT) for a space the caller is a member of. The credential is multi-use until it expires and is bound to the caller's DPoP key (cnf.jkt, RFC 9449): it must be presented under the DPoP auth scheme with a per-request proof signed by that key. It is signed by the space authority's signing key so any repo host can verify it without contacting the authority. Identity is resolved from a delegation token when provided (a standalone DPoP proof in the DPoP header supplies the key to bind), otherwise from the DPoP-authenticated user (the session proof key is bound). Membership is checked live against the enrollment store. App-axis (client attestation) gating is enforced here: spaces configured with an app allow-list require a valid client attestation whose attested client_id is listed; spaces that are open ignore any attestation supplied.",
       "input": {
         "encoding": "application/json",
         "schema": {
@@ -1136,6 +1136,10 @@ export const stratosLexicons: LexiconDoc[] = [
         {
           "name": "ClientNotAllowed",
           "description": "A valid client attestation was supplied but its attested client_id is not in the space's app allow-list."
+        },
+        {
+          "name": "ProofRequired",
+          "description": "No DPoP key was available to bind the credential to: the delegation path requires a standalone DPoP proof in the DPoP header, and unbound credentials are refused outside development mode."
         }
       ]
     }

--- a/stratos-service/src/api/types.ts
+++ b/stratos-service/src/api/types.ts
@@ -12,6 +12,12 @@ export interface HandlerAuth {
      * still filtered per-record by the existing boundary gate.
      */
     spaceUri?: string
+    /**
+     * Present for DPoP user auth: the SHA-256 JWK thumbprint of the caller's
+     * DPoP key (RFC 9449 `jkt`). Used to bind minted space credentials to the
+     * requesting key via `cnf.jkt`.
+     */
+    jkt?: string
   }
 }
 

--- a/stratos-service/src/api/util.ts
+++ b/stratos-service/src/api/util.ts
@@ -171,6 +171,7 @@ export function createXrpcHandler<
       did: string | undefined
       requestId: string
       fullInput?: HandlerInput
+      req?: HandlerContext['req']
     }) => Promise<unknown>
     requireAuth?: boolean
   },
@@ -204,6 +205,7 @@ export function createXrpcHandler<
         did,
         requestId,
         fullInput: input,
+        req: handlerCtx.req,
       })
 
       logRequestSuccess(ctx, {

--- a/stratos-service/src/context.ts
+++ b/stratos-service/src/context.ts
@@ -44,6 +44,7 @@ import {
   type IdentityContext,
 } from './context-types.js'
 import { createAuthVerifiers } from './infra/auth/verifiers.js'
+import { replayStoreFromCache } from './infra/auth/replay-store.js'
 import { JwksResolver } from './infra/auth/jwks-resolver.js'
 import { ExternalAllowListProvider } from './features/enrollment/internal/allow-list.js'
 import { RedisCache } from './infra/storage/redis-cache.js'
@@ -218,6 +219,10 @@ async function initCoreServices(
     logger,
   )
 
+  const cache = cfg.enrollment.valkeyUrl
+    ? new RedisCache(cfg.enrollment.valkeyUrl)
+    : undefined
+
   const { dpopVerifier, authVerifier, lexiconProvider, xrpcServer } = initAuth(
     cfg,
     idResolver,
@@ -226,12 +231,9 @@ async function initCoreServices(
     adminUserStore,
     enrollmentCtx.allowListProvider,
     signingKey,
+    cache,
     logger,
   )
-
-  const cache = cfg.enrollment.valkeyUrl
-    ? new RedisCache(cfg.enrollment.valkeyUrl)
-    : undefined
 
   const boundaryResolver = cfg.enrollment.valkeyUrl
     ? new MigratingBoundaryResolver({
@@ -307,6 +309,7 @@ async function initIdentity(
  * @param adminUserStore - Store of admins granted at runtime.
  * @param allowListProvider - Optional provider for external allowlists.
  * @param signingKey - This service's signing keypair (space-credential authority).
+ * @param cache - Process cache backing the DPoP-proof replay store, if any.
  * @param logger - Logger instance for logging application events.
  * @returns Initialized authentication components.
  */
@@ -318,6 +321,7 @@ function initAuth(
   adminUserStore: AppContext['adminUserStore'],
   allowListProvider: ExternalAllowListProvider | undefined,
   signingKey: AppContext['signingKey'],
+  cache: AppContext['cache'],
   logger?: AppContext['logger'],
 ) {
   const dpopVerifier = new DpopVerifier({
@@ -342,6 +346,7 @@ function initAuth(
     allowListProvider,
     cfg.stratos.devMode === true,
     signingKey,
+    replayStoreFromCache(cache, logger),
     logger,
   )
 

--- a/stratos-service/src/features/space-credential/handler.ts
+++ b/stratos-service/src/features/space-credential/handler.ts
@@ -1,9 +1,14 @@
-import { InvalidRequestError, Server as XrpcServer } from '@atproto/xrpc-server'
+import {
+  InternalServerError,
+  InvalidRequestError,
+  Server as XrpcServer,
+} from '@atproto/xrpc-server'
 import { parseSpaceUri } from '@northskysocial/stratos-core'
 import type { AppContext } from '../../context-types.js'
 import { type XrpcServerInternal } from '../../api/types.js'
 import { createXrpcHandler } from '../../api/util.js'
 import {
+  consumeDelegationJti,
   verifyDelegationToken,
   type DelegationVerifierDeps,
 } from '../../infra/auth/delegation-verifier.js'
@@ -98,7 +103,10 @@ interface MintRequest {
  *      our configured service DID → else {@link UnknownSpace}.
  *   3. Resolve identity: if a `delegationToken` is present, verify it
  *      (its target space MUST equal `space`) and take identity from it; else use
- *      the DPoP-authenticated user (reject anonymous).
+ *      the DPoP-authenticated user (reject anonymous). The token's single-use
+ *      `jti` is NOT consumed here — it burns in step 7, after every other gate
+ *      has passed, so a rejected attestation or missing mint proof does not
+ *      spend the token.
  *   4. Map the space URI to its boundary, then confirm the user's enrollment is
  *      present AND active, and that it carries that boundary (live
  *      enrollment-store lookup, no cache) → else {@link NotEnrolled}.
@@ -109,7 +117,8 @@ interface MintRequest {
  *   6. Resolve the DPoP key thumbprint to bind (`cnf.jkt`): the session key on
  *      the DPoP path, or a standalone mint-time proof on the delegation path.
  *      Outside dev mode an unbound mint is rejected → {@link ProofRequired}.
- *   7. Mint the credential and return `{ credential, expiresAt }`.
+ *   7. On the delegation path, consume the token's `jti` (single-use burn,
+ *      deliberately LAST). Then mint and return `{ credential, expiresAt }`.
  *
  * @param ctx - Application context.
  * @param input - Request body.
@@ -140,9 +149,25 @@ async function handleGetSpaceCredential(
   }
   const { spaceDid, skey } = parsed.value
 
+  // The presentation verifier rejects every proof when no replay store is
+  // configured, so a production mint would issue an unusable credential.
+  // Dev mode is exempt: it accepts unbound Bearer presentations.
+  if (
+    ctx.cfg.stratos.devMode !== true &&
+    !replayStoreFromCache(ctx.cache, ctx.logger)
+  ) {
+    ctx.logger?.warn(
+      'space-credential mint unavailable: no replay store (cache) configured',
+    )
+    throw new InternalServerError('Space credentials are not available')
+  }
+
   // Resolve identity via delegation token (dormant) or DPoP session (live).
-  const userDid = input?.delegationToken
+  const delegation = input?.delegationToken
     ? await resolveDelegationIdentity(ctx, input.delegationToken, space)
+    : undefined
+  const userDid = delegation
+    ? delegation.userDid
     : requireDpopIdentity(credentials?.did)
 
   // Membership: the user must be enrolled in the boundary for this space.
@@ -182,6 +207,12 @@ async function handleGetSpaceCredential(
       'A DPoP proof is required to bind the credential',
       'ProofRequired',
     )
+  }
+
+  // Burn the single-use delegation token LAST: every other gate has passed,
+  // so a rejected attestation or missing mint proof does not spend it.
+  if (delegation) {
+    await delegation.consume()
   }
 
   const { credential, expiresAt } = await mintSpaceCredential({
@@ -231,8 +262,19 @@ async function requireMintProofJkt(
   }
 }
 
+/** Verified delegation identity plus the deferred single-use burn. */
+interface DelegationIdentity {
+  /** The delegating user's DID. */
+  userDid: string
+  /** Consume the token's `jti`. Call LAST, after every other gate passes. */
+  consume: () => Promise<void>
+}
+
 /**
- * Verify a delegation token and return the delegating user's DID.
+ * Verify a delegation token and return the delegating user's DID plus a
+ * deferred `consume` step. Verification does NOT burn the token's single-use
+ * `jti`; the caller invokes `consume` as its final act so a request that fails
+ * a later gate never spends the token.
  *
  * Every verification failure — and a target-space mismatch — surfaces as
  * a single `InvalidToken` error code (the exact reason is logged, not leaked).
@@ -241,14 +283,14 @@ async function requireMintProofJkt(
  * @param token - The raw delegation JWT.
  * @param requestedSpace - The `space` from the request; the token's target space
  *   MUST equal this.
- * @returns The delegating user's DID.
+ * @returns The delegating user's DID and the deferred `consume` step.
  * @throws InvalidRequestError('InvalidToken') on any failure.
  */
 async function resolveDelegationIdentity(
   ctx: AppContext,
   token: string,
   requestedSpace: string,
-): Promise<string> {
+): Promise<DelegationIdentity> {
   const replayStore = replayStoreFromCache(ctx.cache, ctx.logger)
   if (!replayStore) {
     ctx.logger?.warn(
@@ -263,7 +305,6 @@ async function resolveDelegationIdentity(
   const deps: DelegationVerifierDeps = {
     serviceDid: ctx.serviceDid,
     idResolver: ctx.idResolver,
-    replayStore,
   }
 
   try {
@@ -274,7 +315,23 @@ async function resolveDelegationIdentity(
         'InvalidToken',
       )
     }
-    return result.userDid
+    return {
+      userDid: result.userDid,
+      consume: async () => {
+        try {
+          await consumeDelegationJti(replayStore, result.jti)
+        } catch (err) {
+          ctx.logger?.info(
+            { err: err instanceof Error ? err.message : String(err) },
+            'space-credential delegation token rejected',
+          )
+          throw new InvalidRequestError(
+            'Delegation token could not be verified',
+            'InvalidToken',
+          )
+        }
+      },
+    }
   } catch (err) {
     if (err instanceof InvalidRequestError) throw err
     ctx.logger?.info(

--- a/stratos-service/src/features/space-credential/handler.ts
+++ b/stratos-service/src/features/space-credential/handler.ts
@@ -7,7 +7,8 @@ import {
   verifyDelegationToken,
   type DelegationVerifierDeps,
 } from '../../infra/auth/delegation-verifier.js'
-import { ReplayStore, type NxExStore } from '../../infra/auth/replay-store.js'
+import { replayStoreFromCache } from '../../infra/auth/replay-store.js'
+import { SpaceDpopProofChecker } from '../../infra/auth/space-dpop.js'
 import {
   verifyClientAttestation,
   type ClientAttestationVerifierDeps,
@@ -55,6 +56,7 @@ export function registerSpaceCredentialHandlers(
   ctx: AppContext,
 ): void {
   const xrpc = server as unknown as XrpcServerInternal
+  const proofChecker = new SpaceDpopProofChecker(ctx.cfg.service.publicUrl)
 
   xrpc.method(GET_SPACE_CREDENTIAL_METHOD, {
     type: 'procedure',
@@ -66,12 +68,25 @@ export function registerSpaceCredentialHandlers(
         // Both identity paths are resolved explicitly below; the delegation
         // path legitimately arrives with no authenticated DPoP `did`.
         requireAuth: false,
-        handler: async ({ input, auth }) => {
-          return handleGetSpaceCredential(ctx, input, auth?.credentials?.did)
+        handler: async ({ input, auth, req }) => {
+          return handleGetSpaceCredential(
+            ctx,
+            input,
+            auth?.credentials,
+            req,
+            proofChecker,
+          )
         },
       },
     ),
   })
+}
+
+/** Minimal request shape needed to check a mint-time DPoP proof. */
+interface MintRequest {
+  method?: string
+  url?: string
+  headers?: Record<string, string | string[] | undefined>
 }
 
 /**
@@ -91,17 +106,24 @@ export function registerSpaceCredentialHandlers(
  *      require a valid client attestation whose attested `client_id` is listed
  *      (else `AttestationRequired` / `ClientNotAllowed`). `#open` spaces ignore
  *      any attestation supplied.
- *   6. Mint the credential and return `{ credential, expiresAt }`.
+ *   6. Resolve the DPoP key thumbprint to bind (`cnf.jkt`): the session key on
+ *      the DPoP path, or a standalone mint-time proof on the delegation path.
+ *      Outside dev mode an unbound mint is rejected → {@link ProofRequired}.
+ *   7. Mint the credential and return `{ credential, expiresAt }`.
  *
  * @param ctx - Application context.
  * @param input - Request body.
- * @param dpopDid - The DPoP-authenticated user DID, if any.
+ * @param credentials - The caller's resolved auth credentials, if any.
+ * @param req - The underlying request (for mint-time DPoP proof checks).
+ * @param proofChecker - Nonce-free DPoP proof checker.
  * @returns `{ credential, expiresAt }`.
  */
 async function handleGetSpaceCredential(
   ctx: AppContext,
   input: GetSpaceCredentialInput | undefined,
-  dpopDid: string | undefined,
+  credentials: { did?: string; jkt?: string } | undefined,
+  req: MintRequest | undefined,
+  proofChecker: SpaceDpopProofChecker,
 ): Promise<{ credential: string; expiresAt: string }> {
   const space = input?.space
   if (!space) {
@@ -121,7 +143,7 @@ async function handleGetSpaceCredential(
   // Resolve identity via delegation token (dormant) or DPoP session (live).
   const userDid = input?.delegationToken
     ? await resolveDelegationIdentity(ctx, input.delegationToken, space)
-    : requireDpopIdentity(dpopDid)
+    : requireDpopIdentity(credentials?.did)
 
   // Membership: the user must be enrolled in the boundary for this space.
   const boundary = `${spaceDid}/${skey}`
@@ -148,14 +170,65 @@ async function handleGetSpaceCredential(
   // App-axis (client attestation) gating. `#open` spaces are a no-op.
   await enforceAppAccess(ctx, boundary, input?.clientAttestation)
 
+  // Key binding: the delegation path proves key possession with a standalone
+  // mint-time DPoP proof; the DPoP path reuses the session proof's key.
+  const jkt = input?.delegationToken
+    ? await requireMintProofJkt(ctx, proofChecker, req)
+    : credentials?.jkt
+  if (!jkt && ctx.cfg.stratos.devMode !== true) {
+    // Only dev-mode identities (dev Bearer) have no DPoP key. An unbound
+    // credential in production would be freely replayable, so refuse.
+    throw new InvalidRequestError(
+      'A DPoP proof is required to bind the credential',
+      'ProofRequired',
+    )
+  }
+
   const { credential, expiresAt } = await mintSpaceCredential({
     signingKey: ctx.signingKey,
     issuerDid: ctx.serviceDid,
     spaceUri: space,
     ttlSeconds: ctx.cfg.stratos.spaceCredentialTtlSeconds,
+    jkt,
   })
 
   return { credential, expiresAt }
+}
+
+/**
+ * Check the mint-time DPoP proof on the delegation path and return the proof
+ * key's thumbprint. The proof is standalone (no bound token, so no `ath`
+ * claim) — it proves possession of the key the credential will be bound to.
+ *
+ * @param ctx - Application context.
+ * @param proofChecker - Nonce-free DPoP proof checker.
+ * @param req - The underlying request.
+ * @returns The proof key's SHA-256 JWK thumbprint.
+ * @throws InvalidRequestError('ProofRequired') when the proof is missing or
+ *   invalid (the exact reason is logged, not leaked).
+ */
+async function requireMintProofJkt(
+  ctx: AppContext,
+  proofChecker: SpaceDpopProofChecker,
+  req: MintRequest | undefined,
+): Promise<string> {
+  try {
+    const proof = await proofChecker.check({
+      method: req?.method || 'POST',
+      url: req?.url || '/',
+      headers: req?.headers ?? {},
+    })
+    return proof.jkt
+  } catch (err) {
+    ctx.logger?.info(
+      { err: err instanceof Error ? err.message : String(err) },
+      'space-credential mint proof rejected',
+    )
+    throw new InvalidRequestError(
+      'A DPoP proof is required to bind the credential',
+      'ProofRequired',
+    )
+  }
 }
 
 /**
@@ -176,7 +249,7 @@ async function resolveDelegationIdentity(
   token: string,
   requestedSpace: string,
 ): Promise<string> {
-  const replayStore = getReplayStore(ctx)
+  const replayStore = replayStoreFromCache(ctx.cache, ctx.logger)
   if (!replayStore) {
     ctx.logger?.warn(
       'space-credential delegation path unavailable: no replay store (cache) configured',
@@ -251,7 +324,7 @@ async function enforceAppAccess(
     )
   }
 
-  const replayStore = getReplayStore(ctx)
+  const replayStore = replayStoreFromCache(ctx.cache, ctx.logger)
   if (!replayStore) {
     ctx.logger?.warn(
       'client attestation unavailable: no replay store (cache) configured',
@@ -309,18 +382,4 @@ function requireDpopIdentity(dpopDid: string | undefined): string {
     )
   }
   return dpopDid
-}
-
-/**
- * Build a {@link ReplayStore} from the process cache for the dormant delegation
- * path. Returns undefined when no cache is configured (single-instance / no
- * Redis) — in that case the delegation path is unavailable and callers must use
- * the live DPoP path. The cast to {@link NxExStore} is a deliberate seam: the
- * runtime cache is a `RedisCache` exposing `setNxEx`, but the shared `Cache`
- * interface does not declare it.
- */
-function getReplayStore(ctx: AppContext): ReplayStore | undefined {
-  const cache = ctx.cache as (NxExStore & { setNxEx?: unknown }) | undefined
-  if (!cache || typeof cache.setNxEx !== 'function') return undefined
-  return new ReplayStore(cache, ctx.logger)
 }

--- a/stratos-service/src/features/space-credential/minter.ts
+++ b/stratos-service/src/features/space-credential/minter.ts
@@ -9,10 +9,10 @@ import {
  * Space-credential minter.
  *
  * A **space credential** is a JWT by which the space authority (this Stratos
- * service) grants a member bearer-shaped, **multi-use** access to a space until
- * the credential expires. Because it is signed by the authority's own signing
- * key, any repo host can verify it against the authority's published DID
- * document without ever contacting the authority.
+ * service) grants a member **multi-use**, DPoP-key-bound access to a space
+ * until the credential expires. Because it is signed by the authority's own
+ * signing key, any repo host can verify it against the authority's published
+ * DID document without ever contacting the authority.
  *
  * Spec shape (minted EXACTLY as below):
  *   - Header `typ` = {@link SPACE_CREDENTIAL_TYP} (`atproto-space-credential+jwt`).
@@ -26,6 +26,11 @@ import {
  *   - Payload `iat` = issuance time (unix seconds).
  *   - Payload `exp` = `iat + ttlSeconds` (2h default).
  *   - Payload `jti` = a unique nonce.
+ *   - Payload `cnf.jkt` = the SHA-256 JWK thumbprint of the member's DPoP key
+ *     (RFC 9449). The credential is sender-constrained: it must be presented
+ *     under the `DPoP` auth scheme with a per-request proof signed by that key.
+ *     Omitted only when no `jkt` input is supplied (dev-mode identities have no
+ *     DPoP key); an unbound credential is accepted only in dev mode.
  *   - **No `aud` claim** — a space credential is not audience-bound; that is what
  *     makes it multi-use across any repo host.
  *
@@ -59,6 +64,8 @@ export interface SpaceCredentialPayload {
   iat: number
   exp: number
   jti: string
+  /** DPoP key binding (RFC 9449). Absent only for dev-mode unbound mints. */
+  cnf?: { jkt: string }
 }
 
 /** Inputs to {@link mintSpaceCredential}. */
@@ -78,6 +85,11 @@ export interface MintSpaceCredentialInput {
   iat?: number
   /** Unique nonce (`jti`). Defaults to a fresh random value. */
   jti?: string
+  /**
+   * SHA-256 JWK thumbprint of the member's DPoP key → `cnf.jkt`. When absent,
+   * the credential is minted unbound (dev mode only).
+   */
+  jkt?: string
 }
 
 /** Result of minting a space credential. */
@@ -119,6 +131,9 @@ export async function mintSpaceCredential(
     iat,
     exp,
     jti,
+  }
+  if (input.jkt) {
+    payload.cnf = { jkt: input.jkt }
   }
 
   const signingInput = `${b64urlJson(header)}.${b64urlJson(payload)}`

--- a/stratos-service/src/infra/auth/delegation-verifier.ts
+++ b/stratos-service/src/infra/auth/delegation-verifier.ts
@@ -210,9 +210,9 @@ export async function verifyDelegationToken(
   }
   await verifyAtprotoSignature(parts, payload.iss, deps.idResolver)
 
-  // 8. jti — presence only; consumption is the caller's final act
-  if (!payload.jti) {
-    throw new DelegationReplayError('Missing jti claim')
+  // 8. jti — a non-empty string; consumption is the caller's final act
+  if (typeof payload.jti !== 'string' || payload.jti.length === 0) {
+    throw new DelegationReplayError('Missing or malformed jti claim')
   }
 
   return { userDid: payload.iss, spaceUri: payload.sub, jti: payload.jti }

--- a/stratos-service/src/infra/auth/delegation-verifier.ts
+++ b/stratos-service/src/infra/auth/delegation-verifier.ts
@@ -25,9 +25,13 @@ import type { ReplayStore } from './replay-store.js'
  *   - Payload `iat`/`exp` MUST be present and currently valid (with skew).
  *   - The signature MUST verify against the issuer DID document's `#atproto`
  *     verification method **only** (no other method is accepted).
- *   - FINALLY the `jti` is consumed exactly once (replay protection).
+ *   - The `jti` MUST be present. Verification does NOT consume it; the caller
+ *     consumes it via {@link consumeDelegationJti} as its LAST step, after
+ *     every other gate on the request has passed. A request that fails a later
+ *     gate therefore never burns the token.
  *
  * @see verifyDelegationToken
+ * @see consumeDelegationJti
  */
 
 /** Required JWT `typ` header value for a space-delegation token. */
@@ -111,6 +115,11 @@ export interface DelegationResult {
   userDid: string
   /** The target space URI (`sub`), byte-for-byte as presented. */
   spaceUri: string
+  /**
+   * The token's single-use nonce. NOT yet consumed — the caller must pass it
+   * to {@link consumeDelegationJti} after every other gate has passed.
+   */
+  jti: string
 }
 
 /** Dependencies for {@link verifyDelegationToken}. */
@@ -119,8 +128,6 @@ export interface DelegationVerifierDeps {
   serviceDid: string
   /** Identity resolver for resolving the issuer DID document. */
   idResolver: IdResolver
-  /** Single-use nonce store (consumed LAST). */
-  replayStore: ReplayStore
   /** Clock-skew tolerance in seconds (default {@link DEFAULT_CLOCK_SKEW}). */
   clockSkewSeconds?: number
 }
@@ -128,14 +135,15 @@ export interface DelegationVerifierDeps {
 /**
  * Verify a space-delegation JWT.
  *
- * Runs the checks in the exact order documented on this module. The `jti`
- * consumption is performed **last, and only after every other check has
- * passed**, so an invalid token never burns its nonce — a later, genuinely
- * valid token bearing the same `jti` can still succeed.
+ * Runs the checks in the exact order documented on this module. The `jti` is
+ * validated for presence but NOT consumed — the caller consumes it with
+ * {@link consumeDelegationJti} as its final act, so a request that fails a
+ * later gate (attestation, mint proof) never burns the token, and a later,
+ * genuinely valid presentation of the same `jti` can still succeed.
  *
  * @param token - The raw compact JWT (no `Bearer ` prefix).
  * @param deps - Verifier dependencies.
- * @returns `{ userDid, spaceUri }` on success.
+ * @returns `{ userDid, spaceUri, jti }` on success.
  * @throws A distinct {@link DelegationVerificationError} subclass per failure.
  */
 export async function verifyDelegationToken(
@@ -202,20 +210,37 @@ export async function verifyDelegationToken(
   }
   await verifyAtprotoSignature(parts, payload.iss, deps.idResolver)
 
-  // 8. jti — consumed LAST so an invalid token never burns its nonce
+  // 8. jti — presence only; consumption is the caller's final act
   if (!payload.jti) {
     throw new DelegationReplayError('Missing jti claim')
   }
-  const fresh = await deps.replayStore.consumeOnce(
+
+  return { userDid: payload.iss, spaceUri: payload.sub, jti: payload.jti }
+}
+
+/**
+ * Consume a verified delegation token's `jti` exactly once.
+ *
+ * Call this LAST, after every other gate on the request has passed, so a
+ * request that fails a later gate never burns the token.
+ *
+ * @param replayStore - Single-use nonce store.
+ * @param jti - The `jti` returned by {@link verifyDelegationToken}.
+ * @throws DelegationReplayError if the `jti` was already consumed, or the
+ *   store is unavailable (fail closed).
+ */
+export async function consumeDelegationJti(
+  replayStore: ReplayStore,
+  jti: string,
+): Promise<void> {
+  const fresh = await replayStore.consumeOnce(
     DELEGATION_REPLAY_KIND,
-    payload.jti,
+    jti,
     DELEGATION_REPLAY_TTL,
   )
   if (!fresh) {
     throw new DelegationReplayError('Delegation token replay detected')
   }
-
-  return { userDid: payload.iss, spaceUri: payload.sub }
 }
 
 /**

--- a/stratos-service/src/infra/auth/dpop-verifier.ts
+++ b/stratos-service/src/infra/auth/dpop-verifier.ts
@@ -21,6 +21,8 @@ export interface DpopAuthResult {
   scope: string
   pdsEndpoint: string
   tokenType: 'DPoP'
+  /** SHA-256 JWK thumbprint of the proof key (RFC 9449 `jkt`). */
+  jkt: string
 }
 
 /**
@@ -174,6 +176,7 @@ export class DpopVerifier {
       scope: (claims.scope as string) ?? 'atproto',
       pdsEndpoint,
       tokenType: 'DPoP',
+      jkt: dpopProof.jkt,
     }
   }
 

--- a/stratos-service/src/infra/auth/replay-store.ts
+++ b/stratos-service/src/infra/auth/replay-store.ts
@@ -82,3 +82,18 @@ export class ReplayStore {
 function replayKey(kind: string, jti: string): string {
   return `replay:${kind}:${jti}`
 }
+
+/**
+ * Build a {@link ReplayStore} from the process cache, or `undefined` when no
+ * cache is configured (single-instance / no Redis). The structural check is a
+ * deliberate seam: the runtime cache is a `RedisCache` exposing `setNxEx`, but
+ * the shared `Cache` interface does not declare it.
+ */
+export function replayStoreFromCache(
+  cache: unknown,
+  logger?: Logger,
+): ReplayStore | undefined {
+  const store = cache as (NxExStore & { setNxEx?: unknown }) | undefined
+  if (!store || typeof store.setNxEx !== 'function') return undefined
+  return new ReplayStore(store, logger)
+}

--- a/stratos-service/src/infra/auth/space-credential-verifier.ts
+++ b/stratos-service/src/infra/auth/space-credential-verifier.ts
@@ -1,14 +1,18 @@
 import type { Keypair } from '@atproto/crypto'
 import * as crypto from '@atproto/crypto'
+import type { DpopProof } from '@atproto/oauth-provider'
 import { parseSpaceUri } from '@northskysocial/stratos-core'
 import { decodeCompactJwt } from './jwt.js'
+import type { VerifyRequestContext } from './dpop-verifier.js'
+import type { SpaceDpopProofChecker } from './space-dpop.js'
+import type { ReplayStore } from './replay-store.js'
 
 /**
  * Space-credential verifier.
  *
  * A **space credential** is a JWT the space authority (this Stratos service)
  * mints (see `features/space-credential/minter.ts`) to grant a member
- * bearer-shaped, **multi-use** access to a single space until the credential
+ * **multi-use**, DPoP-key-bound access to a single space until the credential
  * expires. On the read/sync surface we accept it as an ALTERNATIVE
  * authentication that COMPOSES with — never replaces — the per-record boundary
  * gate: a credential admits the caller to the API surface for its space, and
@@ -26,10 +30,20 @@ import { decodeCompactJwt } from './jwt.js'
  *   - Header `alg` MUST be one of {@link SPACE_CREDENTIAL_ALLOWED_ALGS} (`ES256K`, `ES256`).
  *   - Header `kid` MUST be exactly {@link SPACE_CREDENTIAL_KID} (`"#atproto"`).
  *   - Payload `exp` MUST be present and not in the past (with skew). There is
- *     no `aud` claim and NO `jti` consumption (the credential is multi-use).
+ *     no `aud` claim and NO credential-`jti` consumption (the credential is
+ *     multi-use; single-use applies to the per-request PROOF `jti` instead).
  *   - Payload `sub` MUST parse as an `at://` space URI whose
  *     `spaceDid` equals our configured service DID (we are the authority).
  *   - The signature MUST verify against OUR OWN service signing key.
+ *
+ * Presentation binding ({@link verifyPresentedSpaceCredential}) — the
+ * credential is sender-constrained per RFC 9449:
+ *   - Payload `cnf.jkt` MUST be present (the member's DPoP key thumbprint).
+ *   - The request MUST carry a `DPoP` proof with `ath` over the credential and
+ *     `htm`/`htu` matching the request.
+ *   - The proof key's thumbprint MUST equal `cnf.jkt`.
+ *   - The proof `jti` is consumed single-use (replay store, fail-closed) —
+ *     LAST, so an invalid presentation never burns its nonce.
  *
  * @see verifySpaceCredential
  */
@@ -42,6 +56,14 @@ export const SPACE_CREDENTIAL_ALLOWED_ALGS = ['ES256K', 'ES256'] as const
 export const SPACE_CREDENTIAL_KID = '#atproto'
 /** Default clock-skew tolerance (seconds) for `exp`. */
 export const SPACE_CREDENTIAL_CLOCK_SKEW = 30
+/** Replay-store namespace for presentation-proof `jti` values. */
+export const SPACE_DPOP_REPLAY_KIND = 'space-dpop'
+/**
+ * How long (seconds) a consumed proof `jti` is remembered. Covers the proof's
+ * freshness window plus the checker's clock tolerance, so a proof can never
+ * outlive its replay record.
+ */
+export const SPACE_DPOP_REPLAY_TTL = 300
 
 /**
  * Base class for all space-credential-verification failures. Each distinct
@@ -71,6 +93,14 @@ export class InvalidSpaceCredentialSubError extends SpaceCredentialVerificationE
 export class ForeignSpaceCredentialError extends SpaceCredentialVerificationError {}
 /** Signature did not verify against our own service signing key. */
 export class InvalidSpaceCredentialSignatureError extends SpaceCredentialVerificationError {}
+/** The credential carries no `cnf.jkt` key binding. */
+export class MissingSpaceCredentialCnfError extends SpaceCredentialVerificationError {}
+/** The request's `DPoP` proof was missing or failed validation. */
+export class InvalidSpaceCredentialProofError extends SpaceCredentialVerificationError {}
+/** The proof key's thumbprint did not equal the credential's `cnf.jkt`. */
+export class SpaceCredentialKeyBindingError extends SpaceCredentialVerificationError {}
+/** The proof `jti` was already consumed (or the replay store is unavailable). */
+export class SpaceCredentialProofReplayError extends SpaceCredentialVerificationError {}
 
 interface SpaceCredentialHeader {
   alg?: string
@@ -84,12 +114,15 @@ interface SpaceCredentialClaims {
   iat?: number
   exp?: number
   jti?: string
+  cnf?: { jkt?: unknown }
 }
 
 /** Successful verification result. */
 export interface SpaceCredentialResult {
   /** The target space URI (`sub`), byte-for-byte as presented. */
   spaceUri: string
+  /** The `cnf.jkt` DPoP key binding, when the credential carries one. */
+  cnfJkt?: string
 }
 
 /** Dependencies for {@link verifySpaceCredential}. */
@@ -176,7 +209,76 @@ export async function verifySpaceCredential(
   // 6. signature against OUR OWN service key (no DID resolution).
   await verifyOwnKeySignature(parts, deps.serviceKey)
 
-  return { spaceUri: payload.sub }
+  const cnfJkt = payload.cnf?.jkt
+  return {
+    spaceUri: payload.sub,
+    ...(typeof cnfJkt === 'string' && cnfJkt ? { cnfJkt } : {}),
+  }
+}
+
+/** Dependencies for {@link verifyPresentedSpaceCredential}. */
+export interface PresentedSpaceCredentialDeps
+  extends SpaceCredentialVerifierDeps {
+  /** RFC 9449 proof checker for the space surface (nonce-free). */
+  proofChecker: Pick<SpaceDpopProofChecker, 'check'>
+  /** Single-use store for proof `jti` values (fail-closed). */
+  replayStore: Pick<ReplayStore, 'consumeOnce'>
+}
+
+/**
+ * Verify a space credential presented under the `DPoP` auth scheme.
+ *
+ * Runs {@link verifySpaceCredential} first, then enforces the sender
+ * constraint: `cnf.jkt` presence, a valid `DPoP` proof with `ath` over the
+ * credential, thumbprint equality, and single-use proof-`jti` consumption.
+ * The `jti` is consumed LAST so an invalid presentation never burns its nonce.
+ *
+ * @param token - The raw compact credential JWT (no scheme prefix).
+ * @param req - The request context the proof must bind (`htm`/`htu`).
+ * @param deps - Credential deps plus the proof checker and replay store.
+ * @returns `{ spaceUri, cnfJkt }` on success.
+ * @throws A distinct {@link SpaceCredentialVerificationError} subclass per failure.
+ */
+export async function verifyPresentedSpaceCredential(
+  token: string,
+  req: VerifyRequestContext,
+  deps: PresentedSpaceCredentialDeps,
+): Promise<SpaceCredentialResult> {
+  const result = await verifySpaceCredential(token, deps)
+
+  // 7. cnf.jkt — every presented credential must be key-bound.
+  if (!result.cnfJkt) {
+    throw new MissingSpaceCredentialCnfError(
+      'Space credential has no cnf.jkt key binding',
+    )
+  }
+
+  // 8. DPoP proof — signature, typ, freshness, htm/htu, ath over the credential.
+  let proof: DpopProof
+  try {
+    proof = await deps.proofChecker.check(req, token)
+  } catch (err) {
+    throw new InvalidSpaceCredentialProofError(
+      err instanceof Error ? err.message : 'Invalid DPoP proof',
+    )
+  }
+
+  // 9. key binding — the proof key must be the bound key.
+  if (proof.jkt !== result.cnfJkt) {
+    throw new SpaceCredentialKeyBindingError('DPoP key binding mismatch')
+  }
+
+  // 10. proof jti — consumed LAST so an invalid presentation never burns it.
+  const fresh = await deps.replayStore.consumeOnce(
+    SPACE_DPOP_REPLAY_KIND,
+    proof.jti,
+    SPACE_DPOP_REPLAY_TTL,
+  )
+  if (!fresh) {
+    throw new SpaceCredentialProofReplayError('DPoP proof replay detected')
+  }
+
+  return result
 }
 
 /**

--- a/stratos-service/src/infra/auth/space-credential-verifier.ts
+++ b/stratos-service/src/infra/auth/space-credential-verifier.ts
@@ -1,10 +1,14 @@
 import type { Keypair } from '@atproto/crypto'
 import * as crypto from '@atproto/crypto'
-import type { DpopProof } from '@atproto/oauth-provider'
 import { parseSpaceUri } from '@northskysocial/stratos-core'
 import { decodeCompactJwt } from './jwt.js'
 import type { VerifyRequestContext } from './dpop-verifier.js'
-import type { SpaceDpopProofChecker } from './space-dpop.js'
+import {
+  SPACE_DPOP_CLOCK_SKEW_SEC,
+  SPACE_DPOP_MAX_PROOF_AGE_SEC,
+  type SpaceDpopProof,
+  type SpaceDpopProofChecker,
+} from './space-dpop.js'
 import type { ReplayStore } from './replay-store.js'
 
 /**
@@ -59,11 +63,12 @@ export const SPACE_CREDENTIAL_CLOCK_SKEW = 30
 /** Replay-store namespace for presentation-proof `jti` values. */
 export const SPACE_DPOP_REPLAY_KIND = 'space-dpop'
 /**
- * How long (seconds) a consumed proof `jti` is remembered. Covers the proof's
- * freshness window plus the checker's clock tolerance, so a proof can never
- * outlive its replay record.
+ * How long (seconds) a consumed proof `jti` is remembered. Derived from the
+ * checker's window — the maximum proof age plus skew on both ends — so a
+ * proof can never outlive its replay record.
  */
-export const SPACE_DPOP_REPLAY_TTL = 300
+export const SPACE_DPOP_REPLAY_TTL =
+  SPACE_DPOP_MAX_PROOF_AGE_SEC + 2 * SPACE_DPOP_CLOCK_SKEW_SEC
 
 /**
  * Base class for all space-credential-verification failures. Each distinct
@@ -217,8 +222,7 @@ export async function verifySpaceCredential(
 }
 
 /** Dependencies for {@link verifyPresentedSpaceCredential}. */
-export interface PresentedSpaceCredentialDeps
-  extends SpaceCredentialVerifierDeps {
+export interface PresentedSpaceCredentialDeps extends SpaceCredentialVerifierDeps {
   /** RFC 9449 proof checker for the space surface (nonce-free). */
   proofChecker: Pick<SpaceDpopProofChecker, 'check'>
   /** Single-use store for proof `jti` values (fail-closed). */
@@ -254,7 +258,7 @@ export async function verifyPresentedSpaceCredential(
   }
 
   // 8. DPoP proof — signature, typ, freshness, htm/htu, ath over the credential.
-  let proof: DpopProof
+  let proof: SpaceDpopProof
   try {
     proof = await deps.proofChecker.check(req, token)
   } catch (err) {

--- a/stratos-service/src/infra/auth/space-dpop.ts
+++ b/stratos-service/src/infra/auth/space-dpop.ts
@@ -1,0 +1,66 @@
+import { DpopManager, type DpopProof } from '@atproto/oauth-provider'
+import type { VerifyRequestContext } from './dpop-verifier.js'
+
+/** Thrown when a space-surface DPoP proof is missing or fails validation. */
+export class SpaceDpopProofError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'SpaceDpopProofError'
+  }
+}
+
+/**
+ * RFC 9449 proof checker for the space surface (credential mint and
+ * presentation).
+ *
+ * Nonces are deliberately disabled (`dpopSecret: false`): the upstream space
+ * surface uses plain per-request proofs with a short freshness window, not the
+ * OAuth nonce round trip. The wrapped `DpopManager.checkProof` verifies the
+ * proof signature (embedded JWK), `typ`, `iat` freshness, `jti` presence, and
+ * the `htm`/`htu` request binding. When `boundToken` is supplied it REQUIRES
+ * `ath` = b64url(SHA-256(boundToken)); when omitted it REJECTS any `ath`
+ * (mint-time proofs are not token-bound). Replay (`jti`) consumption is the
+ * caller's responsibility — a proof that fails later checks must not burn its
+ * nonce.
+ */
+export class SpaceDpopProofChecker {
+  private readonly manager = new DpopManager({ dpopSecret: false })
+
+  /**
+   * @param serviceEndpoint - This service's public base URL, used to resolve
+   *   the request path into the absolute URL that `htu` must match.
+   */
+  constructor(private readonly serviceEndpoint: string) {}
+
+  /**
+   * Validate the request's `DPoP` header proof.
+   *
+   * @param req - Request context (method, url, headers).
+   * @param boundToken - The token the proof must hash-bind via `ath`, if any.
+   * @returns The validated proof (`jti`, `jkt`, `htm`, `htu`).
+   * @throws SpaceDpopProofError when the header is absent or the proof is
+   *   invalid.
+   */
+  async check(
+    req: VerifyRequestContext,
+    boundToken?: string,
+  ): Promise<DpopProof> {
+    const url = new URL(req.url, this.serviceEndpoint)
+    let proof: DpopProof | null
+    try {
+      proof = await this.manager.checkProof(
+        req.method,
+        url,
+        req.headers,
+        boundToken,
+      )
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Invalid DPoP proof'
+      throw new SpaceDpopProofError(message)
+    }
+    if (!proof) {
+      throw new SpaceDpopProofError('DPoP proof required')
+    }
+    return proof
+  }
+}

--- a/stratos-service/src/infra/auth/space-dpop.ts
+++ b/stratos-service/src/infra/auth/space-dpop.ts
@@ -1,5 +1,38 @@
-import { DpopManager, type DpopProof } from '@atproto/oauth-provider'
+import { createHash } from 'node:crypto'
+import { EmbeddedJWK, calculateJwkThumbprint, jwtVerify } from 'jose'
 import type { VerifyRequestContext } from './dpop-verifier.js'
+
+/**
+ * RFC 9449 proof checker for the space surface (credential mint and
+ * presentation).
+ *
+ * This is a standalone implementation that mirrors the upstream space-surface
+ * checker (`@atproto/space` `dpop.ts`) rather than wrapping the OAuth
+ * provider's `DpopManager`. The manager cannot serve this surface: with
+ * nonces disabled it REJECTS any proof that carries a `nonce` claim, and its
+ * freshness window (10s age + 180s tolerance) is both looser than the spec's
+ * and impossible to derive a replay TTL from. Here the space rules apply:
+ *   - `typ` MUST be `dpop+jwt`, `alg` MUST be ES256, key embedded via `jwk`.
+ *   - `iat` MUST be within {@link SPACE_DPOP_MAX_PROOF_AGE_SEC} (plus
+ *     {@link SPACE_DPOP_CLOCK_SKEW_SEC} tolerance).
+ *   - `jti` MUST be present; `htm`/`htu` MUST match the request.
+ *   - A `nonce` claim is IGNORED: the space surface uses plain per-request
+ *     proofs with server-side `jti` replay tracking, not the OAuth nonce
+ *     round trip.
+ *   - When `boundToken` is supplied, `ath` MUST equal
+ *     b64url(SHA-256(boundToken)); when omitted, `ath` MUST be absent
+ *     (mint-time proofs are not token-bound).
+ * Replay (`jti`) consumption is the caller's responsibility — a proof that
+ * fails later checks must not burn its nonce.
+ */
+
+/** Longest accepted proof age (`iat` to now), in seconds. */
+export const SPACE_DPOP_MAX_PROOF_AGE_SEC = 60
+/** Clock-skew tolerance for `iat`, in seconds. */
+export const SPACE_DPOP_CLOCK_SKEW_SEC = 5
+
+const DPOP_PROOF_TYP = 'dpop+jwt'
+const SIGNING_ALG = 'ES256'
 
 /** Thrown when a space-surface DPoP proof is missing or fails validation. */
 export class SpaceDpopProofError extends Error {
@@ -9,23 +42,15 @@ export class SpaceDpopProofError extends Error {
   }
 }
 
-/**
- * RFC 9449 proof checker for the space surface (credential mint and
- * presentation).
- *
- * Nonces are deliberately disabled (`dpopSecret: false`): the upstream space
- * surface uses plain per-request proofs with a short freshness window, not the
- * OAuth nonce round trip. The wrapped `DpopManager.checkProof` verifies the
- * proof signature (embedded JWK), `typ`, `iat` freshness, `jti` presence, and
- * the `htm`/`htu` request binding. When `boundToken` is supplied it REQUIRES
- * `ath` = b64url(SHA-256(boundToken)); when omitted it REJECTS any `ath`
- * (mint-time proofs are not token-bound). Replay (`jti`) consumption is the
- * caller's responsibility — a proof that fails later checks must not burn its
- * nonce.
- */
-export class SpaceDpopProofChecker {
-  private readonly manager = new DpopManager({ dpopSecret: false })
+/** A validated space-surface DPoP proof. */
+export interface SpaceDpopProof {
+  jti: string
+  jkt: string
+  htm: string
+  htu: string
+}
 
+export class SpaceDpopProofChecker {
   /**
    * @param serviceEndpoint - This service's public base URL, used to resolve
    *   the request path into the absolute URL that `htu` must match.
@@ -44,23 +69,98 @@ export class SpaceDpopProofChecker {
   async check(
     req: VerifyRequestContext,
     boundToken?: string,
-  ): Promise<DpopProof> {
-    const url = new URL(req.url, this.serviceEndpoint)
-    let proof: DpopProof | null
-    try {
-      proof = await this.manager.checkProof(
-        req.method,
-        url,
-        req.headers,
-        boundToken,
-      )
-    } catch (err) {
-      const message = err instanceof Error ? err.message : 'Invalid DPoP proof'
-      throw new SpaceDpopProofError(message)
-    }
-    if (!proof) {
+  ): Promise<SpaceDpopProof> {
+    const proofJwt = extractProofHeader(req.headers)
+    if (!proofJwt) {
       throw new SpaceDpopProofError('DPoP proof required')
     }
-    return proof
+
+    // EmbeddedJWK verifies against the proof's own `jwk` header; the caller's
+    // thumbprint comparison is what ties that key to a credential.
+    const { protectedHeader, payload } = await jwtVerify(
+      proofJwt,
+      EmbeddedJWK,
+      {
+        typ: DPOP_PROOF_TYP,
+        algorithms: [SIGNING_ALG],
+        maxTokenAge: SPACE_DPOP_MAX_PROOF_AGE_SEC,
+        clockTolerance: SPACE_DPOP_CLOCK_SKEW_SEC,
+      },
+    ).catch((err) => {
+      throw new SpaceDpopProofError(
+        `could not verify DPoP proof: ${errMsg(err)}`,
+      )
+    })
+
+    const { jti, htm, htu, ath } = payload
+    if (typeof jti !== 'string' || !jti) {
+      throw new SpaceDpopProofError('missing DPoP proof "jti"')
+    }
+    if (htm !== req.method) {
+      throw new SpaceDpopProofError(
+        'DPoP proof "htm" does not match the request',
+      )
+    }
+    if (typeof htu !== 'string' || htu !== this.expectedHtu(req.url)) {
+      throw new SpaceDpopProofError(
+        'DPoP proof "htu" does not match the request',
+      )
+    }
+    if (boundToken !== undefined) {
+      if (ath !== hashToken(boundToken)) {
+        throw new SpaceDpopProofError(
+          'DPoP proof "ath" does not match the credential',
+        )
+      }
+    } else if (ath !== undefined) {
+      throw new SpaceDpopProofError(
+        'DPoP proof "ath" must be omitted when obtaining a credential',
+      )
+    }
+
+    // Present because jwtVerify used EmbeddedJWK.
+    const jkt = await calculateJwkThumbprint(
+      protectedHeader.jwk!,
+      'sha256',
+    ).catch((err) => {
+      throw new SpaceDpopProofError(
+        `could not compute DPoP key thumbprint: ${errMsg(err)}`,
+      )
+    })
+
+    return { jti, jkt, htm, htu }
+  }
+
+  // Strips query and fragment (RFC 9449 section 4.2), so one proof covers any
+  // query on a path.
+  private expectedHtu(requestUrl: string): string {
+    try {
+      const url = new URL(requestUrl, this.serviceEndpoint)
+      return url.origin + url.pathname
+    } catch (err) {
+      throw new SpaceDpopProofError(
+        `could not resolve the request URL: ${errMsg(err)}`,
+      )
+    }
   }
 }
+
+function extractProofHeader(
+  headers: Record<string, undefined | string | string[]>,
+): string | null {
+  const value = headers['dpop']
+  if (value === undefined) return null
+  if (typeof value === 'string') {
+    if (value) return value
+    throw new SpaceDpopProofError('DPoP header must not be empty')
+  }
+  if (value.length === 1 && value[0]) return value[0]
+  throw new SpaceDpopProofError('DPoP header must contain a single proof')
+}
+
+function hashToken(token: string): string {
+  return createHash('sha256').update(token).digest('base64url')
+}
+
+const errMsg = (err: unknown): string =>
+  err instanceof Error ? err.message : String(err)

--- a/stratos-service/src/infra/auth/verifiers.ts
+++ b/stratos-service/src/infra/auth/verifiers.ts
@@ -341,17 +341,12 @@ function createServiceVerifier(deps: {
 function extractSpaceCredentialToken(
   authHeader: string | undefined,
 ): { token: string; scheme: 'dpop' | 'bearer' } | null {
-  let token: string
-  let scheme: 'dpop' | 'bearer'
-  if (authHeader?.startsWith('DPoP ')) {
-    token = authHeader.slice(5).trim()
-    scheme = 'dpop'
-  } else if (authHeader?.startsWith('Bearer ')) {
-    token = authHeader.slice(7).trim()
-    scheme = 'bearer'
-  } else {
-    return null
-  }
+  // RFC 9110 section 11.1: the auth scheme is case-insensitive.
+  const match = authHeader ? /^(dpop|bearer) +(.+)$/i.exec(authHeader) : null
+  if (!match) return null
+  const scheme: 'dpop' | 'bearer' =
+    match[1].toLowerCase() === 'dpop' ? 'dpop' : 'bearer'
+  const token = match[2].trim()
   const parts = token.split('.')
   if (parts.length !== 3) return null
   try {

--- a/stratos-service/src/infra/auth/verifiers.ts
+++ b/stratos-service/src/infra/auth/verifiers.ts
@@ -9,8 +9,11 @@ import { DpopVerificationError, DpopVerifier } from './index.js'
 import {
   SPACE_CREDENTIAL_TYP,
   SpaceCredentialVerificationError,
+  verifyPresentedSpaceCredential,
   verifySpaceCredential,
 } from './space-credential-verifier.js'
+import { SpaceDpopProofChecker } from './space-dpop.js'
+import type { ReplayStore } from './replay-store.js'
 import {
   EnrollmentDeniedError,
   type Logger,
@@ -33,7 +36,7 @@ export interface AuthVerifiers {
   /** Standard user auth (OAuth token) */
   standard: (
     ctx: import('@atproto/xrpc-server').MethodAuthContext,
-  ) => Promise<{ credentials: { type: string; did: string } }>
+  ) => Promise<{ credentials: { type: string; did: string; jkt?: string } }>
   /** Service-to-service auth (inter-service JWT) */
   service: (
     ctx: import('@atproto/xrpc-server').MethodAuthContext,
@@ -41,21 +44,22 @@ export interface AuthVerifiers {
   /** Optional user auth */
   optionalStandard: (
     ctx: import('@atproto/xrpc-server').MethodAuthContext,
-  ) => Promise<{ credentials: { type: string; did?: string } }>
+  ) => Promise<{ credentials: { type: string; did?: string; jkt?: string } }>
   /**
-   * Space-credential auth: a multi-use JWT this service minted for a
-   * single space, verified against our OWN signing key (no DID resolution).
-   * Yields the admitted space URI; the caller has no `did`.
+   * Space-credential auth: a multi-use, DPoP-key-bound JWT this service minted
+   * for a single space, verified against our OWN signing key (no DID
+   * resolution) and sender-constrained per request (RFC 9449). Yields the
+   * admitted space URI; the caller has no `did`.
    */
   spaceCredential: (
     ctx: import('@atproto/xrpc-server').MethodAuthContext,
   ) => Promise<{ credentials: { type: 'space-credential'; spaceUri: string } }>
   /**
    * Composition of {@link standard} and {@link spaceCredential}. A
-   * DPoP session yields `{ type: 'user', did }`; a space credential (a Bearer
-   * JWT whose `typ` is a space credential) yields
-   * `{ type: 'space-credential', spaceUri }`. Anything else is rejected. This
-   * is bound to read/sync endpoints ONLY; writes never accept a credential.
+   * DPoP session yields `{ type: 'user', did }`; a space credential (a JWT
+   * whose `typ` is a space credential, presented under the `DPoP` scheme)
+   * yields `{ type: 'space-credential', spaceUri }`. Anything else is rejected.
+   * This is bound to read/sync endpoints ONLY; writes never accept a credential.
    */
   standardOrSpaceCredential: (
     ctx: import('@atproto/xrpc-server').MethodAuthContext,
@@ -68,7 +72,7 @@ export interface AuthVerifiers {
    * Composition of {@link optionalStandard} and {@link spaceCredential}.
    * Used for read endpoints that were previously anonymous-friendly
    * (the hydration surface): an anonymous request stays anonymous (behaviour
-   * unchanged), a DPoP session yields a user, and a space-credential Bearer JWT
+   * unchanged), a DPoP session yields a user, and a presented space credential
    * yields `{ type: 'space-credential', spaceUri }`.
    */
   optionalStandardOrSpaceCredential: (
@@ -80,8 +84,8 @@ export interface AuthVerifiers {
   }>
   /**
    * Composition of {@link service} and {@link spaceCredential} for the
-   * pull-sync read endpoints. A space-credential Bearer JWT yields
-   * `{ type: 'space-credential', spaceUri }`; any other Bearer is verified as
+   * pull-sync read endpoints. A presented space credential yields
+   * `{ type: 'space-credential', spaceUri }`; any Bearer is verified as
    * inter-service auth and behaves EXACTLY as before.
    */
   serviceOrSpaceCredential: (
@@ -112,6 +116,7 @@ export interface AuthVerifiers {
  * @param allowListProvider - External allowlist provider
  * @param devMode - Development mode flag
  * @param signingKey - This service's signing keypair (space-credential authority)
+ * @param replayStore - Single-use nonce store for DPoP proof `jti` values
  * @param logger
  * @returns Auth verifiers object
  */
@@ -127,6 +132,7 @@ export function createAuthVerifiers(
   allowListProvider: ExternalAllowListProvider | undefined,
   devMode: boolean,
   signingKey: Pick<Keypair, 'did'>,
+  replayStore: ReplayStore | undefined,
   logger?: Logger,
 ): AuthVerifiers {
   const standard = createStandardVerifier({
@@ -141,6 +147,9 @@ export function createAuthVerifiers(
   const spaceCredential = createSpaceCredentialVerifier({
     serviceDid,
     signingKey,
+    proofChecker: new SpaceDpopProofChecker(cfg.service.publicUrl),
+    replayStore,
+    devMode,
     logger,
   })
   const service = createServiceVerifier({ serviceDid, idResolver })
@@ -220,7 +229,7 @@ async function handleDevModeAuth(
 async function verifyDpopAuth(
   ctx: Parameters<AuthVerifiers['standard']>[0],
   deps: StandardVerifierDeps,
-): Promise<{ credentials: { type: string; did: string } }> {
+): Promise<{ credentials: { type: string; did: string; jkt?: string } }> {
   try {
     const result = await deps.dpopVerifier.verify(
       {
@@ -242,7 +251,7 @@ async function verifyDpopAuth(
       logger: deps.logger,
     })
 
-    return { credentials: { type: 'user', did: result.did } }
+    return { credentials: { type: 'user', did: result.did, jkt: result.jkt } }
   } catch (err) {
     if (err instanceof DpopVerificationError && err.code === 'use_dpop_nonce') {
       const nonce = deps.dpopVerifier.nextNonce()
@@ -317,19 +326,32 @@ function createServiceVerifier(deps: {
 }
 
 /**
- * Extract a `Bearer` token whose JWT `typ` header is a space credential, or
- * `null` if the header is absent, not `Bearer`, or the token is not a
- * space-credential JWT. Only a cheap header peek — full verification (signature,
- * `exp`, `sub`) happens in {@link verifySpaceCredential}.
+ * Extract a token whose JWT `typ` header is a space credential, or `null` if
+ * the header is absent, not `DPoP`/`Bearer`, or the token is not a
+ * space-credential JWT. Only a cheap header peek — full verification
+ * (signature, `exp`, `sub`, proof) happens in the credential verifier.
+ *
+ * The spec scheme is `DPoP` (sender-constrained presentation). `Bearer` is
+ * recognized only so dev mode can present unbound credentials; the verifier
+ * rejects a Bearer presentation outside dev mode.
  *
  * @param authHeader - The raw Authorization header value.
- * @returns The bearer token when it looks like a space credential, else null.
+ * @returns The token and its scheme when it looks like a space credential.
  */
 function extractSpaceCredentialToken(
   authHeader: string | undefined,
-): string | null {
-  if (!authHeader?.startsWith('Bearer ')) return null
-  const token = authHeader.slice(7).trim()
+): { token: string; scheme: 'dpop' | 'bearer' } | null {
+  let token: string
+  let scheme: 'dpop' | 'bearer'
+  if (authHeader?.startsWith('DPoP ')) {
+    token = authHeader.slice(5).trim()
+    scheme = 'dpop'
+  } else if (authHeader?.startsWith('Bearer ')) {
+    token = authHeader.slice(7).trim()
+    scheme = 'bearer'
+  } else {
+    return null
+  }
   const parts = token.split('.')
   if (parts.length !== 3) return null
   try {
@@ -338,7 +360,7 @@ function extractSpaceCredentialToken(
     ) as {
       typ?: string
     }
-    return header?.typ === SPACE_CREDENTIAL_TYP ? token : null
+    return header?.typ === SPACE_CREDENTIAL_TYP ? { token, scheme } : null
   } catch {
     return null
   }
@@ -347,33 +369,89 @@ function extractSpaceCredentialToken(
 /**
  * Creates the space-credential auth verifier.
  *
- * Accepts a `Bearer` JWT whose `typ` is a space credential, verifies it against
- * OUR OWN signing key (no DID resolution), and yields the admitted space URI.
- * The caller has no `did`; downstream scope enforcement maps the space to its
- * boundary and injects a singleton viewer-boundary set so the existing
- * per-record gate still applies.
+ * Accepts a `DPoP`-scheme JWT whose `typ` is a space credential, verifies it
+ * against OUR OWN signing key (no DID resolution), checks the per-request DPoP
+ * proof against the credential's `cnf.jkt` binding (RFC 9449, with single-use
+ * proof `jti`), and yields the admitted space URI. The caller has no `did`;
+ * downstream scope enforcement maps the space to its boundary and injects a
+ * singleton viewer-boundary set so the existing per-record gate still applies.
  *
- * @param deps - Service DID, our signing key, and an optional logger.
+ * Dev-mode carve-out: a `Bearer` presentation is accepted ONLY in dev mode and
+ * ONLY for credentials minted without `cnf` — a bound credential can never be
+ * downgraded to an unproven Bearer presentation.
+ *
+ * Fail-closed: when no replay store is configured, DPoP presentation is
+ * unavailable and the request is rejected (a proof-replay check that cannot
+ * run must not grant access).
+ *
+ * @param deps - Service DID, signing key, proof checker, replay store, and flags.
  * @returns Auth verifier function.
  * @throws AuthRequiredError if the header is missing / not a space credential,
- *   or the credential fails verification.
+ *   or the credential or its proof fails verification.
  */
 function createSpaceCredentialVerifier(deps: {
   serviceDid: string
   signingKey: Pick<Keypair, 'did'>
+  proofChecker: SpaceDpopProofChecker
+  replayStore: ReplayStore | undefined
+  devMode: boolean
   logger?: Logger
 }): AuthVerifiers['spaceCredential'] {
   return async (ctx) => {
     const authHeader = ctx.req?.headers?.authorization
-    const token = extractSpaceCredentialToken(authHeader)
-    if (!token) {
+    const extracted = extractSpaceCredentialToken(authHeader)
+    if (!extracted) {
       throw new AuthRequiredError('Space credential required')
     }
+    const { token, scheme } = extracted
     try {
-      const result = await verifySpaceCredential(token, {
-        serviceKey: deps.signingKey,
-        serviceDid: deps.serviceDid,
-      })
+      let result
+      if (scheme === 'dpop') {
+        if (!deps.replayStore) {
+          deps.logger?.warn(
+            { path: ctx.req?.url },
+            'space credential rejected: no replay store (cache) configured',
+          )
+          throw new AuthRequiredError('Authorization failed')
+        }
+        result = await verifyPresentedSpaceCredential(
+          token,
+          {
+            method: ctx.req?.method || 'GET',
+            url: ctx.req?.url || '/',
+            headers: ctx.req?.headers as Record<
+              string,
+              string | string[] | undefined
+            >,
+          },
+          {
+            serviceKey: deps.signingKey,
+            serviceDid: deps.serviceDid,
+            proofChecker: deps.proofChecker,
+            replayStore: deps.replayStore,
+          },
+        )
+      } else {
+        if (!deps.devMode) {
+          deps.logger?.info(
+            { path: ctx.req?.url },
+            'auth rejected: space credential presented as Bearer outside dev mode',
+          )
+          throw new AuthRequiredError('Authorization failed')
+        }
+        result = await verifySpaceCredential(token, {
+          serviceKey: deps.signingKey,
+          serviceDid: deps.serviceDid,
+        })
+        if (result.cnfJkt) {
+          // A key-bound credential must present its proof even in dev mode.
+          deps.logger?.info(
+            { path: ctx.req?.url },
+            'auth rejected: bound space credential presented without DPoP proof',
+          )
+          throw new AuthRequiredError('Authorization failed')
+        }
+      }
       return {
         credentials: {
           type: 'space-credential' as const,
@@ -387,8 +465,9 @@ function createSpaceCredentialVerifier(deps: {
           'auth rejected: space credential verification failed',
         )
         // Generic message only: the detailed reason (expired / foreign /
-        // malformed / bad signature) stays in the log, matching the sibling
-        // verifiers, so callers cannot probe why a credential was rejected.
+        // malformed / bad signature / bad proof) stays in the log, matching
+        // the sibling verifiers, so callers cannot probe why a credential
+        // was rejected.
         throw new AuthRequiredError('Authorization failed')
       }
       throw err
@@ -398,10 +477,11 @@ function createSpaceCredentialVerifier(deps: {
 
 /**
  * Composes a space-credential verifier with a base verifier. Routing is
- * by JWT `typ`: a `Bearer` whose `typ` is a space credential takes the
- * space-credential path; anything else (no header, DPoP, dev `Bearer did:...`,
- * or inter-service `Bearer`) falls through to `fallback`, which behaves EXACTLY
- * as before. Bound to read/sync endpoints ONLY; write endpoints keep `standard`.
+ * by JWT `typ`: a `DPoP` or `Bearer` token whose `typ` is a space credential
+ * takes the space-credential path; anything else (no header, a DPoP session
+ * token, dev `Bearer did:...`, or inter-service `Bearer`) falls through to
+ * `fallback`, which behaves EXACTLY as before. Bound to read/sync endpoints
+ * ONLY; write endpoints keep `standard`.
  *
  * @param fallback - The base verifier used when the token is not a space credential.
  * @param spaceCredential - The space-credential verifier.
@@ -526,7 +606,9 @@ async function verifyDpop(
   },
   dpopVerifier: DpopVerifier,
 ): Promise<{
-  credentials: { type: 'user'; did: string } | { type: 'anonymous' }
+  credentials:
+    | { type: 'user'; did: string; jkt?: string }
+    | { type: 'anonymous' }
 }> {
   try {
     const result = await dpopVerifier.verify(
@@ -540,7 +622,7 @@ async function verifyDpop(
       },
     )
     return {
-      credentials: { type: 'user', did: result.did },
+      credentials: { type: 'user', did: result.did, jkt: result.jkt },
     }
   } catch (err) {
     if (err instanceof DpopVerificationError) {

--- a/stratos-service/tests/admin-auth.integration.test.ts
+++ b/stratos-service/tests/admin-auth.integration.test.ts
@@ -393,6 +393,8 @@ describe('admin auth verifier', () => {
       false,
       // signingKey — the space-credential path is not exercised here
       { did: () => cfg.service.did },
+      // replayStore — the space-credential path is not exercised here
+      undefined,
     )
   })
 

--- a/stratos-service/tests/delegation-verifier.test.ts
+++ b/stratos-service/tests/delegation-verifier.test.ts
@@ -40,10 +40,6 @@ const SPACE_URI = makeSpaceUri(
 )
 const AUD = `${SERVICE_DID}#atproto_space_host`
 
-// ---------------------------------------------------------------------------
-// In-memory NX-EX store + replay store helpers
-// ---------------------------------------------------------------------------
-
 /**
  * A minimal in-memory `NxExStore` that mimics `SET NX EX` semantics: the first
  * set for a key succeeds, subsequent sets fail. TTL is recorded but not expired
@@ -69,10 +65,6 @@ class DownNxExStore implements NxExStore {
   }
 }
 
-// ---------------------------------------------------------------------------
-// Token minting (hand-built compact JWT so we control typ/alg/kid/payload)
-// ---------------------------------------------------------------------------
-
 const b64url = (obj: unknown): string =>
   Buffer.from(JSON.stringify(obj)).toString('base64url')
 
@@ -86,7 +78,8 @@ interface MintOpts {
   aud?: string
   iat?: number
   exp?: number
-  jti?: string
+  /** `unknown` so a test can mint a malformed, non-string jti. */
+  jti?: unknown
   /** If set, corrupt the signature after signing. */
   tamperSignature?: boolean
 }
@@ -122,10 +115,6 @@ async function mintToken(opts: MintOpts): Promise<string> {
   }
   return `${signingInput}.${sigStr}`
 }
-
-// ---------------------------------------------------------------------------
-// Mock IdResolver returning a DID doc with a chosen set of verification methods
-// ---------------------------------------------------------------------------
 
 interface VmSpec {
   /** Fragment (e.g. '#atproto', '#atproto_pns'). */
@@ -173,10 +162,6 @@ function makeDeps(
   }
 }
 
-// ===========================================================================
-// ReplayStore
-// ===========================================================================
-
 describe('ReplayStore.consumeOnce', () => {
   it('returns true exactly once per (kind, jti), false thereafter', async () => {
     const store = new ReplayStore(new MemoryNxExStore())
@@ -212,10 +197,6 @@ describe('ReplayStore.consumeOnce', () => {
     expect(logger.error).toHaveBeenCalled()
   })
 })
-
-// ===========================================================================
-// verifyDelegationToken — happy path & single-use
-// ===========================================================================
 
 describe('verifyDelegationToken (happy path & replay)', () => {
   it('accepts a valid delegation token and returns userDid + spaceUri', async () => {
@@ -259,10 +240,6 @@ describe('verifyDelegationToken (happy path & replay)', () => {
     )
   })
 })
-
-// ===========================================================================
-// verifyDelegationToken — each violation → its distinct error
-// ===========================================================================
 
 describe('verifyDelegationToken (distinct rejection per violation)', () => {
   it('rejects a structurally malformed token', async () => {
@@ -394,6 +371,22 @@ describe('verifyDelegationToken (distinct rejection per violation)', () => {
     ).rejects.toBeInstanceOf(InvalidDelegationSignatureError)
   })
 
+  it('rejects a non-string jti', async () => {
+    const keypair = await Secp256k1Keypair.create({ exportable: true })
+    const token = await mintToken({ keypair, jti: { not: 'a-string' } })
+    await expect(
+      verifyDelegationToken(token, makeDeps(keypair)),
+    ).rejects.toBeInstanceOf(DelegationReplayError)
+  })
+
+  it('rejects an empty-string jti', async () => {
+    const keypair = await Secp256k1Keypair.create({ exportable: true })
+    const token = await mintToken({ keypair, jti: '' })
+    await expect(
+      verifyDelegationToken(token, makeDeps(keypair)),
+    ).rejects.toBeInstanceOf(DelegationReplayError)
+  })
+
   it('accepts a signature made by the #atproto key when other methods also exist', async () => {
     // Sanity mirror of the above: signing with #atproto succeeds even though a
     // second method is present.
@@ -415,10 +408,6 @@ describe('verifyDelegationToken (distinct rejection per violation)', () => {
   })
 })
 
-// ===========================================================================
-// Redis-down ⇒ reject
-// ===========================================================================
-
 describe('consumeDelegationJti (replay store unavailable)', () => {
   it('rejects when the replay store is down (fail closed)', async () => {
     const replayStore = new ReplayStore(new DownNxExStore())
@@ -427,10 +416,6 @@ describe('consumeDelegationJti (replay store unavailable)', () => {
     ).rejects.toBeInstanceOf(DelegationReplayError)
   })
 })
-
-// ===========================================================================
-// Two-phase proof: verification never consumes the jti; consume does
-// ===========================================================================
 
 describe('verifyDelegationToken / consumeDelegationJti (two-phase)', () => {
   it('verification (pass OR fail) leaves the jti unconsumed; consumeDelegationJti burns it with the correct TTL', async () => {

--- a/stratos-service/tests/delegation-verifier.test.ts
+++ b/stratos-service/tests/delegation-verifier.test.ts
@@ -5,13 +5,15 @@
  * These modules are dormant (wired to nothing yet); the contract these tests
  * pin down IS the deliverable. We mint delegation JWTs with local keypairs and
  * a hand-built header/payload so we can exercise every distinct rejection path
- * — including the ordering guarantee that an invalid token never burns its jti.
+ * — including the two-phase guarantee that verification never burns the jti;
+ * only the explicit `consumeDelegationJti` step does.
  */
 import { describe, expect, it, vi } from 'vitest'
 import { P256Keypair, Secp256k1Keypair } from '@atproto/crypto'
 import type { IdResolver } from '@atproto/identity'
 import type { Keypair } from '@atproto/crypto'
 import {
+  consumeDelegationJti,
   DelegationReplayError,
   DelegationTimingError,
   DELEGATION_REPLAY_KIND,
@@ -167,7 +169,6 @@ function makeDeps(
   return {
     serviceDid: SERVICE_DID,
     idResolver: atprotoResolver(keypair),
-    replayStore: new ReplayStore(new MemoryNxExStore()),
     ...overrides,
   }
 }
@@ -235,15 +236,25 @@ describe('verifyDelegationToken (happy path & replay)', () => {
     expect(result.userDid).toBe(keypair.did())
   })
 
-  it('accepts once, then rejects the second use as a replay', async () => {
+  it('returns the token jti without consuming it', async () => {
     const keypair = await Secp256k1Keypair.create({ exportable: true })
-    const deps = makeDeps(keypair) // shared replay store across both calls
+    const jti = freshJti()
+    const token = await mintToken({ keypair, jti })
+
+    const result = await verifyDelegationToken(token, makeDeps(keypair))
+    expect(result.jti).toBe(jti)
+  })
+
+  it('consumeDelegationJti accepts once, then rejects the second use as a replay', async () => {
+    const keypair = await Secp256k1Keypair.create({ exportable: true })
+    const replayStore = new ReplayStore(new MemoryNxExStore())
     const token = await mintToken({ keypair })
 
-    await expect(verifyDelegationToken(token, deps)).resolves.toMatchObject({
-      userDid: keypair.did(),
-    })
-    await expect(verifyDelegationToken(token, deps)).rejects.toBeInstanceOf(
+    const { jti } = await verifyDelegationToken(token, makeDeps(keypair))
+    await expect(
+      consumeDelegationJti(replayStore, jti),
+    ).resolves.toBeUndefined()
+    await expect(consumeDelegationJti(replayStore, jti)).rejects.toBeInstanceOf(
       DelegationReplayError,
     )
   })
@@ -379,7 +390,6 @@ describe('verifyDelegationToken (distinct rejection per violation)', () => {
       verifyDelegationToken(token, {
         serviceDid: SERVICE_DID,
         idResolver,
-        replayStore: new ReplayStore(new MemoryNxExStore()),
       }),
     ).rejects.toBeInstanceOf(InvalidDelegationSignatureError)
   })
@@ -400,7 +410,6 @@ describe('verifyDelegationToken (distinct rejection per violation)', () => {
       verifyDelegationToken(token, {
         serviceDid: SERVICE_DID,
         idResolver,
-        replayStore: new ReplayStore(new MemoryNxExStore()),
       }),
     ).resolves.toMatchObject({ userDid: iss })
   })
@@ -410,55 +419,47 @@ describe('verifyDelegationToken (distinct rejection per violation)', () => {
 // Redis-down ⇒ reject
 // ===========================================================================
 
-describe('verifyDelegationToken (replay store unavailable)', () => {
-  it('rejects a valid token when the replay store is down (fail closed)', async () => {
-    const keypair = await Secp256k1Keypair.create({ exportable: true })
-    const token = await mintToken({ keypair })
-    const deps = makeDeps(keypair, {
-      replayStore: new ReplayStore(new DownNxExStore()),
-    })
-    await expect(verifyDelegationToken(token, deps)).rejects.toBeInstanceOf(
-      DelegationReplayError,
-    )
+describe('consumeDelegationJti (replay store unavailable)', () => {
+  it('rejects when the replay store is down (fail closed)', async () => {
+    const replayStore = new ReplayStore(new DownNxExStore())
+    await expect(
+      consumeDelegationJti(replayStore, freshJti()),
+    ).rejects.toBeInstanceOf(DelegationReplayError)
   })
 })
 
 // ===========================================================================
-// Ordering proof: consumeOnce runs LAST (invalid token must not burn its jti)
+// Two-phase proof: verification never consumes the jti; consume does
 // ===========================================================================
 
-describe('verifyDelegationToken (consumeOnce runs LAST)', () => {
-  it('an invalid token (bad signature) does NOT consume its jti; a fresh valid token with the same jti still succeeds', async () => {
+describe('verifyDelegationToken / consumeDelegationJti (two-phase)', () => {
+  it('verification (pass OR fail) leaves the jti unconsumed; consumeDelegationJti burns it with the correct TTL', async () => {
     const keypair = await Secp256k1Keypair.create({ exportable: true })
     const mem = new MemoryNxExStore()
     const replayStore = new ReplayStore(mem)
     const sharedJti = freshJti()
+    const replayKey = `replay:${DELEGATION_REPLAY_KIND}:${sharedJti}`
 
-    // 1. Present an otherwise-valid token with a bad signature and the shared jti.
+    // 1. An otherwise-valid token with a bad signature and the shared jti.
     const badToken = await mintToken({
       keypair,
       jti: sharedJti,
       tamperSignature: true,
     })
     await expect(
-      verifyDelegationToken(badToken, makeDeps(keypair, { replayStore })),
+      verifyDelegationToken(badToken, makeDeps(keypair)),
     ).rejects.toBeInstanceOf(InvalidDelegationSignatureError)
+    expect(mem.keys.has(replayKey)).toBe(false)
 
-    // The jti must NOT have been consumed by the rejected token.
-    expect(mem.keys.has(`replay:${DELEGATION_REPLAY_KIND}:${sharedJti}`)).toBe(
-      false,
-    )
-
-    // 2. A fresh, genuinely valid token bearing the SAME jti still succeeds,
-    //    proving consumeOnce only ran after all other checks passed.
+    // 2. A genuinely valid token bearing the SAME jti verifies — and still
+    //    leaves the jti unconsumed.
     const goodToken = await mintToken({ keypair, jti: sharedJti })
-    await expect(
-      verifyDelegationToken(goodToken, makeDeps(keypair, { replayStore })),
-    ).resolves.toMatchObject({ userDid: keypair.did() })
+    const result = await verifyDelegationToken(goodToken, makeDeps(keypair))
+    expect(result.userDid).toBe(keypair.did())
+    expect(mem.keys.has(replayKey)).toBe(false)
 
-    // Now the jti is consumed with the correct TTL.
-    expect(
-      mem.keys.get(`replay:${DELEGATION_REPLAY_KIND}:${sharedJti}`)?.ttl,
-    ).toBe(DELEGATION_REPLAY_TTL)
+    // 3. Only the explicit consume step burns it, with the correct TTL.
+    await consumeDelegationJti(replayStore, result.jti)
+    expect(mem.keys.get(replayKey)?.ttl).toBe(DELEGATION_REPLAY_TTL)
   })
 })

--- a/stratos-service/tests/dpop-verifier.test.ts
+++ b/stratos-service/tests/dpop-verifier.test.ts
@@ -64,6 +64,7 @@ describe('DpopVerifier', () => {
       scope: 'atproto',
       pdsEndpoint: 'https://pds.example.com',
       tokenType: 'DPoP',
+      jkt: 'test-jkt',
     })
   })
 

--- a/stratos-service/tests/replay-store.test.ts
+++ b/stratos-service/tests/replay-store.test.ts
@@ -1,7 +1,3 @@
-/**
- * Unit tests for `replayStoreFromCache` — the structural seam that adapts the
- * process cache into a ReplayStore only when it exposes `setNxEx`.
- */
 import { describe, expect, it } from 'vitest'
 import {
   ReplayStore,
@@ -9,7 +5,6 @@ import {
   type NxExStore,
 } from '../src/infra/auth/replay-store.js'
 
-/** In-memory SET-NX-EX store. First set of a key wins. */
 class MemoryNxExStore implements NxExStore {
   private readonly seen = new Set<string>()
   async setNxEx(key: string): Promise<boolean> {

--- a/stratos-service/tests/replay-store.test.ts
+++ b/stratos-service/tests/replay-store.test.ts
@@ -31,11 +31,11 @@ describe('replayStoreFromCache', () => {
   it('wraps a setNxEx-capable cache into a working ReplayStore', async () => {
     const store = replayStoreFromCache(new MemoryNxExStore())
     expect(store).toBeInstanceOf(ReplayStore)
-    await expect(store!.consumeOnce('space-dpop', 'jti-rei', 300)).resolves.toBe(
-      true,
-    )
-    await expect(store!.consumeOnce('space-dpop', 'jti-rei', 300)).resolves.toBe(
-      false,
-    )
+    await expect(
+      store!.consumeOnce('space-dpop', 'jti-rei', 300),
+    ).resolves.toBe(true)
+    await expect(
+      store!.consumeOnce('space-dpop', 'jti-rei', 300),
+    ).resolves.toBe(false)
   })
 })

--- a/stratos-service/tests/replay-store.test.ts
+++ b/stratos-service/tests/replay-store.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Unit tests for `replayStoreFromCache` — the structural seam that adapts the
+ * process cache into a ReplayStore only when it exposes `setNxEx`.
+ */
+import { describe, expect, it } from 'vitest'
+import {
+  ReplayStore,
+  replayStoreFromCache,
+  type NxExStore,
+} from '../src/infra/auth/replay-store.js'
+
+/** In-memory SET-NX-EX store. First set of a key wins. */
+class MemoryNxExStore implements NxExStore {
+  private readonly seen = new Set<string>()
+  async setNxEx(key: string): Promise<boolean> {
+    if (this.seen.has(key)) return false
+    this.seen.add(key)
+    return true
+  }
+}
+
+describe('replayStoreFromCache', () => {
+  it('returns undefined when no cache is configured', () => {
+    expect(replayStoreFromCache(undefined)).toBeUndefined()
+  })
+
+  it('returns undefined for a cache without setNxEx', () => {
+    expect(replayStoreFromCache({})).toBeUndefined()
+  })
+
+  it('wraps a setNxEx-capable cache into a working ReplayStore', async () => {
+    const store = replayStoreFromCache(new MemoryNxExStore())
+    expect(store).toBeInstanceOf(ReplayStore)
+    await expect(store!.consumeOnce('space-dpop', 'jti-rei', 300)).resolves.toBe(
+      true,
+    )
+    await expect(store!.consumeOnce('space-dpop', 'jti-rei', 300)).resolves.toBe(
+      false,
+    )
+  })
+})

--- a/stratos-service/tests/space-credential-acceptance.test.ts
+++ b/stratos-service/tests/space-credential-acceptance.test.ts
@@ -6,13 +6,21 @@
  * the existing per-record boundary gate is UNCHANGED — a credential for S
  * yields records in S ONLY, and only those the gate would release to a member
  * of S. We assert this on the hydration and pull-sync endpoints, plus the
- * verifier-composition routing (DPoP / service paths unchanged; writes reject).
+ * verifier-composition routing (DPoP / service paths unchanged; writes reject)
+ * and DPoP sender-constrained presentation (cnf.jkt binding, proof replay,
+ * Bearer-only-in-dev-mode, fail-closed without a replay store).
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { mkdir, rm } from 'node:fs/promises'
 import { join } from 'path'
 import { tmpdir } from 'os'
-import { randomBytes } from 'crypto'
+import { createHash, randomBytes, randomUUID } from 'crypto'
+import {
+  SignJWT,
+  calculateJwkThumbprint,
+  exportJWK,
+  generateKeyPair,
+} from 'jose'
 import { Secp256k1Keypair } from '@atproto/crypto'
 import { AuthRequiredError } from '@atproto/xrpc-server'
 import { encodeRecord, spaceUriToBoundary } from '@northskysocial/stratos-core'
@@ -32,6 +40,7 @@ import { registerHydrationHandlers } from '../src/features/index.js'
 import { HydrationServiceImpl } from '../src/features/hydration/adapter.js'
 import { mintSpaceCredential } from '../src/features/space-credential/minter.js'
 import { createAuthVerifiers } from '../src/infra/auth/verifiers.js'
+import { ReplayStore, type NxExStore } from '../src/infra/auth/replay-store.js'
 import { createMockBlobStore, createTestConfig } from './utils/index.js'
 import { makeSpaceUri } from './helpers/space-uri.js'
 import { decode } from '@atcute/cbor'
@@ -95,14 +104,53 @@ describe('space-credential acceptance', () => {
   // ── helpers ────────────────────────────────────────────────────────────
 
   /** Mint a valid space credential for a space (signed by our service key). */
-  async function credentialFor(spaceUri: string): Promise<string> {
+  async function credentialFor(spaceUri: string, jkt?: string): Promise<string> {
     const { credential } = await mintSpaceCredential({
       signingKey,
       issuerDid: SERVICE_DID,
       spaceUri,
       ttlSeconds: 7_200,
+      ...(jkt ? { jkt } : {}),
     })
     return credential
+  }
+
+  /** In-memory SET-NX-EX store backing a real ReplayStore. First set wins. */
+  class MemoryNxExStore implements NxExStore {
+    private readonly seen = new Set<string>()
+    async setNxEx(key: string): Promise<boolean> {
+      if (this.seen.has(key)) return false
+      this.seen.add(key)
+      return true
+    }
+  }
+
+  /**
+   * A presentation keypair: its RFC 7638 thumbprint (jkt) plus a builder that
+   * signs an ath-bound DPoP presentation proof for a given credential+request.
+   */
+  async function makePresentationKey() {
+    const { privateKey, publicKey } = await generateKeyPair('ES256', {
+      extractable: true,
+    })
+    const jwk = await exportJWK(publicKey)
+    const jkt = await calculateJwkThumbprint(jwk)
+    async function buildProof(
+      credential: string,
+      url = '/x',
+      method = 'GET',
+    ): Promise<string> {
+      return new SignJWT({
+        htm: method,
+        htu: new URL(url, 'https://stratos.test').toString(),
+        ath: createHash('sha256').update(credential).digest('base64url'),
+        jti: randomUUID(),
+      })
+        .setProtectedHeader({ typ: 'dpop+jwt', alg: 'ES256', jwk })
+        .setIssuedAt()
+        .sign(privateKey)
+    }
+    return { jkt, buildProof }
   }
 
   /** A handler-shaped auth carrying a verified space credential. */
@@ -347,8 +395,11 @@ describe('space-credential acceptance', () => {
   // ── verifier composition (routing + regression) ──────────────────────────
 
   describe('verifier composition', () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    function makeVerifiers(): any {
+    function makeVerifiers(opts?: {
+      devMode?: boolean
+      withoutReplayStore?: boolean
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    }): any {
       return createAuthVerifiers(
         SERVICE_DID,
         // idResolver — only used by service/standard paths we don't exercise
@@ -381,22 +432,83 @@ describe('space-credential acceptance', () => {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
         } as any,
         undefined,
-        false,
+        opts?.devMode ?? false,
         signingKey,
+        opts?.withoutReplayStore
+          ? undefined
+          : new ReplayStore(new MemoryNxExStore()),
         ctx.logger,
       )
     }
 
-    function ctxWithHeader(authorization?: string) {
+    function ctxWithHeader(
+      authorization?: string,
+      extraHeaders?: Record<string, string>,
+    ) {
       return {
-        req: { headers: authorization ? { authorization } : {}, url: '/x' },
+        req: {
+          method: 'GET',
+          headers: {
+            ...(authorization ? { authorization } : {}),
+            ...(extraHeaders ?? {}),
+          },
+          url: '/x',
+        },
         res: { setHeader: vi.fn() },
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } as any
     }
 
-    it('spaceCredential verifier accepts a valid credential (Bearer)', async () => {
+    it('spaceCredential accepts a BOUND credential presented under DPoP with a valid proof', async () => {
       const verifiers = makeVerifiers()
+      const key = await makePresentationKey()
+      const cred = await credentialFor(SPACE_S, key.jkt)
+      const result = await verifiers.spaceCredential(
+        ctxWithHeader(`DPoP ${cred}`, { dpop: await key.buildProof(cred) }),
+      )
+      expect(result.credentials).toEqual({
+        type: 'space-credential',
+        spaceUri: SPACE_S,
+      })
+    })
+
+    it('spaceCredential REJECTS a proof replay (same jti twice)', async () => {
+      const verifiers = makeVerifiers()
+      const key = await makePresentationKey()
+      const cred = await credentialFor(SPACE_S, key.jkt)
+      const proof = await key.buildProof(cred)
+      await verifiers.spaceCredential(ctxWithHeader(`DPoP ${cred}`, { dpop: proof }))
+      // The same verifiers instance shares one replay store — the second
+      // presentation of the SAME proof must fail.
+      await expect(
+        verifiers.spaceCredential(ctxWithHeader(`DPoP ${cred}`, { dpop: proof })),
+      ).rejects.toBeInstanceOf(AuthRequiredError)
+    })
+
+    it('spaceCredential REJECTS a proof signed by a key other than cnf.jkt', async () => {
+      const verifiers = makeVerifiers()
+      const boundKey = await makePresentationKey()
+      const attackerKey = await makePresentationKey()
+      const cred = await credentialFor(SPACE_S, boundKey.jkt)
+      await expect(
+        verifiers.spaceCredential(
+          ctxWithHeader(`DPoP ${cred}`, {
+            dpop: await attackerKey.buildProof(cred),
+          }),
+        ),
+      ).rejects.toBeInstanceOf(AuthRequiredError)
+    })
+
+    it('spaceCredential REJECTS a Bearer credential outside dev mode', async () => {
+      const verifiers = makeVerifiers()
+      const cred = await credentialFor(SPACE_S)
+      await expect(
+        verifiers.spaceCredential(ctxWithHeader(`Bearer ${cred}`)),
+      ).rejects.toBeInstanceOf(AuthRequiredError)
+    })
+
+    it('dev mode: spaceCredential accepts an UNBOUND credential over Bearer', async () => {
+      const verifiers = makeVerifiers({ devMode: true })
       const cred = await credentialFor(SPACE_S)
       const result = await verifiers.spaceCredential(
         ctxWithHeader(`Bearer ${cred}`),
@@ -407,8 +519,28 @@ describe('space-credential acceptance', () => {
       })
     })
 
+    it('dev mode: spaceCredential REJECTS a BOUND credential over Bearer (no downgrade)', async () => {
+      const verifiers = makeVerifiers({ devMode: true })
+      const key = await makePresentationKey()
+      const cred = await credentialFor(SPACE_S, key.jkt)
+      await expect(
+        verifiers.spaceCredential(ctxWithHeader(`Bearer ${cred}`)),
+      ).rejects.toBeInstanceOf(AuthRequiredError)
+    })
+
+    it('fails closed: DPoP presentation REJECTED when no replay store is configured', async () => {
+      const verifiers = makeVerifiers({ withoutReplayStore: true })
+      const key = await makePresentationKey()
+      const cred = await credentialFor(SPACE_S, key.jkt)
+      await expect(
+        verifiers.spaceCredential(
+          ctxWithHeader(`DPoP ${cred}`, { dpop: await key.buildProof(cred) }),
+        ),
+      ).rejects.toBeInstanceOf(AuthRequiredError)
+    })
+
     it('standardOrSpaceCredential routes a credential Bearer to the credential path', async () => {
-      const verifiers = makeVerifiers()
+      const verifiers = makeVerifiers({ devMode: true })
       const cred = await credentialFor(SPACE_S)
       const result = await verifiers.standardOrSpaceCredential(
         ctxWithHeader(`Bearer ${cred}`),
@@ -431,8 +563,10 @@ describe('space-credential acceptance', () => {
       expect(result.credentials).toEqual({ type: 'anonymous' })
     })
 
+    // The three rejection tests below present over dev-mode Bearer so the
+    // failure they observe is the CREDENTIAL check, not the scheme gate.
     it('rejects an expired credential through the composition', async () => {
-      const verifiers = makeVerifiers()
+      const verifiers = makeVerifiers({ devMode: true })
       const iat = Math.floor(Date.now() / 1000) - 10_000
       const { credential } = await mintSpaceCredential({
         signingKey,
@@ -447,7 +581,7 @@ describe('space-credential acceptance', () => {
     })
 
     it('rejects a bad-signature credential through the composition', async () => {
-      const verifiers = makeVerifiers()
+      const verifiers = makeVerifiers({ devMode: true })
       const attacker = await Secp256k1Keypair.create()
       const { credential } = await mintSpaceCredential({
         signingKey: attacker, // wrong signer
@@ -461,7 +595,7 @@ describe('space-credential acceptance', () => {
     })
 
     it('rejects a foreign-space credential (spaceDid ≠ serviceDid)', async () => {
-      const verifiers = makeVerifiers()
+      const verifiers = makeVerifiers({ devMode: true })
       const { credential } = await mintSpaceCredential({
         signingKey,
         issuerDid: SERVICE_DID,

--- a/stratos-service/tests/space-credential-acceptance.test.ts
+++ b/stratos-service/tests/space-credential-acceptance.test.ts
@@ -104,7 +104,10 @@ describe('space-credential acceptance', () => {
   // ── helpers ────────────────────────────────────────────────────────────
 
   /** Mint a valid space credential for a space (signed by our service key). */
-  async function credentialFor(spaceUri: string, jkt?: string): Promise<string> {
+  async function credentialFor(
+    spaceUri: string,
+    jkt?: string,
+  ): Promise<string> {
     const { credential } = await mintSpaceCredential({
       signingKey,
       issuerDid: SERVICE_DID,
@@ -472,16 +475,33 @@ describe('space-credential acceptance', () => {
       })
     })
 
+    it('spaceCredential accepts a lowercase "dpop" auth scheme (RFC 9110: schemes are case-insensitive)', async () => {
+      const verifiers = makeVerifiers()
+      const key = await makePresentationKey()
+      const cred = await credentialFor(SPACE_S, key.jkt)
+      const result = await verifiers.spaceCredential(
+        ctxWithHeader(`dpop ${cred}`, { dpop: await key.buildProof(cred) }),
+      )
+      expect(result.credentials).toEqual({
+        type: 'space-credential',
+        spaceUri: SPACE_S,
+      })
+    })
+
     it('spaceCredential REJECTS a proof replay (same jti twice)', async () => {
       const verifiers = makeVerifiers()
       const key = await makePresentationKey()
       const cred = await credentialFor(SPACE_S, key.jkt)
       const proof = await key.buildProof(cred)
-      await verifiers.spaceCredential(ctxWithHeader(`DPoP ${cred}`, { dpop: proof }))
+      await verifiers.spaceCredential(
+        ctxWithHeader(`DPoP ${cred}`, { dpop: proof }),
+      )
       // The same verifiers instance shares one replay store — the second
       // presentation of the SAME proof must fail.
       await expect(
-        verifiers.spaceCredential(ctxWithHeader(`DPoP ${cred}`, { dpop: proof })),
+        verifiers.spaceCredential(
+          ctxWithHeader(`DPoP ${cred}`, { dpop: proof }),
+        ),
       ).rejects.toBeInstanceOf(AuthRequiredError)
     })
 

--- a/stratos-service/tests/space-credential-app-gating.test.ts
+++ b/stratos-service/tests/space-credential-app-gating.test.ts
@@ -63,8 +63,9 @@ async function invoke(
 ): Promise<InvokeResult> {
   const method = server.methods['zone.stratos.space.getSpaceCredential']
   if (!method) throw new Error('method not registered')
+  // A session jkt so the mint clears the key-binding guard (not under test here).
   const auth = authDid
-    ? { credentials: { type: 'user', did: authDid } }
+    ? { credentials: { type: 'user', did: authDid, jkt: 'thumb-gate' } }
     : { credentials: { type: 'anonymous' } }
   try {
     const result = await method.handler({
@@ -115,6 +116,7 @@ function createMockCtx(opts: MockCtxOptions): AppContext {
     cache: new MemoryCache(),
     jwksResolver: resolverFor(opts.clients, { failFetch: opts.failFetch }),
     cfg: {
+      service: { publicUrl: 'https://stratos.test' },
       stratos: {
         spaceCredentialTtlSeconds: TTL_SECONDS,
         spaceAppAccess: validateSpaceAppAccess(

--- a/stratos-service/tests/space-credential-handler.test.ts
+++ b/stratos-service/tests/space-credential-handler.test.ts
@@ -177,7 +177,9 @@ function createMockCtx(opts: MockCtxOptions): AppContext {
     idResolver:
       opts.idResolver ??
       ({ did: { resolve: vi.fn() } } as unknown as IdResolver),
-    cache: opts.cache,
+    // Default to a working store: a production mint requires one. Pass an
+    // explicit `cache: undefined` to exercise the no-store rejection paths.
+    cache: 'cache' in opts ? opts.cache : new MemoryNxExStore(),
     cfg: {
       service: { publicUrl: PUBLIC_URL },
       stratos: {
@@ -566,6 +568,49 @@ describe('getSpaceCredential — delegation-token path', () => {
     expect(res.error?.name).toBe('ProofRequired')
   })
 
+  it('a request that fails a later gate does NOT burn the token: a retry with the proof succeeds', async () => {
+    const { userKey, server } = await setup(true)
+    const token = await mintDelegation({ userKey, iss: userKey.did() })
+
+    // First presentation fails the mint-proof gate AFTER identity resolution.
+    const first = await invoke(server, {
+      space: SPACE_URI,
+      delegationToken: token,
+    })
+    expect(first.error?.name).toBe('ProofRequired')
+
+    // The single-use jti was not consumed: the SAME token still mints.
+    const { proof } = await makeMintProof(`${PUBLIC_URL}${MINT_PATH}`)
+    const second = await invoke(
+      server,
+      { space: SPACE_URI, delegationToken: token },
+      undefined,
+      { req: { method: 'POST', url: MINT_PATH, headers: { dpop: proof } } },
+    )
+    expect(second.error).toBeUndefined()
+    expect(second.body?.credential).toBeTruthy()
+  })
+
+  it('a successful mint burns the token: replaying it → InvalidToken', async () => {
+    const { userKey, server } = await setup(true)
+    const token = await mintDelegation({ userKey, iss: userKey.did() })
+    const present = async () => {
+      const { proof } = await makeMintProof(`${PUBLIC_URL}${MINT_PATH}`)
+      return invoke(
+        server,
+        { space: SPACE_URI, delegationToken: token },
+        undefined,
+        { req: { method: 'POST', url: MINT_PATH, headers: { dpop: proof } } },
+      )
+    }
+
+    const first = await present()
+    expect(first.error).toBeUndefined()
+
+    const second = await present()
+    expect(second.error?.name).toBe('InvalidToken')
+  })
+
   it('dev mode: the delegation path STILL requires the mint proof', async () => {
     // Dev mode relaxes only the DPoP-session path (unbound mint). A delegated
     // mint proves key possession with the mint proof, so its absence must
@@ -667,7 +712,9 @@ describe('getSpaceCredential — delegation-token path', () => {
     expect(res.error?.name).toBe('InvalidToken')
   })
 
-  it('delegation path unavailable when no replay store configured → InvalidToken', async () => {
+  it('production with no replay store → mint refused (InternalServerError)', async () => {
+    // A presented credential is replay-checked; with no store the presentation
+    // verifier fail-closes, so the mint itself must refuse.
     const signingKey = await Secp256k1Keypair.create()
     const userKey = await Secp256k1Keypair.create()
     const ctx = createMockCtx({
@@ -675,6 +722,28 @@ describe('getSpaceCredential — delegation-token path', () => {
       enrolledBoundaries: [SPACE_BOUNDARY],
       idResolver: atprotoResolver(userKey.did(), userKey),
       cache: undefined,
+    })
+    const server = createMockXrpcServer()
+    registerSpaceCredentialHandlers(server as any, ctx)
+    const token = await mintDelegation({ userKey, iss: userKey.did() })
+    const res = await invoke(server, {
+      space: SPACE_URI,
+      delegationToken: token,
+    })
+    expect(res.error?.name).toBe('InternalServerError')
+  })
+
+  it('dev mode with no replay store: delegation path still rejects → InvalidToken', async () => {
+    // Dev mode skips the mint guard (unbound Bearer presentation works), but
+    // the single-use delegation check still needs a store and fails closed.
+    const signingKey = await Secp256k1Keypair.create()
+    const userKey = await Secp256k1Keypair.create()
+    const ctx = createMockCtx({
+      signingKey,
+      enrolledBoundaries: [SPACE_BOUNDARY],
+      idResolver: atprotoResolver(userKey.did(), userKey),
+      cache: undefined,
+      devMode: true,
     })
     const server = createMockXrpcServer()
     registerSpaceCredentialHandlers(server as any, ctx)

--- a/stratos-service/tests/space-credential-handler.test.ts
+++ b/stratos-service/tests/space-credential-handler.test.ts
@@ -52,9 +52,6 @@ const SPACE_URI = makeSpaceUri(
 const SPACE_BOUNDARY = `${SERVICE_DID}/myspace`
 const USER_DID = 'did:plc:abcabcabcabcabcabcabcabc'
 
-// ---------------------------------------------------------------------------
-// Mock XRPC server (records registered methods; invoked directly).
-// ---------------------------------------------------------------------------
 interface MockXrpcServer {
   methods: Record<string, { type: string; auth?: unknown; handler: Function }>
   method: (
@@ -122,10 +119,6 @@ async function invoke(
     return { error: { name, message: e.message } }
   }
 }
-
-// ---------------------------------------------------------------------------
-// Mock AppContext.
-// ---------------------------------------------------------------------------
 
 /** In-memory NX-EX store (first set wins) so the delegation replay check works. */
 class MemoryNxExStore implements NxExStore {
@@ -203,9 +196,6 @@ function createMockCtx(opts: MockCtxOptions): AppContext {
   } as unknown as AppContext
 }
 
-// ---------------------------------------------------------------------------
-// Delegation-token minting (real delegation shape, signed by the user key).
-// ---------------------------------------------------------------------------
 const b64url = (v: unknown): string =>
   Buffer.from(JSON.stringify(v)).toString('base64url')
 
@@ -247,9 +237,6 @@ async function mintDelegation(opts: DelegationMintOpts): Promise<string> {
   return `${signingInput}.${Buffer.from(sig).toString('base64url')}`
 }
 
-// ---------------------------------------------------------------------------
-// Mint-time DPoP proof (real ES256 proof with an embedded JWK; no `ath`).
-// ---------------------------------------------------------------------------
 async function makeMintProof(
   htu: string,
 ): Promise<{ proof: string; jkt: string }> {
@@ -265,9 +252,6 @@ async function makeMintProof(
   return { proof, jkt }
 }
 
-// ---------------------------------------------------------------------------
-// Credential decode/verify helpers.
-// ---------------------------------------------------------------------------
 function decodeCredential(jwt: string) {
   const parts = jwt.split('.')
   return {
@@ -290,9 +274,6 @@ async function verifyCredentialAgainst(
   )
 }
 
-// ===========================================================================
-// DPoP (interim, live) path
-// ===========================================================================
 describe('getSpaceCredential — DPoP path', () => {
   it('issues a credential BOUND to the session DPoP key (verifies; no aud; TTL)', async () => {
     const signingKey = await Secp256k1Keypair.create()
@@ -420,10 +401,6 @@ describe('getSpaceCredential — DPoP path', () => {
   })
 })
 
-// ===========================================================================
-// Deactivation gate
-// ===========================================================================
-
 /**
  * Deactivation revokes credential issuance.
  *
@@ -517,9 +494,6 @@ describe('getSpaceCredential — deactivation gate', () => {
   })
 })
 
-// ===========================================================================
-// Delegation-token (dormant) path
-// ===========================================================================
 describe('getSpaceCredential — delegation-token path', () => {
   async function setup(enrolled: boolean) {
     const signingKey = await Secp256k1Keypair.create()

--- a/stratos-service/tests/space-credential-handler.test.ts
+++ b/stratos-service/tests/space-credential-handler.test.ts
@@ -566,6 +566,29 @@ describe('getSpaceCredential — delegation-token path', () => {
     expect(res.error?.name).toBe('ProofRequired')
   })
 
+  it('dev mode: the delegation path STILL requires the mint proof', async () => {
+    // Dev mode relaxes only the DPoP-session path (unbound mint). A delegated
+    // mint proves key possession with the mint proof, so its absence must
+    // reject — never fall back to an unbound credential.
+    const signingKey = await Secp256k1Keypair.create()
+    const userKey = await Secp256k1Keypair.create()
+    const ctx = createMockCtx({
+      signingKey,
+      enrolledBoundaries: [SPACE_BOUNDARY],
+      idResolver: atprotoResolver(userKey.did(), userKey),
+      cache: new MemoryNxExStore(),
+      devMode: true,
+    })
+    const server = createMockXrpcServer()
+    registerSpaceCredentialHandlers(server as any, ctx)
+    const token = await mintDelegation({ userKey, iss: userKey.did() })
+    const res = await invoke(server, {
+      space: SPACE_URI,
+      delegationToken: token,
+    })
+    expect(res.error?.name).toBe('ProofRequired')
+  })
+
   it('valid token but user not enrolled → NotEnrolled', async () => {
     const { userKey, server } = await setup(false)
     const token = await mintDelegation({ userKey, iss: userKey.did() })

--- a/stratos-service/tests/space-credential-handler.test.ts
+++ b/stratos-service/tests/space-credential-handler.test.ts
@@ -8,11 +8,22 @@
  *     while holding the boundary, and the deny lands on the very next mint.
  *   - Delegation-token path (dormant, real delegation verifier): happy path
  *     issues a credential; every verification failure surfaces as `InvalidToken`.
+ *   - Key binding: the DPoP path binds the session key's `jkt` into `cnf.jkt`;
+ *     the delegation path requires a REAL standalone DPoP proof (jose-built,
+ *     ES256, embedded JWK) and binds the proof key. An unbound mint is refused
+ *     outside dev mode (`ProofRequired`).
  * The issued credential is decoded and verified against the service key (and
  * asserted to FAIL against another key), with the full spec claim set checked
  * including the absence of `aud`, and `exp - iat` equal to the configured TTL.
  */
+import { randomUUID } from 'node:crypto'
 import { describe, expect, it, vi } from 'vitest'
+import {
+  SignJWT,
+  calculateJwkThumbprint,
+  exportJWK,
+  generateKeyPair,
+} from 'jose'
 import { Secp256k1Keypair, verifySignature } from '@atproto/crypto'
 import type { Keypair } from '@atproto/crypto'
 import type { IdResolver } from '@atproto/identity'
@@ -29,6 +40,8 @@ import type { AppContext } from '../src/index.js'
 import { makeSpaceUri } from './helpers/space-uri.js'
 
 const SERVICE_DID = 'did:web:stratos.test'
+const PUBLIC_URL = 'https://stratos.test'
+const MINT_PATH = '/xrpc/zone.stratos.space.getSpaceCredential'
 const TTL_SECONDS = 7_200
 const SPACE_URI = makeSpaceUri(
   SERVICE_DID,
@@ -65,22 +78,34 @@ interface InvokeResult {
   error?: { name: string; message: string }
 }
 
+interface InvokeOptions {
+  /** DPoP session key thumbprint carried on the caller's auth credentials. */
+  jkt?: string
+  /** Request shape (method/url/headers) for mint-time DPoP proof checks. */
+  req?: {
+    method?: string
+    url?: string
+    headers?: Record<string, string | string[] | undefined>
+  }
+}
+
 async function invoke(
   server: MockXrpcServer,
   input: Record<string, unknown>,
   authDid?: string,
+  opts?: InvokeOptions,
 ): Promise<InvokeResult> {
   const method = server.methods['zone.stratos.space.getSpaceCredential']
   if (!method) throw new Error('method not registered')
   const auth = authDid
-    ? { credentials: { type: 'user', did: authDid } }
+    ? { credentials: { type: 'user', did: authDid, jkt: opts?.jkt } }
     : { credentials: { type: 'anonymous' } }
   try {
     const result = await method.handler({
       input: { body: input, encoding: 'application/json' },
       params: {},
       auth,
-      req: { headers: {} },
+      req: opts?.req ?? { headers: {} },
     })
     return { body: result.body }
   } catch (err) {
@@ -136,6 +161,8 @@ interface MockCtxOptions {
   enrolledBoundaries?: string[]
   /** Whether the caller's enrollment row is still active. Defaults to true. */
   enrollmentActive?: boolean
+  /** Dev-mode flag; only dev mode may mint UNBOUND (no cnf) credentials. */
+  devMode?: boolean
   idResolver?: IdResolver
   cache?: NxExStore
 }
@@ -152,7 +179,11 @@ function createMockCtx(opts: MockCtxOptions): AppContext {
       ({ did: { resolve: vi.fn() } } as unknown as IdResolver),
     cache: opts.cache,
     cfg: {
-      stratos: { spaceCredentialTtlSeconds: TTL_SECONDS },
+      service: { publicUrl: PUBLIC_URL },
+      stratos: {
+        spaceCredentialTtlSeconds: TTL_SECONDS,
+        ...(opts.devMode === undefined ? {} : { devMode: opts.devMode }),
+      },
     },
     enrollmentStore: {
       getEnrollment: vi.fn(async (did: string) => ({
@@ -215,6 +246,24 @@ async function mintDelegation(opts: DelegationMintOpts): Promise<string> {
 }
 
 // ---------------------------------------------------------------------------
+// Mint-time DPoP proof (real ES256 proof with an embedded JWK; no `ath`).
+// ---------------------------------------------------------------------------
+async function makeMintProof(
+  htu: string,
+): Promise<{ proof: string; jkt: string }> {
+  const { privateKey, publicKey } = await generateKeyPair('ES256', {
+    extractable: true,
+  })
+  const jwk = await exportJWK(publicKey)
+  const jkt = await calculateJwkThumbprint(jwk)
+  const proof = await new SignJWT({ htm: 'POST', htu, jti: randomUUID() })
+    .setProtectedHeader({ typ: 'dpop+jwt', alg: 'ES256', jwk })
+    .setIssuedAt()
+    .sign(privateKey)
+  return { proof, jkt }
+}
+
+// ---------------------------------------------------------------------------
 // Credential decode/verify helpers.
 // ---------------------------------------------------------------------------
 function decodeCredential(jwt: string) {
@@ -243,7 +292,7 @@ async function verifyCredentialAgainst(
 // DPoP (interim, live) path
 // ===========================================================================
 describe('getSpaceCredential — DPoP path', () => {
-  it('issues a credential to an enrolled DPoP-authed user (verifies; no aud; TTL)', async () => {
+  it('issues a credential BOUND to the session DPoP key (verifies; no aud; TTL)', async () => {
     const signingKey = await Secp256k1Keypair.create()
     const ctx = createMockCtx({
       signingKey,
@@ -252,7 +301,9 @@ describe('getSpaceCredential — DPoP path', () => {
     const server = createMockXrpcServer()
     registerSpaceCredentialHandlers(server as any, ctx)
 
-    const res = await invoke(server, { space: SPACE_URI }, USER_DID)
+    const res = await invoke(server, { space: SPACE_URI }, USER_DID, {
+      jkt: 'thumb-misato',
+    })
     expect(res.error).toBeUndefined()
     expect(res.body?.credential).toBeTruthy()
 
@@ -265,6 +316,7 @@ describe('getSpaceCredential — DPoP path', () => {
     expect(payload.iss).toBe(SERVICE_DID)
     expect(payload.sub).toBe(SPACE_URI)
     expect('aud' in payload).toBe(false)
+    expect(payload.cnf).toEqual({ jkt: 'thumb-misato' })
     expect(payload.exp - payload.iat).toBe(TTL_SECONDS)
     expect(res.body!.expiresAt).toBe(new Date(payload.exp * 1000).toISOString())
 
@@ -333,6 +385,36 @@ describe('getSpaceCredential — DPoP path', () => {
 
     const res = await invoke(server, { space: 'not-a-space-uri' }, USER_DID)
     expect(res.error?.name).toBe('UnknownSpace')
+  })
+
+  it('rejects a jkt-less session outside dev mode with ProofRequired', async () => {
+    const signingKey = await Secp256k1Keypair.create()
+    const ctx = createMockCtx({
+      signingKey,
+      enrolledBoundaries: [SPACE_BOUNDARY],
+    })
+    const server = createMockXrpcServer()
+    registerSpaceCredentialHandlers(server as any, ctx)
+
+    const res = await invoke(server, { space: SPACE_URI }, USER_DID)
+    expect(res.error?.name).toBe('ProofRequired')
+    expect(res.body).toBeUndefined()
+  })
+
+  it('dev mode: mints an UNBOUND credential (no cnf) for a jkt-less session', async () => {
+    const signingKey = await Secp256k1Keypair.create()
+    const ctx = createMockCtx({
+      signingKey,
+      enrolledBoundaries: [SPACE_BOUNDARY],
+      devMode: true,
+    })
+    const server = createMockXrpcServer()
+    registerSpaceCredentialHandlers(server as any, ctx)
+
+    const res = await invoke(server, { space: SPACE_URI }, USER_DID)
+    expect(res.error).toBeUndefined()
+    const { payload } = decodeCredential(res.body!.credential!)
+    expect('cnf' in payload).toBe(false)
   })
 })
 
@@ -414,13 +496,17 @@ describe('getSpaceCredential — deactivation gate', () => {
     registerSpaceCredentialHandlers(server as any, ctx)
 
     try {
-      const before = await invoke(server, { space: SPACE_URI }, USER_DID)
+      const before = await invoke(server, { space: SPACE_URI }, USER_DID, {
+        jkt: 'thumb-shinji',
+      })
       expect(before.error).toBeUndefined()
       expect(before.body?.credential).toBeTruthy()
 
       await store.updateEnrollment(USER_DID, { active: false })
 
-      const after = await invoke(server, { space: SPACE_URI }, USER_DID)
+      const after = await invoke(server, { space: SPACE_URI }, USER_DID, {
+        jkt: 'thumb-shinji',
+      })
       expect(after.error?.name).toBe('NotEnrolled')
       expect(after.body).toBeUndefined()
     } finally {
@@ -447,23 +533,37 @@ describe('getSpaceCredential — delegation-token path', () => {
     return { signingKey, userKey, ctx, server }
   }
 
-  it('happy path: valid token for enrolled user issues a credential', async () => {
+  it('happy path: valid token + mint proof issues a credential bound to the proof key', async () => {
     const { signingKey, userKey, server } = await setup(true)
     const token = await mintDelegation({ userKey, iss: userKey.did() })
+    const { proof, jkt } = await makeMintProof(`${PUBLIC_URL}${MINT_PATH}`)
 
-    const res = await invoke(server, {
-      space: SPACE_URI,
-      delegationToken: token,
-    })
+    const res = await invoke(
+      server,
+      { space: SPACE_URI, delegationToken: token },
+      undefined,
+      { req: { method: 'POST', url: MINT_PATH, headers: { dpop: proof } } },
+    )
     expect(res.error).toBeUndefined()
     expect(res.body?.credential).toBeTruthy()
     const { payload } = decodeCredential(res.body!.credential!)
     expect(payload.iss).toBe(SERVICE_DID)
     expect(payload.sub).toBe(SPACE_URI)
     expect('aud' in payload).toBe(false)
+    expect(payload.cnf).toEqual({ jkt })
     expect(
       await verifyCredentialAgainst(signingKey.did(), res.body!.credential!),
     ).toBe(true)
+  })
+
+  it('rejects a valid token WITHOUT a mint-time DPoP proof → ProofRequired', async () => {
+    const { userKey, server } = await setup(true)
+    const token = await mintDelegation({ userKey, iss: userKey.did() })
+    const res = await invoke(server, {
+      space: SPACE_URI,
+      delegationToken: token,
+    })
+    expect(res.error?.name).toBe('ProofRequired')
   })
 
   it('valid token but user not enrolled → NotEnrolled', async () => {

--- a/stratos-service/tests/space-credential-minter.test.ts
+++ b/stratos-service/tests/space-credential-minter.test.ts
@@ -129,6 +129,32 @@ describe('mintSpaceCredential', () => {
     expect(await verifyAgainst(p256.did(), decoded)).toBe(false)
   })
 
+  it('binds the credential to a DPoP key via cnf.jkt when jkt is supplied', async () => {
+    const signingKey = await Secp256k1Keypair.create()
+    const { credential, payload } = await mintSpaceCredential({
+      signingKey,
+      issuerDid: ISSUER_DID,
+      spaceUri: SPACE_URI,
+      ttlSeconds: 7_200,
+      jkt: 'thumb-rei-ayanami',
+    })
+    expect(payload.cnf).toEqual({ jkt: 'thumb-rei-ayanami' })
+    const decoded = decodeJwt(credential)
+    expect(decoded.payload.cnf).toEqual({ jkt: 'thumb-rei-ayanami' })
+  })
+
+  it('omits cnf entirely when no jkt is supplied (unbound, dev mode only)', async () => {
+    const signingKey = await Secp256k1Keypair.create()
+    const { credential, payload } = await mintSpaceCredential({
+      signingKey,
+      issuerDid: ISSUER_DID,
+      spaceUri: SPACE_URI,
+      ttlSeconds: 7_200,
+    })
+    expect('cnf' in payload).toBe(false)
+    expect('cnf' in decodeJwt(credential).payload).toBe(false)
+  })
+
   it('generates a unique jti when none is supplied', async () => {
     const signingKey = await Secp256k1Keypair.create()
     const a = await mintSpaceCredential({

--- a/stratos-service/tests/space-credential-verifier.test.ts
+++ b/stratos-service/tests/space-credential-verifier.test.ts
@@ -258,6 +258,44 @@ describe('verifySpaceCredential', () => {
       }),
     ).resolves.toEqual({ spaceUri: SPACE_URI, cnfJkt: 'thumb-asuka' })
   })
+
+  it('omits cnfJkt entirely for an unbound credential', async () => {
+    const signingKey = await Secp256k1Keypair.create()
+    const { credential } = await mintSpaceCredential({
+      signingKey,
+      issuerDid: SERVICE_DID,
+      spaceUri: SPACE_URI,
+      ttlSeconds: 7_200,
+    })
+    const result = await verifySpaceCredential(credential, {
+      serviceKey: signingKey,
+      serviceDid: SERVICE_DID,
+    })
+    expect('cnfJkt' in result).toBe(false)
+  })
+
+  it('ignores a non-string or empty cnf.jkt (no binding surfaced)', async () => {
+    const signingKey = await Secp256k1Keypair.create()
+    const iat = Math.floor(Date.now() / 1000)
+    for (const jkt of [42, '']) {
+      const jwt = await signJwt(
+        { typ: 'atproto-space-credential+jwt', alg: 'ES256K', kid: '#atproto' },
+        {
+          iss: SERVICE_DID,
+          sub: SPACE_URI,
+          iat,
+          exp: iat + 3600,
+          cnf: { jkt },
+        },
+        signingKey,
+      )
+      const result = await verifySpaceCredential(jwt, {
+        serviceKey: signingKey,
+        serviceDid: SERVICE_DID,
+      })
+      expect('cnfJkt' in result).toBe(false)
+    }
+  })
 })
 
 // ===========================================================================

--- a/stratos-service/tests/space-credential-verifier.test.ts
+++ b/stratos-service/tests/space-credential-verifier.test.ts
@@ -6,20 +6,30 @@
  * resolution). These tests mint real credentials with a local Secp256k1 keypair
  * and assert the verifier accepts a good one and rejects each distinct failure
  * mode with a distinct typed error — including that it is deliberately
- * MULTI-USE (no `jti` consumption).
+ * MULTI-USE (no credential-`jti` consumption). The presentation suite covers
+ * the RFC 9449 sender constraint with fake proof-checker/replay-store seams:
+ * `cnf.jkt` required, thumbprint equality, and the single-use PROOF `jti`
+ * consumed LAST (a failed presentation never burns its nonce).
  */
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { P256Keypair, Secp256k1Keypair } from '@atproto/crypto'
 import { mintSpaceCredential } from '../src/features/space-credential/minter.js'
 import {
   ForeignSpaceCredentialError,
   InvalidSpaceCredentialAlgError,
   InvalidSpaceCredentialKidError,
+  InvalidSpaceCredentialProofError,
   InvalidSpaceCredentialSignatureError,
   InvalidSpaceCredentialSubError,
   InvalidSpaceCredentialTypError,
   MalformedSpaceCredentialError,
+  MissingSpaceCredentialCnfError,
+  SPACE_DPOP_REPLAY_KIND,
+  SPACE_DPOP_REPLAY_TTL,
   SpaceCredentialExpiredError,
+  SpaceCredentialKeyBindingError,
+  SpaceCredentialProofReplayError,
+  verifyPresentedSpaceCredential,
   verifySpaceCredential,
 } from '../src/infra/auth/space-credential-verifier.js'
 import { makeSpaceUri } from './helpers/space-uri.js'
@@ -230,5 +240,144 @@ describe('verifySpaceCredential', () => {
         serviceDid: SERVICE_DID,
       }),
     ).rejects.toBeInstanceOf(InvalidSpaceCredentialSubError)
+  })
+
+  it('surfaces the cnf.jkt binding of a bound credential', async () => {
+    const signingKey = await Secp256k1Keypair.create()
+    const { credential } = await mintSpaceCredential({
+      signingKey,
+      issuerDid: SERVICE_DID,
+      spaceUri: SPACE_URI,
+      ttlSeconds: 7_200,
+      jkt: 'thumb-asuka',
+    })
+    await expect(
+      verifySpaceCredential(credential, {
+        serviceKey: signingKey,
+        serviceDid: SERVICE_DID,
+      }),
+    ).resolves.toEqual({ spaceUri: SPACE_URI, cnfJkt: 'thumb-asuka' })
+  })
+})
+
+// ===========================================================================
+// Presentation (RFC 9449 sender constraint)
+// ===========================================================================
+describe('verifyPresentedSpaceCredential', () => {
+  const REQ = { method: 'GET', url: '/x', headers: {} }
+
+  /** Mint a credential and build presentation deps with fake proof/replay. */
+  async function setup(opts?: {
+    credJkt?: string
+    proofJkt?: string
+    proofError?: Error
+    replayFresh?: boolean
+  }) {
+    const signingKey = await Secp256k1Keypair.create()
+    const { credential } = await mintSpaceCredential({
+      signingKey,
+      issuerDid: SERVICE_DID,
+      spaceUri: SPACE_URI,
+      ttlSeconds: 7_200,
+      ...(opts?.credJkt === undefined ? {} : { jkt: opts.credJkt }),
+    })
+    const check = opts?.proofError
+      ? vi.fn().mockRejectedValue(opts.proofError)
+      : vi.fn().mockResolvedValue({
+          jti: 'proof-jti-1',
+          jkt: opts?.proofJkt ?? opts?.credJkt ?? 'thumb-rei',
+          htm: 'GET',
+          htu: 'https://stratos.test/x',
+        })
+    const consumeOnce = vi.fn().mockResolvedValue(opts?.replayFresh ?? true)
+    const deps = {
+      serviceKey: signingKey,
+      serviceDid: SERVICE_DID,
+      proofChecker: { check },
+      replayStore: { consumeOnce },
+    }
+    return { credential, deps, check, consumeOnce }
+  }
+
+  it('accepts a bound credential with a matching proof and consumes the proof jti', async () => {
+    const { credential, deps, check, consumeOnce } = await setup({
+      credJkt: 'thumb-rei',
+    })
+    await expect(
+      verifyPresentedSpaceCredential(credential, REQ, deps),
+    ).resolves.toEqual({ spaceUri: SPACE_URI, cnfJkt: 'thumb-rei' })
+    // The proof is checked against THIS request and hash-bound to the token.
+    expect(check).toHaveBeenCalledWith(REQ, credential)
+    expect(consumeOnce).toHaveBeenCalledWith(
+      SPACE_DPOP_REPLAY_KIND,
+      'proof-jti-1',
+      SPACE_DPOP_REPLAY_TTL,
+    )
+  })
+
+  it('rejects an UNBOUND credential (no cnf.jkt) without touching the proof', async () => {
+    const { credential, deps, check, consumeOnce } = await setup()
+    await expect(
+      verifyPresentedSpaceCredential(credential, REQ, deps),
+    ).rejects.toBeInstanceOf(MissingSpaceCredentialCnfError)
+    expect(check).not.toHaveBeenCalled()
+    expect(consumeOnce).not.toHaveBeenCalled()
+  })
+
+  it('rejects when the proof check fails — and does NOT burn the jti', async () => {
+    const { credential, deps, consumeOnce } = await setup({
+      credJkt: 'thumb-rei',
+      proofError: new Error('bad proof'),
+    })
+    await expect(
+      verifyPresentedSpaceCredential(credential, REQ, deps),
+    ).rejects.toBeInstanceOf(InvalidSpaceCredentialProofError)
+    expect(consumeOnce).not.toHaveBeenCalled()
+  })
+
+  it('rejects a proof from a DIFFERENT key — and does NOT burn the jti', async () => {
+    const { credential, deps, consumeOnce } = await setup({
+      credJkt: 'thumb-rei',
+      proofJkt: 'thumb-attacker',
+    })
+    await expect(
+      verifyPresentedSpaceCredential(credential, REQ, deps),
+    ).rejects.toBeInstanceOf(SpaceCredentialKeyBindingError)
+    expect(consumeOnce).not.toHaveBeenCalled()
+  })
+
+  it('rejects a replayed proof jti (consumeOnce false, fail-closed)', async () => {
+    const { credential, deps } = await setup({
+      credJkt: 'thumb-rei',
+      replayFresh: false,
+    })
+    await expect(
+      verifyPresentedSpaceCredential(credential, REQ, deps),
+    ).rejects.toBeInstanceOf(SpaceCredentialProofReplayError)
+  })
+
+  it('runs credential verification FIRST: an expired bound credential never reaches the proof', async () => {
+    const signingKey = await Secp256k1Keypair.create()
+    const iat = Math.floor(Date.now() / 1000) - 10_000
+    const { credential } = await mintSpaceCredential({
+      signingKey,
+      issuerDid: SERVICE_DID,
+      spaceUri: SPACE_URI,
+      ttlSeconds: 60,
+      iat,
+      jkt: 'thumb-rei',
+    })
+    const check = vi.fn()
+    const consumeOnce = vi.fn()
+    await expect(
+      verifyPresentedSpaceCredential(credential, REQ, {
+        serviceKey: signingKey,
+        serviceDid: SERVICE_DID,
+        proofChecker: { check },
+        replayStore: { consumeOnce },
+      }),
+    ).rejects.toBeInstanceOf(SpaceCredentialExpiredError)
+    expect(check).not.toHaveBeenCalled()
+    expect(consumeOnce).not.toHaveBeenCalled()
   })
 })

--- a/stratos-service/tests/space-credential-verifier.test.ts
+++ b/stratos-service/tests/space-credential-verifier.test.ts
@@ -298,9 +298,6 @@ describe('verifySpaceCredential', () => {
   })
 })
 
-// ===========================================================================
-// Presentation (RFC 9449 sender constraint)
-// ===========================================================================
 describe('verifyPresentedSpaceCredential', () => {
   const REQ = { method: 'GET', url: '/x', headers: {} }
 

--- a/stratos-service/tests/space-dpop.test.ts
+++ b/stratos-service/tests/space-dpop.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Unit tests for the SpaceDpopProofChecker.
+ *
+ * The checker wraps `DpopManager` with nonces disabled and enforces the
+ * space-surface proof rules: a proof is REQUIRED (missing header rejects),
+ * `ath` is REQUIRED and must match when a bound token is supplied, and `ath`
+ * is REJECTED on standalone (mint-time) proofs. All failures surface as
+ * `SpaceDpopProofError`.
+ */
+import { createHash, randomUUID } from 'node:crypto'
+import { describe, expect, it } from 'vitest'
+import {
+  SignJWT,
+  calculateJwkThumbprint,
+  exportJWK,
+  generateKeyPair,
+} from 'jose'
+import {
+  SpaceDpopProofChecker,
+  SpaceDpopProofError,
+} from '../src/infra/auth/space-dpop.js'
+
+const SERVICE_ENDPOINT = 'https://stratos.test'
+const PATH = '/xrpc/zone.stratos.space.getSpaceCredential'
+
+/** An ES256 proof key: its jkt plus a builder for htm/htu-bound proofs. */
+async function makeProofKey() {
+  const { privateKey, publicKey } = await generateKeyPair('ES256', {
+    extractable: true,
+  })
+  const jwk = await exportJWK(publicKey)
+  const jkt = await calculateJwkThumbprint(jwk)
+  async function buildProof(opts: { ath?: string } = {}): Promise<string> {
+    return new SignJWT({
+      htm: 'POST',
+      htu: `${SERVICE_ENDPOINT}${PATH}`,
+      jti: randomUUID(),
+      ...(opts.ath ? { ath: opts.ath } : {}),
+    })
+      .setProtectedHeader({ typ: 'dpop+jwt', alg: 'ES256', jwk })
+      .setIssuedAt()
+      .sign(privateKey)
+  }
+  return { jkt, buildProof }
+}
+
+const request = (proof?: string) => ({
+  method: 'POST',
+  url: PATH,
+  headers: proof ? { dpop: proof } : {},
+})
+
+const athOf = (token: string) =>
+  createHash('sha256').update(token).digest('base64url')
+
+describe('SpaceDpopProofChecker', () => {
+  it('accepts a valid standalone proof and returns its jkt and jti', async () => {
+    const key = await makeProofKey()
+    const checker = new SpaceDpopProofChecker(SERVICE_ENDPOINT)
+    const proof = await checker.check(request(await key.buildProof()))
+    expect(proof.jkt).toBe(key.jkt)
+    expect(proof.jti).toBeTruthy()
+  })
+
+  it('rejects a missing DPoP header with "DPoP proof required"', async () => {
+    const checker = new SpaceDpopProofChecker(SERVICE_ENDPOINT)
+    const err = await checker.check(request()).catch((e) => e)
+    expect(err).toBeInstanceOf(SpaceDpopProofError)
+    expect(err.name).toBe('SpaceDpopProofError')
+    expect(err.message).toBe('DPoP proof required')
+  })
+
+  it('rejects a malformed proof and surfaces the validation reason', async () => {
+    const checker = new SpaceDpopProofChecker(SERVICE_ENDPOINT)
+    const err = await checker.check(request('not-a-jwt')).catch((e) => e)
+    expect(err).toBeInstanceOf(SpaceDpopProofError)
+    // The catch path must carry the manager's reason, not the missing-header
+    // message the fall-through `!proof` branch would produce.
+    expect(err.message).not.toBe('DPoP proof required')
+  })
+
+  it('with a bound token: requires a matching ath', async () => {
+    const key = await makeProofKey()
+    const checker = new SpaceDpopProofChecker(SERVICE_ENDPOINT)
+    const token = 'credential-token'
+    await expect(
+      checker.check(request(await key.buildProof()), token),
+    ).rejects.toBeInstanceOf(SpaceDpopProofError)
+    const bound = await checker.check(
+      request(await key.buildProof({ ath: athOf(token) })),
+      token,
+    )
+    expect(bound.jkt).toBe(key.jkt)
+  })
+
+  it('without a bound token: rejects a proof carrying ath', async () => {
+    const key = await makeProofKey()
+    const checker = new SpaceDpopProofChecker(SERVICE_ENDPOINT)
+    await expect(
+      checker.check(request(await key.buildProof({ ath: athOf('anything') }))),
+    ).rejects.toBeInstanceOf(SpaceDpopProofError)
+  })
+})

--- a/stratos-service/tests/space-dpop.test.ts
+++ b/stratos-service/tests/space-dpop.test.ts
@@ -1,11 +1,12 @@
 /**
  * Unit tests for the SpaceDpopProofChecker.
  *
- * The checker wraps `DpopManager` with nonces disabled and enforces the
- * space-surface proof rules: a proof is REQUIRED (missing header rejects),
- * `ath` is REQUIRED and must match when a bound token is supplied, and `ath`
- * is REJECTED on standalone (mint-time) proofs. All failures surface as
- * `SpaceDpopProofError`.
+ * The checker is a standalone RFC 9449 verifier (mirroring the upstream
+ * space-surface rules) and enforces: a proof is REQUIRED (missing header
+ * rejects), `ath` is REQUIRED and must match when a bound token is supplied,
+ * `ath` is REJECTED on standalone (mint-time) proofs, and a `nonce` claim is
+ * IGNORED (the space surface has no nonce round trip). All failures surface
+ * as `SpaceDpopProofError`.
  */
 import { createHash, randomUUID } from 'node:crypto'
 import { describe, expect, it } from 'vitest'
@@ -30,12 +31,15 @@ async function makeProofKey() {
   })
   const jwk = await exportJWK(publicKey)
   const jkt = await calculateJwkThumbprint(jwk)
-  async function buildProof(opts: { ath?: string } = {}): Promise<string> {
+  async function buildProof(
+    opts: { ath?: string; nonce?: string } = {},
+  ): Promise<string> {
     return new SignJWT({
       htm: 'POST',
       htu: `${SERVICE_ENDPOINT}${PATH}`,
       jti: randomUUID(),
       ...(opts.ath ? { ath: opts.ath } : {}),
+      ...(opts.nonce ? { nonce: opts.nonce } : {}),
     })
       .setProtectedHeader({ typ: 'dpop+jwt', alg: 'ES256', jwk })
       .setIssuedAt()
@@ -62,6 +66,15 @@ describe('SpaceDpopProofChecker', () => {
     expect(proof.jti).toBeTruthy()
   })
 
+  it('ignores a stray "nonce" claim (no OAuth nonce round trip on this surface)', async () => {
+    const key = await makeProofKey()
+    const checker = new SpaceDpopProofChecker(SERVICE_ENDPOINT)
+    const proof = await checker.check(
+      request(await key.buildProof({ nonce: 'server-issued-nonce' })),
+    )
+    expect(proof.jkt).toBe(key.jkt)
+  })
+
   it('rejects a missing DPoP header with "DPoP proof required"', async () => {
     const checker = new SpaceDpopProofChecker(SERVICE_ENDPOINT)
     const err = await checker.check(request()).catch((e) => e)
@@ -74,8 +87,8 @@ describe('SpaceDpopProofChecker', () => {
     const checker = new SpaceDpopProofChecker(SERVICE_ENDPOINT)
     const err = await checker.check(request('not-a-jwt')).catch((e) => e)
     expect(err).toBeInstanceOf(SpaceDpopProofError)
-    // The catch path must carry the manager's reason, not the missing-header
-    // message the fall-through `!proof` branch would produce.
+    // The failure must carry the verification reason, not the missing-header
+    // message.
     expect(err.message).not.toBe('DPoP proof required')
   })
 


### PR DESCRIPTION
## Summary
- Binds `zone.stratos.space.getSpaceCredential` credentials to the caller's DPoP key (`cnf.jkt`, RFC 9449), matching the upstream alpha PDS credential model (atproto#5187).
- Credentials must be presented under the DPoP scheme with a per-request proof; unbound credentials are refused outside development mode (`ProofRequired`).
- Delegation-token path binds the standalone DPoP proof supplied in the `DPoP` header.

## Verification
- Full vitest suites green; scoped StrykerJS run on the changed auth lines — surviving mutants on changed lines killed (follow-up commit).

🤖 Generated with Rommie Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Space credentials are now bound to DPoP keys and require per-request proofs.
  * Added replay protection for DPoP proofs and delegation tokens.
  * Added clear errors when proofs, key bindings, or replay protection are unavailable.
  * Bearer credentials remain supported only for eligible development-mode scenarios.

* **Documentation**
  * Updated API and routing documentation to describe DPoP-bound credentials and authentication requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->