### PR TITLE
docs(lexicons): note the upstream space-ref format on space params

### DIFF
--- a/lexicons/zone/stratos/space/getRecord.json
+++ b/lexicons/zone/stratos/space/getRecord.json
@@ -11,7 +11,7 @@
         "properties": {
           "space": {
             "type": "string",
-            "description": "The space's at:// URI (at://{did}/space/{type}/{skey}). Its space DID must equal this service's DID."
+            "description": "The space's at:// URI (at://{did}/space/{type}/{skey}). Mirrors the upstream space-ref string format (atproto#5187); declared as a plain string until @atproto/lexicon supports that format. Its space DID must equal this service's DID."
           },
           "repo": {
             "type": "string",

--- a/lexicons/zone/stratos/space/getSpaceCredential.json
+++ b/lexicons/zone/stratos/space/getSpaceCredential.json
@@ -13,7 +13,7 @@
           "properties": {
             "space": {
               "type": "string",
-              "description": "The space's at:// URI (at://{did}/space/{type}/{skey}). Its space DID must equal this service's DID."
+              "description": "The space's at:// URI (at://{did}/space/{type}/{skey}). Mirrors the upstream space-ref string format (atproto#5187); declared as a plain string until @atproto/lexicon supports that format. Its space DID must equal this service's DID."
             },
             "delegationToken": {
               "type": "string",

--- a/lexicons/zone/stratos/space/listBlobs.json
+++ b/lexicons/zone/stratos/space/listBlobs.json
@@ -11,7 +11,7 @@
         "properties": {
           "space": {
             "type": "string",
-            "description": "The space's at:// URI (at://{did}/space/{type}/{skey}). Its space DID must equal this service's DID."
+            "description": "The space's at:// URI (at://{did}/space/{type}/{skey}). Mirrors the upstream space-ref string format (atproto#5187); declared as a plain string until @atproto/lexicon supports that format. Its space DID must equal this service's DID."
           },
           "repo": {
             "type": "string",

--- a/stratos-client/src/lexicons.gen.ts
+++ b/stratos-client/src/lexicons.gen.ts
@@ -1014,7 +1014,7 @@ export const stratosLexicons: LexiconDoc[] = [
         "properties": {
           "space": {
             "type": "string",
-            "description": "The space's at:// URI (at://{did}/space/{type}/{skey}). Its space DID must equal this service's DID."
+            "description": "The space's at:// URI (at://{did}/space/{type}/{skey}). Mirrors the upstream space-ref string format (atproto#5187); declared as a plain string until @atproto/lexicon supports that format. Its space DID must equal this service's DID."
           },
           "repo": {
             "type": "string",
@@ -1085,7 +1085,7 @@ export const stratosLexicons: LexiconDoc[] = [
           "properties": {
             "space": {
               "type": "string",
-              "description": "The space's at:// URI (at://{did}/space/{type}/{skey}). Its space DID must equal this service's DID."
+              "description": "The space's at:// URI (at://{did}/space/{type}/{skey}). Mirrors the upstream space-ref string format (atproto#5187); declared as a plain string until @atproto/lexicon supports that format. Its space DID must equal this service's DID."
             },
             "delegationToken": {
               "type": "string",
@@ -1158,7 +1158,7 @@ export const stratosLexicons: LexiconDoc[] = [
         "properties": {
           "space": {
             "type": "string",
-            "description": "The space's at:// URI (at://{did}/space/{type}/{skey}). Its space DID must equal this service's DID."
+            "description": "The space's at:// URI (at://{did}/space/{type}/{skey}). Mirrors the upstream space-ref string format (atproto#5187); declared as a plain string until @atproto/lexicon supports that format. Its space DID must equal this service's DID."
           },
           "repo": {
             "type": "string",


### PR DESCRIPTION
## Summary
- Adds a description note to every `space` param in the space lexicons (`getRecord`, `getSpaceCredential`, `listBlobs`): the param mirrors the upstream `space-ref` string format (`at://{did}/space/{type}/{skey}`, atproto#5187).
- The params stay plain strings because @atproto/lexicon 0.6.1 does not know the `space-ref` format value; enforcement is already universal via `parseSpaceUri`.
- Description-only change; regenerated `lexicons.gen.ts`.

🤖 Generated with Rommie Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the supported space-reference format for space-related parameters.
  * Documented that these values remain plain strings until structured lexicon support is available.
  * Updated descriptions consistently across related API documentation and generated client references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->