### PR TITLE
fix: restore the client exports that 0.4.0 did not publish

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,6 +72,9 @@ importers:
       '@atcute/car':
         specifier: ^6.0.2
         version: 6.0.2(@atcute/cbor@2.3.6(@atcute/cid@2.4.2))(@atcute/cid@2.4.2)
+      '@atcute/cbor':
+        specifier: ^2.3.6
+        version: 2.3.6(@atcute/cid@2.4.2)
       '@atcute/cid':
         specifier: ^2.4.2
         version: 2.4.2
@@ -91,9 +94,6 @@ importers:
         specifier: ^1.0.2
         version: 1.0.2(@atcute/cbor@2.3.6(@atcute/cid@2.4.2))(@atcute/cid@2.4.2)(@atcute/lexicons@2.1.0)
     devDependencies:
-      '@atcute/cbor':
-        specifier: ^2.3.6
-        version: 2.3.6(@atcute/cid@2.4.2)
       '@atcute/mst':
         specifier: ^1.0.3
         version: 1.0.3(@atcute/cbor@2.3.6(@atcute/cid@2.4.2))(@atcute/cid@2.4.2)

--- a/stratos-client/package.json
+++ b/stratos-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@northskysocial/stratos-client",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Client library for Stratos private namespace service",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -37,11 +37,13 @@
     "format": "prettier --write .",
     "lint": "eslint .",
     "check:self-contained": "node scripts/check-self-contained.mjs",
