### PR TITLE
Fix postgres/appview E2E harness drift

### DIFF
--- a/test/scripts/lib/pg-db.ts
+++ b/test/scripts/lib/pg-db.ts
@@ -133,6 +133,21 @@ export async function createActorStore(did: string): Promise<void> {
     `)
 
     await sql.unsafe(`
+      CREATE TABLE IF NOT EXISTS stratos_record_boundary (
+        "recordUri" TEXT NOT NULL,
+        boundary TEXT NOT NULL,
+        PRIMARY KEY ("recordUri", boundary)
+      )
+    `)
+
+    await sql.unsafe(`
+      CREATE TABLE IF NOT EXISTS stratos_signing_key (
+        did TEXT PRIMARY KEY,
+        key BYTEA NOT NULL
+      )
+    `)
+
+    await sql.unsafe(`
       CREATE TABLE IF NOT EXISTS stratos_backlink (
         uri TEXT NOT NULL,
         path TEXT NOT NULL,

--- a/test/scripts/setup.ts
+++ b/test/scripts/setup.ts
@@ -104,6 +104,13 @@ function getEnvVars(state: TestState): Record<string, string> {
     )
   }
 
+  if (isAppview()) {
+    // The e2e compose overlay hardcodes these values inside the container.
+    // Record the same values so state and test scripts match the service.
+    envVars['STRATOS_PUBLIC_URL'] = 'https://stratos.test'
+    envVars['STRATOS_SERVICE_DID'] = 'did:web:stratos.test'
+  }
+
   return envVars
 }
 

--- a/test/scripts/test-appview-feed.ts
+++ b/test/scripts/test-appview-feed.ts
@@ -20,6 +20,7 @@
  *   - Unauthenticated timeline is denied
  */
 
+import { DOMAINS } from './lib/config.ts'
 import { createRecord } from './lib/stratos.ts'
 import type { CreateRecordResponse } from './lib/stratos.ts'
 import { loadState } from './lib/state.ts'
@@ -151,7 +152,7 @@ async function createTestPosts(users: {
   const reiPost1 = await createRecord(rei.did, 'zone.stratos.feed.post', {
     $type: 'zone.stratos.feed.post',
     text: 'Rei forging a new katana at the Spirit Forge',
-    boundary: { values: [{ value: 'swordsmith' }] },
+    boundary: { values: [{ value: DOMAINS.swordsmith }] },
     createdAt: new Date().toISOString(),
   })
   pass('Rei post 1 created', reiPost1.uri)
@@ -159,7 +160,7 @@ async function createTestPosts(users: {
   const reiPost2 = await createRecord(rei.did, 'zone.stratos.feed.post', {
     $type: 'zone.stratos.feed.post',
     text: 'The blade of the Zanpakutō glows with inner fire',
-    boundary: { values: [{ value: 'swordsmith' }] },
+    boundary: { values: [{ value: DOMAINS.swordsmith }] },
     createdAt: new Date().toISOString(),
   })
   pass('Rei post 2 created', reiPost2.uri)
@@ -168,7 +169,7 @@ async function createTestPosts(users: {
   const sakuraPost = await createRecord(sakura.did, 'zone.stratos.feed.post', {
     $type: 'zone.stratos.feed.post',
     text: 'Sakura polishing the sacred Hōgyoku blade',
-    boundary: { values: [{ value: 'swordsmith' }] },
+    boundary: { values: [{ value: DOMAINS.swordsmith }] },
     createdAt: new Date().toISOString(),
   })
   pass('Sakura post created', sakuraPost.uri)
@@ -180,7 +181,7 @@ async function createTestPosts(users: {
     {
       $type: 'zone.stratos.feed.post',
       text: 'Kaoruko arranging flowers in the Aekea garden pavilion',
-      boundary: { values: [{ value: 'aekea' }] },
+      boundary: { values: [{ value: DOMAINS.aekea }] },
       createdAt: new Date().toISOString(),
     },
   )


### PR DESCRIPTION
## Summary
- Add the `stratos_signing_key` and `stratos_record_boundary` tables to the `pg-db.ts` actor-store helper. The hand-copied DDL drifted from `stratos-core/src/db/pg.ts`, so every postgres-mode `createRecord` failed with `relation "stratos_signing_key" does not exist`. The `stratos_record_boundary` table anticipates #143 and is a harmless no-op before it merges (`CREATE TABLE IF NOT EXISTS`).
- Record the e2e compose overlay's hardcoded service DID (`did:web:stratos.test`) in setup state when running in appview mode. Previously `setup.ts` recorded the ngrok-derived DID while the container used the overlay value, so boundary writes failed with `ForbiddenDomain`.
- Use qualified `DOMAINS.*` boundary values in `test-appview-feed.ts`. The script still sent bare names (`swordsmith`), but `config.allowedDomains` has been service-qualified via `qualifyBoundaries` since that migration, so every create failed with `Domain 'swordsmith' is not allowed`.

All three defects reproduce on `main` and are invisible in the default sqlite/OAuth suite — they only surface in `--postgres` / `--appview` mode.

## Test plan
- [x] Manual appview-mode phase sequence on a merged validation branch: setup → direct-enroll → configure-boundaries → test-posts (21/21) → test-spaces (20/21, remaining miss is the known direct-DB revocation vs enrollment-cache limitation) → test-appview-feed (15/15) → teardown
- [ ] `pnpm e2etestappview` end-to-end on this branch after merge

🤖 Generated with Rommie Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test setup for more consistent application environments.
  * Expanded test data coverage for record boundaries and signing keys.
  * Standardized test scenarios around configured domain values, reducing reliance on hardcoded inputs.
* **Chores**
  * Updated test infrastructure to use stable application URLs and service identifiers during automated runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->