### PR TITLE
fix(service): scope removeBoundary delete to the caller DID

### DIFF
--- a/stratos-service/src/storage/sqlite/enrollment-store.ts
+++ b/stratos-service/src/storage/sqlite/enrollment-store.ts
@@ -267,8 +267,10 @@ export class SqliteEnrollmentStore
     await this.db
       .delete(enrollmentBoundary)
       .where(
-        eq(enrollmentBoundary.did, did) &&
+        and(
+          eq(enrollmentBoundary.did, did),
           eq(enrollmentBoundary.boundary, boundary),
+        ),
       )
   }
 }

--- a/stratos-service/tests/enrollment-store-service.integration.test.ts
+++ b/stratos-service/tests/enrollment-store-service.integration.test.ts
@@ -338,3 +338,47 @@ describe('enrollment isService migration', () => {
     expect(enrollment?.pdsEndpoint).toBe('https://pds.example.com')
   })
 })
+
+describe('SqliteEnrollmentStore removeBoundary', () => {
+  const RYOKO_DID = 'did:plc:ryokohakubi'
+  const AYEKA_DID = 'did:plc:ayekajurai'
+
+  let testDir: string
+  let store: SqliteEnrollmentStore
+
+  beforeEach(async () => {
+    testDir = join(
+      tmpdir(),
+      `stratos-enrollment-boundary-${randomBytes(8).toString('hex')}`,
+    )
+    await mkdir(testDir, { recursive: true })
+    const db = createServiceDb(join(testDir, 'service.sqlite'))
+    await migrateServiceDb(db)
+    store = new SqliteEnrollmentStore(db)
+
+    for (const did of [RYOKO_DID, AYEKA_DID]) {
+      await store.enroll({
+        did,
+        enrolledAt: '2025-02-01T00:00:00Z',
+        pdsEndpoint: 'https://pds.jurai.example.com',
+        signingKeyDid: 'did:key:zDnaeJuraiKey',
+        active: true,
+        boundaries: ['galaxy-police', 'jurai-royals'],
+      })
+    }
+  })
+
+  afterEach(async () => {
+    await rm(testDir, { recursive: true, force: true })
+  })
+
+  it('removes only the named boundary of the named DID', async () => {
+    await store.removeBoundary(RYOKO_DID, 'galaxy-police')
+
+    expect(await store.getBoundaries(RYOKO_DID)).toEqual(['jurai-royals'])
+    expect((await store.getBoundaries(AYEKA_DID)).toSorted()).toEqual([
+      'galaxy-police',
+      'jurai-royals',
+    ])
+  })
+})


### PR DESCRIPTION
## Description

`SqliteEnrollmentStore.removeBoundary` built its where clause with JavaScript `&&` between two Drizzle predicates. `&&` on two truthy predicate objects evaluates to the **second** one, so the executed SQL was `DELETE FROM enrollment_boundary WHERE boundary = ?` — no DID filter. Removing a boundary from one actor removed it from **every enrolled actor** sharing that boundary name. Cross-tenant data loss from a single call.

The fix is one word: wrap the predicates in Drizzle's `and(...)` (already imported in the file).

Found during the opus review sweep; filed standalone as directed because it belongs to no open stack and should not wait on one.

## Testing

New integration case enrolls two actors with the same two boundaries, removes one boundary from one actor, and asserts the other actor's boundaries are untouched.

- **Red-verified**: with only the source file stashed (test kept), the new test fails against the old code — the second actor loses the boundary too.
- Full service suite green with the fix.

## Mutation gate

Scoped Stryker run on `src/storage/sqlite/enrollment-store.ts`: **score 89.66 ≥ break 60**, 104 killed, 9 survived. All 9 survivors sit on pre-existing lines (enroll/update row mapping at :50/:60/:62/:66/:133/:201); **zero survivors on the changed lines**.

🤖 Generated with Rommie Code