-    "postbuild": "node scripts/check-self-contained.mjs"
+    "check:exports": "node scripts/check-exports.mjs",
+    "postbuild": "node scripts/check-self-contained.mjs && node scripts/check-exports.mjs"
   },
   "dependencies": {
     "@atcute/atproto": "^4.0.4",
     "@atcute/car": "^6.0.2",
+    "@atcute/cbor": "^2.3.6",
     "@atcute/cid": "^2.4.2",
     "@atcute/client": "^5.1.1",
     "@atcute/crypto": "^2.4.4",
@@ -50,7 +52,6 @@
     "@atcute/repo": "^1.0.2"
   },
   "devDependencies": {
-    "@atcute/cbor": "^2.3.6",
     "@atcute/mst": "^1.0.3",
     "@atproto/crypto": "^0.5.4",
     "@atproto/lexicon": "^0.7.11",

--- a/stratos-client/scripts/check-exports.mjs
+++ b/stratos-client/scripts/check-exports.mjs
@@ -1,0 +1,111 @@
+// Guards that the published dist/ exports the full public surface.
+//
+// Version 0.4.0 shipped without attestation.js and five other exports. The
+// build was green, because nothing compared the built surface against the
+// surface that consumers import. A downstream install then failed to compile.
+// This script fails the build if an expected export ever disappears again.
+//
+// Add a name here when you add an export to src/index.ts.
+//
+// Run with: node scripts/check-exports.mjs
+
+import { readFileSync, existsSync } from 'node:fs'
+import { dirname, relative, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDir = dirname(fileURLToPath(import.meta.url))
+const packageRoot = resolve(scriptDir, '..')
+const distDir = resolve(packageRoot, 'dist')
+const entryPath = resolve(distDir, 'index.d.ts')
+
+const EXPECTED_EXPORTS = [
+  // types
+  'FetchHandler',
+  'FetchHandlerObject',
+  'FetchAndVerifyOptions',
+  'ResolveSigningKeyOptions',
+  'ServiceAttestation',
+  'StratosEnrollment',
+  'StratosScopes',
+  'VerificationLevel',
+  'VerifiedRecord',
+  // discovery
+  'ENROLLMENT_COLLECTION',
+  'discoverEnrollment',
+  'discoverEnrollments',
+  'getEnrollmentByServiceDid',
+  'parseEnrollmentRecord',
+  // routing
+  'createServiceFetchHandler',
+  'resolveServiceUrl',
+  'findEnrollmentByService',
+  'serviceDIDToRkey',
+  'ServiceFetchHandlerOptions',
+  // verification
+  'verifyCidIntegrity',
+  'verifyRecordCid',
+  'resolveServiceSigningKey',
+  'resolveUserSigningKey',
+  'fetchAndVerifyRecord',
+  'verifyStratosRecord',
+  // attestation
+  'verifyEnrollmentAttestation',
+  'AttestationResult',
+  // scopes
+  'STRATOS_SCOPES',
+  'buildCollectionScope',
+  'buildRpcScope',
+  'buildStratosScopes',
+]
+
+const EXPECTED_MODULES = [
+  'attestation.js',
+  'discovery.js',
+  'lexicons.js',
+  'routing.js',
+  'scopes.js',
+  'types.js',
+  'verification.js',
+]
+
+if (!existsSync(entryPath)) {
+  console.error(
+    `error: ${relative(packageRoot, entryPath)} does not exist — run the build first.`,
+  )
+  process.exit(1)
+}
+
+const entry = readFileSync(entryPath, 'utf-8')
+
+const missingExports = EXPECTED_EXPORTS.filter(
+  (name) => !new RegExp(`\\b${name}\\b`).test(entry),
+)
+
+const missingModules = EXPECTED_MODULES.filter(
+  (file) => !existsSync(resolve(distDir, file)),
+)
+
+if (missingExports.length > 0 || missingModules.length > 0) {
+  if (missingExports.length > 0) {
+    console.error(
+      `missing ${missingExports.length} export(s) from dist/index.d.ts:\n`,
+    )
+    for (const name of missingExports) console.error(`  ${name}`)
+    console.error('')
+  }
+  if (missingModules.length > 0) {
+    console.error(`missing ${missingModules.length} module(s) from dist/:\n`)
+    for (const file of missingModules) console.error(`  ${file}`)
+    console.error('')
+  }
+  console.error(
+    'Export the missing name from src/index.ts, or update EXPECTED_EXPORTS\n' +
+      'in this script when you remove an export on purpose.',
+  )
+  process.exit(1)
+}
+
+console.log(
+  `ok: dist/index.d.ts exports all ${EXPECTED_EXPORTS.length} expected names ` +
+    `(${EXPECTED_MODULES.length} modules present)`,
+)

--- a/stratos-client/src/attestation.ts
+++ b/stratos-client/src/attestation.ts
@@ -1,0 +1,109 @@
+import { encode as cborEncode, fromBytes, isBytes } from '@atcute/cbor'
+import { verifySigWithDidKey } from '@atcute/crypto'
+
+/**
+ * result of an enrollment attestation check.
+ *
+ * the check never throws. when it cannot complete, valid is false and error
+ * holds the reason.
+ */
+export interface AttestationResult {
+  valid: boolean
+  serviceKey: string
+  userSigningKey: string
+  boundaries: Array<string>
+  error?: string
+}
+
+interface EnrollmentWithAttestation {
+  signingKey: string
+  attestation: { sig: unknown; signingKey: string }
+  boundaries?: unknown
+}
+
+// @atcute/crypto requires ArrayBuffer-backed arrays, but @atcute/cbor returns
+// ArrayBufferLike. copy the bytes to satisfy the narrower type. an attestation
+// signature and its payload are both small, so the copy costs little.
+const toArrayBufferBytes = (bytes: Uint8Array): Uint8Array<ArrayBuffer> =>
+  new Uint8Array(bytes)
+
+const isEnrollmentWithAttestation = (
+  val: unknown,
+): val is EnrollmentWithAttestation => {
+  if (typeof val !== 'object' || val === null) return false
+  const obj = val as Record<string, unknown>
+  if (typeof obj.signingKey !== 'string') return false
+  if (typeof obj.attestation !== 'object' || obj.attestation === null) {
+    return false
+  }
+  const att = obj.attestation as Record<string, unknown>
+  return (
+    typeof att.signingKey === 'string' &&
+    (isBytes(att.sig) || att.sig instanceof Uint8Array)
+  )
+}
+
+/**
+ * verifies the service attestation in an enrollment record.
+ *
+ * the attestation is an ECDSA signature by the service did:key. the service
+ * signs the DAG-CBOR encoding of {boundaries, did, signingKey}, where the
+ * keys are in sorted order and the boundaries are sorted strings.
+ *
+ * @param recordValue the raw enrollment record value (JSON or decoded CBOR)
+ * @param userDid the DID of the enrolled user (repo owner)
+ * @returns the attestation verification result; never throws
+ */
+export const verifyEnrollmentAttestation = async (
+  recordValue: unknown,
+  userDid: string,
+): Promise<AttestationResult> => {
+  if (!isEnrollmentWithAttestation(recordValue)) {
+    return {
+      valid: false,
+      serviceKey: '',
+      userSigningKey: '',
+      boundaries: [],
+      error: 'Record missing attestation or signingKey fields',
+    }
+  }
+
+  const {
+    signingKey: userSigningKey,
+    attestation,
+    boundaries: rawBoundaries,
+  } = recordValue
+
+  const serviceKey = attestation.signingKey
+  const boundaries = Array.isArray(rawBoundaries)
+    ? rawBoundaries.map((b: { value: string }) => b.value).sort()
+    : []
+
+  try {
+    const sigBytes =
+      attestation.sig instanceof Uint8Array
+        ? attestation.sig
+        : fromBytes(attestation.sig as Parameters<typeof fromBytes>[0])
+
+    const payload = cborEncode({
+      boundaries,
+      did: userDid,
+      signingKey: userSigningKey,
+    })
+
+    const valid = await verifySigWithDidKey(
+      serviceKey,
+      toArrayBufferBytes(sigBytes),
+      toArrayBufferBytes(payload),
+    )
+    return { valid, serviceKey, userSigningKey, boundaries }
+  } catch (err) {
+    return {
+      valid: false,
+      serviceKey,
+      userSigningKey,
+      boundaries,
+      error: err instanceof Error ? err.message : String(err),
+    }
+  }
+}

--- a/stratos-client/src/discovery.ts
+++ b/stratos-client/src/discovery.ts
@@ -92,6 +92,86 @@ export const parseEnrollmentRecord = (
   }
 }
 
+const toHandler = (pdsUrlOrHandler: string | FetchHandler): FetchHandler =>
+  typeof pdsUrlOrHandler === 'string'
+    ? simpleFetchHandler({ service: pdsUrlOrHandler })
+    : pdsUrlOrHandler
+
+const extractRkey = (uri: string): string => {
+  const parts = uri.split('/')
+  return parts[parts.length - 1]
+}
+
+interface ListRecordsResponse {
+  records: Array<GetRecordResponse>
+}
+
+/**
+ * discovers all Stratos enrollments by listing enrollment records
+ * from the user's PDS via com.atproto.repo.listRecords.
+ *
+ * @param did the DID to check for enrollments
+ * @param pdsUrlOrHandler the user's PDS service URL or a FetchHandler
+ * @returns all valid enrollments, empty array when none exist
+ */
+export const discoverEnrollments = async (
+  did: string,
+  pdsUrlOrHandler: string | FetchHandler,
+): Promise<Array<StratosEnrollment>> => {
+  const rpc = new Client({ handler: toHandler(pdsUrlOrHandler) })
+
+  try {
+    const res = (await rpc.get('com.atproto.repo.listRecords', {
+      params: {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        repo: did as any,
+        collection: ENROLLMENT_COLLECTION,
+        limit: 100,
+      },
+    })) as XRPCResponse<ListRecordsResponse>
+
+    if (!res.ok) return []
+
+    const enrollments: Array<StratosEnrollment> = []
+    for (const record of res.data.records) {
+      const enrollment = parseEnrollmentRecord(
+        record.value,
+        extractRkey(record.uri),
+      )
+      if (enrollment) enrollments.push(enrollment)
+    }
+    return enrollments
+  } catch {
+    return []
+  }
+}
+
+/**
+ * discovers a single Stratos enrollment from the user's PDS.
+ *
+ * a user can enroll with more than one service. this function sorts the
+ * enrollments by createdAt, then by rkey, and returns the first one. the
+ * sort makes the result stable: two callers always get the same enrollment,
+ * and a new enrollment does not change the result for an existing user.
+ *
+ * to see every enrollment, call discoverEnrollments instead.
+ *
+ * @param did the DID to check for enrollment
+ * @param pdsUrlOrHandler the user's PDS service URL or a FetchHandler
+ * @returns the oldest enrollment if any exist, null otherwise
+ */
+export const discoverEnrollment = async (
+  did: string,
+  pdsUrlOrHandler: string | FetchHandler,
+): Promise<StratosEnrollment | null> => {
+  const enrollments = await discoverEnrollments(did, pdsUrlOrHandler)
+  const sorted = [...enrollments].sort(
+    (a, b) =>
+      a.createdAt.localeCompare(b.createdAt) || a.rkey.localeCompare(b.rkey),
+  )
+  return sorted[0] ?? null
+}
+
 /**
  * discovers a specific Stratos enrollment by the service's DID.
  * uses com.atproto.repo.getRecord with the service DID as the rkey
@@ -107,12 +187,7 @@ export const getEnrollmentByServiceDid = async (
   pdsUrlOrHandler: string | FetchHandler,
   serviceDid: string,
 ): Promise<StratosEnrollment | null> => {
-  const handler =
-    typeof pdsUrlOrHandler === 'string'
-      ? simpleFetchHandler({ service: pdsUrlOrHandler })
-      : pdsUrlOrHandler
-
-  const rpc = new Client({ handler })
+  const rpc = new Client({ handler: toHandler(pdsUrlOrHandler) })
   const rkey = serviceDIDToRkey(serviceDid)
 
   try {

--- a/stratos-client/src/index.ts
+++ b/stratos-client/src/index.ts
@@ -12,6 +12,8 @@ export type {
 
 export {
   ENROLLMENT_COLLECTION,
+  discoverEnrollment,
+  discoverEnrollments,
   getEnrollmentByServiceDid,
   parseEnrollmentRecord,
 } from './discovery.js'
@@ -20,13 +22,20 @@ export {
   resolveServiceUrl,
   findEnrollmentByService,
   serviceDIDToRkey,
+  type ServiceFetchHandlerOptions,
 } from './routing.js'
 export {
   verifyCidIntegrity,
+  verifyRecordCid,
   resolveServiceSigningKey,
   resolveUserSigningKey,
   fetchAndVerifyRecord,
+  verifyStratosRecord,
 } from './verification.js'
+export {
+  verifyEnrollmentAttestation,
+  type AttestationResult,
+} from './attestation.js'
 export {
   STRATOS_SCOPES,
   buildCollectionScope,

--- a/stratos-client/src/routing.ts
+++ b/stratos-client/src/routing.ts
@@ -11,6 +11,18 @@ export const serviceDIDToRkey = (serviceDid: string): string => {
 }
 
 /**
+ * options for createServiceFetchHandler.
+ */
+export interface ServiceFetchHandlerOptions {
+  /**
+   * extra headers to set on every routed request, for example development
+   * tunnel bypass headers. these headers replace the per-request headers
+   * that use the same name.
+   */
+  headers?: HeadersInit
+}
+
+/**
  * creates a fetch handler that routes XRPC calls to a specific service URL
  * using an existing authenticated handler for DPoP credentials.
  *
@@ -20,16 +32,25 @@ export const serviceDIDToRkey = (serviceDid: string): string => {
  *
  * @param authenticatedHandler a handler that attaches auth headers (DPoP proof + access token)
  * @param serviceUrl the target Stratos service base URL
+ * @param options optional configuration (extra headers)
  * @returns a FetchHandlerObject that routes calls to the target service
  */
 export const createServiceFetchHandler = (
   authenticatedHandler: FetchHandler,
   serviceUrl: string,
+  options?: ServiceFetchHandlerOptions,
 ): FetchHandlerObject => {
   return {
     async handle(pathname: string, init?: RequestInit): Promise<Response> {
       const url = new URL(pathname, serviceUrl)
-      return authenticatedHandler(url.href, init ?? {})
+      if (!options?.headers) {
+        return authenticatedHandler(url.href, init ?? {})
+      }
+      const headers = new Headers(init?.headers)
+      new Headers(options.headers).forEach((value, name) => {
+        headers.set(name, value)
+      })
+      return authenticatedHandler(url.href, { ...init, headers })
     },
   }
 }

--- a/stratos-client/src/types.ts
+++ b/stratos-client/src/types.ts
@@ -74,6 +74,12 @@ export interface ResolveSigningKeyOptions {
    * defaults to global fetch.
    */
   fetchFn?: typeof fetch
+  /**
+   * keeps each resolved key between calls, with the service DID as the map
+   * key. the function reads the map before it fetches, and writes to the map
+   * after a successful fetch.
+   */
+  cache?: Map<string, import('@atcute/crypto').PublicKey>
 }
 
 /**

--- a/stratos-client/src/verification.ts
+++ b/stratos-client/src/verification.ts
@@ -1,4 +1,10 @@
 import { verifyRecord as atcuteVerifyRecord } from '@atcute/repo'
+import { encode as cborEncode } from '@atcute/cbor'
+import {
+  create as cidCreate,
+  toString as cidToString,
+  CODEC_DCBOR,
+} from '@atcute/cid'
 import {
   getPublicKeyFromDidController,
   P256PublicKey,
@@ -58,21 +64,55 @@ export const verifyCidIntegrity = async (
 }
 
 /**
+ * verifies that a record value matches its claimed CID. the function
+ * encodes the value again as DAG-CBOR and compares the two CIDs. it accepts
+ * records in atproto JSON interchange form ({$link} / {$bytes} wrappers).
+ *
+ * this is the verification path for a service that does not serve CAR
+ * inclusion proofs. the Stratos service removed com.atproto.sync.getRecord
+ * with private image support (#84). a record that you read from it with
+ * com.atproto.repo.getRecord therefore has no proof of provenance, and CID
+ * integrity is the only available check. do not replace this with a
+ * signature check: the necessary commit data does not arrive.
+ *
+ * @param value the record value as returned by com.atproto.repo.getRecord
+ * @param expectedCid the CID claimed for the record
+ * @returns the verified record with level 'cid-integrity'
+ * @throws when the computed CID does not match the expected CID
+ */
+export const verifyRecordCid = async (
+  value: unknown,
+  expectedCid: string,
+): Promise<VerifiedRecord> => {
+  const bytes = cborEncode(value)
+  const computed = cidToString(await cidCreate(CODEC_DCBOR, bytes))
+  if (computed !== expectedCid) {
+    throw new Error(
+      `record CID mismatch: computed ${computed}, expected ${expectedCid}`,
+    )
+  }
+  return { cid: computed, record: value, level: 'cid-integrity' }
+}
+
+/**
  * resolves the service's signing public key from its DID document.
  * uses WebDidDocumentResolver for validated DID document fetching and
  * getPublicKeyFromDidController for key type dispatch.
  *
- * callers should cache the returned key — it does not change unless
- * the service rotates its signing key.
+ * pass a cache Map in options to keep the result between calls. the key
+ * does not change unless the service rotates its signing key.
  *
  * @param serviceDid the service's did:web identifier
- * @param options optional configuration (fetch function)
+ * @param options optional configuration (fetch function, cache)
  * @returns the service's public signing key
  */
 export const resolveServiceSigningKey = async (
   serviceDid: string,
   options?: ResolveSigningKeyOptions,
 ): Promise<PublicKey> => {
+  const cached = options?.cache?.get(serviceDid)
+  if (cached) return cached
+
   if (!serviceDid.startsWith('did:web:')) {
     throw new Error(`expected did:web, got: ${serviceDid}`)
   }
@@ -90,12 +130,18 @@ export const resolveServiceSigningKey = async (
 
   const found = getPublicKeyFromDidController(material)
 
+  let key: PublicKey
   switch (found.type) {
     case 'secp256k1':
-      return Secp256k1PublicKey.importRaw(found.publicKeyBytes)
+      key = await Secp256k1PublicKey.importRaw(found.publicKeyBytes)
+      break
     case 'p256':
-      return P256PublicKey.importRaw(found.publicKeyBytes)
+      key = await P256PublicKey.importRaw(found.publicKeyBytes)
+      break
   }
+
+  options?.cache?.set(serviceDid, key)
+  return key
 }
 
 /**
@@ -185,5 +231,55 @@ export const fetchAndVerifyRecord = async (
     rkey,
     did,
     options?.serviceSigningKey,
+  )
+}
+
+/** signing key cache that verifyStratosRecord uses between calls. */
+const defaultSigningKeyCache = new Map<string, PublicKey>()
+
+/**
+ * verifies a Stratos record CAR. the function checks the signature when it
+ * can resolve the service signing key, and falls back to CID integrity when
+ * it cannot. it keeps each service key between calls.
+ *
+ * take the CAR from a source that serves inclusion proofs, such as a PDS
+ * com.atproto.sync.getRecord response or an owner-scoped
+ * zone.stratos.sync.getRepo export. the Stratos service does not serve a
+ * proof for a single record. for a record that you read from it with
+ * com.atproto.repo.getRecord, use verifyRecordCid instead.
+ *
+ * @param carBytes the CAR file bytes containing the inclusion proof
+ * @param did the repo DID
+ * @param collection the collection NSID
+ * @param rkey the record key
+ * @param serviceDid the service's did:web identifier, if known
+ * @returns the verified record with its CID and verification level
+ */
+export const verifyStratosRecord = async (
+  carBytes: Uint8Array,
+  did: string,
+  collection: string,
+  rkey: string,
+  serviceDid?: string,
+): Promise<VerifiedRecord> => {
+  let signingKey: PublicKey | undefined
+
+  if (serviceDid) {
+    try {
+      signingKey = await resolveServiceSigningKey(serviceDid, {
+        cache: defaultSigningKeyCache,
+      })
+    } catch {
+      // the key did not resolve. fall through to CID-only verification.
+    }
+  }
+
+  return verifyRecordCar(
+    carBytes,
+    collection,
+    rkey,
+    did,
+    signingKey,
+    signingKey ? 'service-signature' : 'cid-integrity',
   )
 }

--- a/stratos-client/tests/attestation.test.ts
+++ b/stratos-client/tests/attestation.test.ts
@@ -1,0 +1,212 @@
+import { describe, expect, it } from 'vitest'
+import { P256Keypair, Secp256k1Keypair } from '@atproto/crypto'
+import { encode as cborEncode } from '@atcute/cbor'
+
+import { verifyEnrollmentAttestation } from '../src/index.js'
+
+const USER_DID = 'did:plc:shinjiikari'
+const USER_SIGNING_KEY = 'did:key:zUserSigningKeyPlaceholder'
+const SERVICE_URL = 'https://stratos.nerv.tokyo.jp'
+
+const BOUNDARIES = [
+  'did:web:nerv.tokyo.jp/engineering',
+  'did:web:nerv.tokyo.jp/leadership',
+]
+
+type Keypair = Secp256k1Keypair | P256Keypair
+
+/**
+ * builds an enrollment record with a real service attestation over
+ * {boundaries, did, signingKey}.
+ */
+const buildAttestedEnrollment = async (
+  serviceKeypair: Keypair,
+  options: {
+    userDid?: string
+    userSigningKey?: string
+    boundaryValues?: Array<string>
+    signedBoundaries?: Array<string>
+  } = {},
+) => {
+  const userDid = options.userDid ?? USER_DID
+  const userSigningKey = options.userSigningKey ?? USER_SIGNING_KEY
+  const boundaryValues = options.boundaryValues ?? BOUNDARIES
+
+  const payload = cborEncode({
+    boundaries: [...(options.signedBoundaries ?? boundaryValues)].sort(),
+    did: userDid,
+    signingKey: userSigningKey,
+  })
+
+  const sig = await serviceKeypair.sign(payload)
+
+  return {
+    service: SERVICE_URL,
+    boundaries: boundaryValues.map((value) => ({ value })),
+    signingKey: userSigningKey,
+    attestation: { sig, signingKey: serviceKeypair.did() },
+    createdAt: '1995-10-04T00:00:00Z',
+  }
+}
+
+const toBase64 = (bytes: Uint8Array) =>
+  btoa(String.fromCharCode(...Array.from(bytes)))
+
+describe('verifyEnrollmentAttestation', () => {
+  it('accepts a valid secp256k1 attestation', async () => {
+    const serviceKeypair = await Secp256k1Keypair.create({ exportable: true })
+    const record = await buildAttestedEnrollment(serviceKeypair)
+
+    const result = await verifyEnrollmentAttestation(record, USER_DID)
+
+    expect(result.valid).toBe(true)
+    expect(result.error).toBeUndefined()
+    expect(result.serviceKey).toBe(serviceKeypair.did())
+    expect(result.userSigningKey).toBe(USER_SIGNING_KEY)
+    expect(result.boundaries).toEqual([...BOUNDARIES].sort())
+  })
+
+  it('accepts a valid p256 attestation', async () => {
+    const serviceKeypair = await P256Keypair.create({ exportable: true })
+    const record = await buildAttestedEnrollment(serviceKeypair)
+
+    const result = await verifyEnrollmentAttestation(record, USER_DID)
+
+    expect(result.valid).toBe(true)
+  })
+
+  it('accepts a signature in { $bytes } JSON interchange form', async () => {
+    const serviceKeypair = await Secp256k1Keypair.create({ exportable: true })
+    const record = await buildAttestedEnrollment(serviceKeypair)
+
+    const jsonRecord = {
+      ...record,
+      attestation: {
+        ...record.attestation,
+        sig: { $bytes: toBase64(record.attestation.sig) },
+      },
+    }
+
+    const result = await verifyEnrollmentAttestation(jsonRecord, USER_DID)
+
+    expect(result.valid).toBe(true)
+  })
+
+  it('ignores the stored boundary order', async () => {
+    const serviceKeypair = await Secp256k1Keypair.create({ exportable: true })
+    const record = await buildAttestedEnrollment(serviceKeypair, {
+      boundaryValues: [...BOUNDARIES].reverse(),
+    })
+
+    const result = await verifyEnrollmentAttestation(record, USER_DID)
+
+    expect(result.valid).toBe(true)
+    expect(result.boundaries).toEqual([...BOUNDARIES].sort())
+  })
+
+  it('rejects a record whose boundaries were tampered with', async () => {
+    const serviceKeypair = await Secp256k1Keypair.create({ exportable: true })
+    const record = await buildAttestedEnrollment(serviceKeypair, {
+      signedBoundaries: BOUNDARIES,
+      boundaryValues: [...BOUNDARIES, 'did:web:nerv.tokyo.jp/seele'],
+    })
+
+    const result = await verifyEnrollmentAttestation(record, USER_DID)
+
+    expect(result.valid).toBe(false)
+  })
+
+  it('rejects a record attested for a different user', async () => {
+    const serviceKeypair = await Secp256k1Keypair.create({ exportable: true })
+    const record = await buildAttestedEnrollment(serviceKeypair)
+
+    const result = await verifyEnrollmentAttestation(
+      record,
+      'did:plc:reiayanami',
+    )
+
+    expect(result.valid).toBe(false)
+  })
+
+  it('rejects a record whose signingKey was swapped', async () => {
+    const serviceKeypair = await Secp256k1Keypair.create({ exportable: true })
+    const record = await buildAttestedEnrollment(serviceKeypair)
+
+    const tampered = { ...record, signingKey: 'did:key:zAttackerControlledKey' }
+
+    const result = await verifyEnrollmentAttestation(tampered, USER_DID)
+
+    expect(result.valid).toBe(false)
+  })
+
+  it('rejects a signature made by a different service key', async () => {
+    const serviceKeypair = await Secp256k1Keypair.create({ exportable: true })
+    const impostorKeypair = await Secp256k1Keypair.create({ exportable: true })
+    const record = await buildAttestedEnrollment(serviceKeypair)
+
+    const tampered = {
+      ...record,
+      attestation: {
+        ...record.attestation,
+        signingKey: impostorKeypair.did(),
+      },
+    }
+
+    const result = await verifyEnrollmentAttestation(tampered, USER_DID)
+
+    expect(result.valid).toBe(false)
+  })
+
+  it('reports a missing attestation field without throwing', async () => {
+    const result = await verifyEnrollmentAttestation(
+      {
+        service: SERVICE_URL,
+        boundaries: [],
+        signingKey: USER_SIGNING_KEY,
+        createdAt: '1995-10-04T00:00:00Z',
+      },
+      USER_DID,
+    )
+
+    expect(result.valid).toBe(false)
+    expect(result.error).toMatch(/missing attestation/i)
+    expect(result.serviceKey).toBe('')
+    expect(result.boundaries).toEqual([])
+  })
+
+  it('reports a missing signingKey field without throwing', async () => {
+    const serviceKeypair = await Secp256k1Keypair.create({ exportable: true })
+    const record = await buildAttestedEnrollment(serviceKeypair)
+    const { signingKey: _removed, ...withoutSigningKey } = record
+
+    const result = await verifyEnrollmentAttestation(
+      withoutSigningKey,
+      USER_DID,
+    )
+
+    expect(result.valid).toBe(false)
+    expect(result.error).toMatch(/missing attestation/i)
+  })
+
+  it('reports a malformed service did:key without throwing', async () => {
+    const serviceKeypair = await Secp256k1Keypair.create({ exportable: true })
+    const record = await buildAttestedEnrollment(serviceKeypair)
+
+    const tampered = {
+      ...record,
+      attestation: { ...record.attestation, signingKey: 'not-a-did-key' },
+    }
+
+    const result = await verifyEnrollmentAttestation(tampered, USER_DID)
+
+    expect(result.valid).toBe(false)
+    expect(result.error).toBeTruthy()
+  })
+
+  it('returns a falsy result for a non-object record', async () => {
+    const result = await verifyEnrollmentAttestation(null, USER_DID)
+
+    expect(result.valid).toBe(false)
+    expect(result.error).toMatch(/missing attestation/i)
+  })
+})


### PR DESCRIPTION
## Summary

`@northskysocial/stratos-client@0.4.0` published without `attestation.js` and six exports that downstream code imports. Its `index.d.ts` is byte-identical to `0.3.0` — the release was a pure dependency bump, and the missing surface went with it.

Downstream effect: `pdslss` cannot compile against any published version. It builds today only because a stale, unpublished build sits in its `node_modules`. No branch, tag, or remote ref in this repo contains `stratos-client/src/attestation.ts`, so this restores the modules from that compiled artifact.

Restored exports:

| export | module |
| --- | --- |
| `verifyEnrollmentAttestation`, `AttestationResult` | `attestation.ts` (new) |
| `verifyRecordCid`, `verifyStratosRecord` | `verification.ts` |
| `discoverEnrollment`, `discoverEnrollments` | `discovery.ts` |
| `ServiceFetchHandlerOptions` | `routing.ts` |

Every change is additive. No existing export changes signature.

## Notable changes

- **`@atcute/cbor` moves to `dependencies`.** Attestation and CID verification need it at runtime. It was already a transitive dep of `@atcute/car` and `@atcute/repo`; this makes it explicit.
- **`discoverEnrollment` sorts by `createdAt`, then `rkey`.** The artifact returned whatever `listRecords` yielded first. That arbitrary pick sits on both sides of the caller's service-match check, so two users enrolled with the same pair of services could appear mismatched. Oldest-first is stable under addition.
- **`scripts/check-exports.mjs` joins `postbuild`.** The existing guard stops `stratos-core` leaking in; nothing checked that the built surface still holds the names consumers import. Run against the broken `0.4.0` dist, the new guard flags exactly the 7 missing exports and `attestation.js`.
- **`toArrayBufferBytes` in `attestation.ts`.** `verifySigWithDidKey` requires `Uint8Array<ArrayBuffer>`; `cborEncode` returns `ArrayBufferLike`. The compiled artifact hid this because JS carries no types.

## Fidelity to the recovered artifact

- `index.d.ts` export surface — identical
- `routing.js` — byte-identical
- `verification.js` — doc comments only; executable code byte-identical
- `discovery.js` — identical but for the deterministic sort
- `attestation.js` — identical but for the type-safety helper

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm exec vitest run --project stratos-client` — 86 passed, including 12 new attestation cases
- [x] `pnpm --filter @northskysocial/stratos-client build` — clean, both postbuild guards pass
- [x] `eslint .` — clean
- [x] `prettier --check` — clean
- [x] New guard verified non-vacuous against the published `0.4.0` dist
- [ ] CI green on this PR

## Notes

Merging publishes `0.4.1` via `publish.yml`. `pdslss` is blocked until it lands.

Two pre-existing issues found while working, both left alone:
- `pnpm test` inside `stratos-client` fails at startup — the root `vitest.config.ts` lists `./webapp/vite.config.ts`, which resolves against cwd. Tests must run from the repo root.
- `test.yml` triggers on pushes to `main`, `develop`, and `feat/*`, so `fix/*` and `chore/*` branches get no CI until a PR exists.

🤖 Generated with Rommie Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added enrollment discovery APIs to find one or all enrollments.
  * Added enrollment attestation verification with detailed validation results.
  * Added record verification using service signatures or content integrity checks.
  * Added optional request headers and signing-key caching support.
  * Expanded the public client API with additional verification and discovery tools.

* **Bug Fixes**
  * Added build validation to detect missing public exports and modules before release.

* **Chores**
  * Updated the package version to 0.4.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->