### PR TITLE
Release 0.3.0: version bump and docker image publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -95,3 +95,70 @@ jobs:
         run: pnpm --filter @northskysocial/stratos-client publish --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  docker:
+    name: Build and push docker images
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Check if stratos image version already pushed
+        id: stratos-image-check
+        run: |
+          VERSION=$(node -p "require('./stratos-service/package.json').version")
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          if docker manifest inspect "ghcr.io/northskysocial/stratos:${VERSION}" >/dev/null 2>&1; then
+            echo "skip=true" >> $GITHUB_OUTPUT
+            echo "stratos ${VERSION} already pushed — skipping"
+          else
+            echo "skip=false" >> $GITHUB_OUTPUT
+            echo "stratos ${VERSION} not yet pushed — proceeding"
+          fi
+
+      - name: Build and push stratos image
+        if: steps.stratos-image-check.outputs.skip == 'false'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: stratos
+          push: true
+          tags: |
+            ghcr.io/northskysocial/stratos:${{ steps.stratos-image-check.outputs.version }}
+            ghcr.io/northskysocial/stratos:latest
+
+      - name: Check if feedgen image version already pushed
+        id: feedgen-image-check
+        run: |
+          VERSION=$(node -p "require('./stratos-feedgen/package.json').version")
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          if docker manifest inspect "ghcr.io/northskysocial/stratos-feedgen:${VERSION}" >/dev/null 2>&1; then
+            echo "skip=true" >> $GITHUB_OUTPUT
+            echo "stratos-feedgen ${VERSION} already pushed — skipping"
+          else
+            echo "skip=false" >> $GITHUB_OUTPUT
+            echo "stratos-feedgen ${VERSION} not yet pushed — proceeding"
+          fi
+
+      - name: Build and push feedgen image
+        if: steps.feedgen-image-check.outputs.skip == 'false'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: stratos-feedgen/Dockerfile
+          target: feedgen
+          push: true
+          tags: |
+            ghcr.io/northskysocial/stratos-feedgen:${{ steps.feedgen-image-check.outputs.version }}
+            ghcr.io/northskysocial/stratos-feedgen:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 # --- Build stage ---
 FROM node:24-alpine AS builder
 
-RUN corepack enable && corepack prepare pnpm@latest --activate
+RUN corepack enable && corepack prepare pnpm@10.28.2 --activate
 
 WORKDIR /app
 
@@ -17,6 +17,7 @@ COPY stratos-core/package.json ./stratos-core/
 COPY stratos-service/package.json ./stratos-service/
 COPY stratos-indexer/package.json ./stratos-indexer/
 COPY stratos-client/package.json ./stratos-client/
+COPY stratos-feedgen/package.json ./stratos-feedgen/
 COPY webapp/package.json ./webapp/
 
 # Install all dependencies (including devDependencies for tsc)
@@ -54,7 +55,7 @@ RUN node -e " \
 # --- Production stage for Stratos Service ---
 FROM node:24-alpine AS stratos
 
-RUN corepack enable && corepack prepare pnpm@latest --activate
+RUN corepack enable && corepack prepare pnpm@10.28.2 --activate
 
 WORKDIR /app
 
@@ -113,6 +114,7 @@ COPY --from=builder /app/stratos-indexer/ ./stratos-indexer/
 # Copy package.json for other workspace members to satisfy Deno workspace requirements
 COPY --from=builder /app/stratos-service/package.json ./stratos-service/
 COPY --from=builder /app/stratos-client/package.json ./stratos-client/
+COPY --from=builder /app/stratos-feedgen/package.json ./stratos-feedgen/
 COPY --from=builder /app/webapp/package.json ./webapp/
 
 # Copy workspace files for Deno to resolve dependencies correctly.

--- a/stratos-client/package.json
+++ b/stratos-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@northskysocial/stratos-client",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Client library for Stratos private namespace service",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/stratos-core/package.json
+++ b/stratos-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@northskysocial/stratos-core",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Shared library for Stratos private namespace service",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/stratos-feedgen/package.json
+++ b/stratos-feedgen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@northskysocial/stratos-feedgen",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "description": "Standalone Stratos feed generator",
   "main": "dist/index.js",

--- a/stratos-indexer/package.json
+++ b/stratos-indexer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@northskysocial/stratos-indexer",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/stratos-service/package.json
+++ b/stratos-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@northskysocial/stratos-service",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Standalone Stratos private namespace service for ATProtocol",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@northskysocial/stratos-webapp",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@northskysocial/stratos-webapp",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@atproto/api": "^0.15.8",
         "@atproto/oauth-client-browser": "^0.3.17",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@northskysocial/stratos-webapp",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- Bump all package versions: stratos-core/service/indexer/feedgen 0.2.0 → 0.3.0, stratos-client 0.3.0 → 0.4.0, webapp 0.1.0 → 0.2.0
- Repair the root Dockerfile: the builder stage never copied `stratos-feedgen/package.json` after the feedgen joined the workspace (#101), so `pnpm install --frozen-lockfile` failed and the stratos image has been unbuildable since. Also pin pnpm to 10.28.2 to match the feedgen Dockerfile.
- Add a `docker` job to `publish.yml` that builds and pushes `ghcr.io/northskysocial/stratos` and `ghcr.io/northskysocial/stratos-feedgen` (version tag + `latest`) on release, with the same skip-if-already-published guard as the npm packages.

## Test plan
- [x] `docker build --target stratos` and `--target feedgen` both succeed locally; entrypoints verified (`dist/bin/stratos.js`, `main.mjs`)
- [x] Workflow YAML validated
- [ ] After merge: confirm the publish.yml run publishes core 0.3.0 / client 0.4.0 and pushes both images to GHCR