### PR TITLE
fix: repair legacy stratos_enrollment layouts at indexer startup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,7 +164,7 @@ stratos-service/src/features/{feature}/
 | `pds/pds-firehose.ts`       | Connects to the PDS firehose and discovers enrollment records                                                                                                                      |
 | `pds/pds-subscriber.ts`     | Wires PDS firehose work into the indexing service, handle dedup, and the worker pool                                                                                               |
 | `storage/cursor-manager.ts` | Manages PDS and Stratos sync cursors with periodic flush                                                                                                                           |
-| `storage/db.ts`             | Kysely Postgres connection setup, DID-resolver cache, legacy lowercase-column migration                                                                                            |
+| `storage/db.ts`             | Kysely Postgres connection setup, DID-resolver cache, startup repair of legacy column layouts (renames + `boundaries` add)                                                         |
 | `storage/schema.ts`         | Kysely table types for sync cursors, enrollments, indexed records, record boundaries, and posts                                                                                    |
 | `sync/stratos-sync.ts`      | Service and actor-level WebSocket subscription handlers                                                                                                                            |
 | `sync/actor-syncer.ts`      | Decodes per-actor sync frames; upserts every record into the AppView database (`stratos_record` + `stratos_record_boundary`, plus a `post` row for feed posts) and applies deletes |

--- a/stratos-indexer/src/storage/db.ts
+++ b/stratos-indexer/src/storage/db.ts
@@ -14,8 +14,9 @@ const DID_CACHE_MAX_SIZE = 10_000
  * Maps every historical column layout forward to the shared AppView schema:
  * unquoted DDL that Postgres folded to lower case, and the quoted
  * createdAt/updatedAt intermediate that predates enrolledAt/lastChecked.
- * Each rename no-ops once the target column exists, so entries that share a
- * target are order-independent.
+ * Each rename no-ops when the source column is absent or the target column
+ * exists, so shared-target entries cannot error. If two source columns for
+ * one target coexist, the earlier entry wins and the later column stays.
  */
 const LEGACY_COLUMN_RENAMES = [
   { table: 'stratos_enrollment', from: 'serviceurl', to: 'serviceUrl' },

--- a/stratos-indexer/src/storage/db.ts
+++ b/stratos-indexer/src/storage/db.ts
@@ -11,13 +11,19 @@ const DID_CACHE_SWEEP_INTERVAL = 60 * 1000 // sweep every 60s
 const DID_CACHE_MAX_SIZE = 10_000
 
 /**
- * Columns created by pre-quoting builds of this file, which declared them
- * unquoted and so had Postgres fold them to lower case. Kysely emits quoted
- * camelCase, so those tables must be renamed forward or every write fails.
+ * Maps every historical column layout forward to the shared AppView schema:
+ * unquoted DDL that Postgres folded to lower case, and the quoted
+ * createdAt/updatedAt intermediate that predates enrolledAt/lastChecked.
+ * Each rename no-ops once the target column exists, so entries that share a
+ * target are order-independent.
  */
-const LEGACY_LOWERCASE_COLUMNS = [
+const LEGACY_COLUMN_RENAMES = [
   { table: 'stratos_enrollment', from: 'serviceurl', to: 'serviceUrl' },
+  { table: 'stratos_enrollment', from: 'createdat', to: 'enrolledAt' },
+  { table: 'stratos_enrollment', from: 'createdAt', to: 'enrolledAt' },
   { table: 'stratos_enrollment', from: 'enrolledat', to: 'enrolledAt' },
+  { table: 'stratos_enrollment', from: 'updatedat', to: 'lastChecked' },
+  { table: 'stratos_enrollment', from: 'updatedAt', to: 'lastChecked' },
   { table: 'stratos_enrollment', from: 'lastchecked', to: 'lastChecked' },
   { table: 'stratos_sync_cursor', from: 'updatedat', to: 'updatedAt' },
   { table: 'stratos_record', from: 'indexedat', to: 'indexedAt' },
@@ -37,8 +43,8 @@ interface RawDbHolder {
 }
 
 /**
- * Rename a legacy lower-cased column to its camelCase form. No-ops when the
- * table is absent, already renamed, or freshly created, so it is safe to rerun.
+ * Rename a legacy column to its current name. No-ops when the table is
+ * absent, already renamed, or freshly created, so it is safe to rerun.
  */
 async function renameLegacyColumn(
   db: Kysely<Record<string, unknown>>,
@@ -119,9 +125,16 @@ export async function ensureIndexerSchema(db: Database): Promise<void> {
       )
     `.execute(rawDb)
 
-    for (const { table, from, to } of LEGACY_LOWERCASE_COLUMNS) {
+    for (const { table, from, to } of LEGACY_COLUMN_RENAMES) {
       await renameLegacyColumn(rawDb, table, from, to)
     }
+
+    // Legacy bootstraps predate the boundaries column, and CREATE TABLE
+    // IF NOT EXISTS cannot add it to an existing table.
+    await sql`
+      ALTER TABLE stratos_enrollment
+      ADD COLUMN IF NOT EXISTS boundaries TEXT
+    `.execute(rawDb)
 
     // Optimized index for boundary-based hydration
     await sql`

--- a/stratos-indexer/tests/db-schema.test.ts
+++ b/stratos-indexer/tests/db-schema.test.ts
@@ -1,0 +1,254 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  Kysely,
+  PostgresAdapter,
+  PostgresIntrospector,
+  PostgresQueryCompiler,
+  type CompiledQuery,
+  type DatabaseConnection,
+  type Dialect,
+  type Driver,
+  type QueryResult,
+} from 'kysely'
+import type { Database } from '@atproto/bsky'
+import { ensureIndexerSchema } from '../src/storage/db.js'
+
+const TARGET_ENROLLMENT_COLUMNS = [
+  'did',
+  'serviceUrl',
+  'enrolledAt',
+  'lastChecked',
+  'boundaries',
+]
+
+/**
+ * In-memory schema simulator: tracks each table's column set and enforces the
+ * same DDL rules Postgres does, so tests observe the schema end-state rather
+ * than the exact statement sequence.
+ */
+class FakePostgres {
+  readonly tables = new Map<string, Set<string>>()
+  readonly statements: string[] = []
+  failOn?: (sql: string) => boolean
+
+  constructor(seed: Record<string, string[]> = {}) {
+    for (const [table, columns] of Object.entries(seed)) {
+      this.tables.set(table, new Set(columns))
+    }
+  }
+
+  columns(table: string): string[] {
+    return [...(this.tables.get(table) ?? [])].sort()
+  }
+
+  execute(query: CompiledQuery): QueryResult<Record<string, unknown>> {
+    const text = query.sql
+    this.statements.push(text)
+    if (this.failOn?.(text)) {
+      throw new Error(`injected failure for: ${text}`)
+    }
+
+    if (text.includes('information_schema.columns')) {
+      const [table, ...names] = query.parameters as string[]
+      const existing = this.tables.get(table)
+      const rows = names
+        .filter((name) => existing?.has(name))
+        .map((name) => ({ column_name: name }))
+      return { rows }
+    }
+
+    const createTable = text.match(
+      /CREATE TABLE IF NOT EXISTS (\w+)\s*\(([\s\S]*)\)/,
+    )
+    if (createTable) {
+      const [, table, body] = createTable
+      if (!this.tables.has(table)) {
+        this.tables.set(table, new Set(parseColumnNames(body)))
+      }
+      return { rows: [] }
+    }
+
+    const rename = text.match(
+      /ALTER TABLE\s+"?(\w+)"?\s+RENAME COLUMN\s+"?(\w+)"?\s+TO\s+"?(\w+)"?/,
+    )
+    if (rename) {
+      const [, table, from, to] = rename
+      const existing = this.tables.get(table)
+      if (!existing) throw new Error(`relation "${table}" does not exist`)
+      if (!existing.has(from)) {
+        throw new Error(`column "${from}" does not exist`)
+      }
+      if (existing.has(to)) {
+        throw new Error(`column "${to}" already exists`)
+      }
+      existing.delete(from)
+      existing.add(to)
+      return { rows: [] }
+    }
+
+    const addColumn = text.match(
+      /ALTER TABLE\s+"?(\w+)"?\s+ADD COLUMN IF NOT EXISTS\s+"?(\w+)"?/,
+    )
+    if (addColumn) {
+      const [, table, column] = addColumn
+      const existing = this.tables.get(table)
+      if (!existing) throw new Error(`relation "${table}" does not exist`)
+      existing.add(column)
+      return { rows: [] }
+    }
+
+    if (text.includes('CREATE INDEX')) {
+      return { rows: [] }
+    }
+
+    throw new Error(`unexpected statement: ${text}`)
+  }
+}
+
+function parseColumnNames(body: string): string[] {
+  return body
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && !line.startsWith('PRIMARY KEY'))
+    .map((line) => line.match(/^"?([A-Za-z_]+)"?/)?.[1])
+    .filter((name): name is string => name !== undefined)
+}
+
+function createFakeDb(seed: Record<string, string[]> = {}): {
+  db: Database
+  fake: FakePostgres
+} {
+  const fake = new FakePostgres(seed)
+  const connection: DatabaseConnection = {
+    executeQuery: async <R>(query: CompiledQuery) =>
+      fake.execute(query) as QueryResult<R>,
+    streamQuery: () => {
+      throw new Error('streaming is not supported')
+    },
+  }
+  const driver: Driver = {
+    init: async () => {},
+    acquireConnection: async () => connection,
+    beginTransaction: async () => {},
+    commitTransaction: async () => {},
+    rollbackTransaction: async () => {},
+    releaseConnection: async () => {},
+    destroy: async () => {},
+  }
+  const dialect: Dialect = {
+    createAdapter: () => new PostgresAdapter(),
+    createDriver: () => driver,
+    createIntrospector: (kysely) => new PostgresIntrospector(kysely),
+    createQueryCompiler: () => new PostgresQueryCompiler(),
+  }
+  const db = { db: new Kysely({ dialect }) } as unknown as Database
+  return { db, fake }
+}
+
+describe('ensureIndexerSchema enrollment repair', () => {
+  it('repairs the unquoted legacy bootstrap layout', async () => {
+    const { db, fake } = createFakeDb({
+      stratos_enrollment: ['did', 'serviceurl', 'createdat', 'updatedat'],
+    })
+
+    await ensureIndexerSchema(db)
+
+    expect(fake.columns('stratos_enrollment')).toEqual(
+      [...TARGET_ENROLLMENT_COLUMNS].sort(),
+    )
+  })
+
+  it('repairs the quoted createdAt/updatedAt intermediate layout', async () => {
+    const { db, fake } = createFakeDb({
+      stratos_enrollment: ['did', 'serviceUrl', 'createdAt', 'updatedAt'],
+    })
+
+    await ensureIndexerSchema(db)
+
+    expect(fake.columns('stratos_enrollment')).toEqual(
+      [...TARGET_ENROLLMENT_COLUMNS].sort(),
+    )
+  })
+
+  it('repairs the lowercase enrolledat/lastchecked layout', async () => {
+    const { db, fake } = createFakeDb({
+      stratos_enrollment: ['did', 'serviceurl', 'enrolledat', 'lastchecked'],
+    })
+
+    await ensureIndexerSchema(db)
+
+    expect(fake.columns('stratos_enrollment')).toEqual(
+      [...TARGET_ENROLLMENT_COLUMNS].sort(),
+    )
+  })
+
+  it('leaves the current layout untouched apart from the idempotent boundaries add', async () => {
+    const { db, fake } = createFakeDb({
+      stratos_enrollment: [...TARGET_ENROLLMENT_COLUMNS],
+    })
+
+    await ensureIndexerSchema(db)
+
+    expect(fake.columns('stratos_enrollment')).toEqual(
+      [...TARGET_ENROLLMENT_COLUMNS].sort(),
+    )
+    const enrollmentRenames = fake.statements.filter(
+      (sql) => sql.includes('RENAME COLUMN') && sql.includes('stratos_enrollment'),
+    )
+    expect(enrollmentRenames).toEqual([])
+    const boundariesAdd = fake.statements.find((sql) =>
+      sql.includes('ADD COLUMN IF NOT EXISTS boundaries'),
+    )
+    expect(boundariesAdd).toBeDefined()
+  })
+
+  it('bootstraps a fresh database with the target layout and repairs after creation', async () => {
+    const { db, fake } = createFakeDb()
+
+    await ensureIndexerSchema(db)
+
+    expect(fake.columns('stratos_enrollment')).toEqual(
+      [...TARGET_ENROLLMENT_COLUMNS].sort(),
+    )
+    expect(fake.tables.has('stratos_sync_cursor')).toBe(true)
+    expect(fake.tables.has('stratos_record')).toBe(true)
+    expect(fake.tables.has('stratos_record_boundary')).toBe(true)
+    expect(fake.tables.has('post')).toBe(true)
+
+    const createIdx = fake.statements.findIndex((sql) =>
+      sql.includes('CREATE TABLE IF NOT EXISTS stratos_enrollment'),
+    )
+    const repairIdx = fake.statements.findIndex((sql) =>
+      sql.includes('ADD COLUMN IF NOT EXISTS boundaries'),
+    )
+    expect(createIdx).toBeGreaterThanOrEqual(0)
+    expect(repairIdx).toBeGreaterThan(createIdx)
+  })
+
+  it('does not rename when the old and new column names coexist', async () => {
+    const { db, fake } = createFakeDb({
+      stratos_enrollment: ['did', 'serviceUrl', 'createdat', 'enrolledAt', 'lastChecked'],
+    })
+
+    await ensureIndexerSchema(db)
+
+    const columns = fake.columns('stratos_enrollment')
+    expect(columns).toContain('createdat')
+    expect(columns).toContain('enrolledAt')
+    expect(columns).toContain('boundaries')
+  })
+
+  it('fails startup when the boundaries repair fails', async () => {
+    const { db, fake } = createFakeDb({
+      stratos_enrollment: [...TARGET_ENROLLMENT_COLUMNS],
+    })
+    fake.failOn = (sql) => sql.includes('ADD COLUMN IF NOT EXISTS boundaries')
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {})
+
+    await expect(ensureIndexerSchema(db)).rejects.toThrow('injected failure')
+
+    consoleError.mockRestore()
+  })
+})

--- a/stratos-indexer/tests/db-schema.test.ts
+++ b/stratos-indexer/tests/db-schema.test.ts
@@ -193,7 +193,8 @@ describe('ensureIndexerSchema enrollment repair', () => {
       [...TARGET_ENROLLMENT_COLUMNS].sort(),
     )
     const enrollmentRenames = fake.statements.filter(
-      (sql) => sql.includes('RENAME COLUMN') && sql.includes('stratos_enrollment'),
+      (sql) =>
+        sql.includes('RENAME COLUMN') && sql.includes('stratos_enrollment'),
     )
     expect(enrollmentRenames).toEqual([])
     const boundariesAdd = fake.statements.find((sql) =>
@@ -227,7 +228,13 @@ describe('ensureIndexerSchema enrollment repair', () => {
 
   it('does not rename when the old and new column names coexist', async () => {
     const { db, fake } = createFakeDb({
-      stratos_enrollment: ['did', 'serviceUrl', 'createdat', 'enrolledAt', 'lastChecked'],
+      stratos_enrollment: [
+        'did',
+        'serviceUrl',
+        'createdat',
+        'enrolledAt',
+        'lastChecked',
+      ],
     })
 
     await ensureIndexerSchema(db)
@@ -243,9 +250,7 @@ describe('ensureIndexerSchema enrollment repair', () => {
       stratos_enrollment: [...TARGET_ENROLLMENT_COLUMNS],
     })
     fake.failOn = (sql) => sql.includes('ADD COLUMN IF NOT EXISTS boundaries')
-    const consoleError = vi
-      .spyOn(console, 'error')
-      .mockImplementation(() => {})
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
 
     await expect(ensureIndexerSchema(db)).rejects.toThrow('injected failure')
 

--- a/stratos-indexer/tests/db-schema.test.ts
+++ b/stratos-indexer/tests/db-schema.test.ts
@@ -182,6 +182,21 @@ describe('ensureIndexerSchema enrollment repair', () => {
     )
   })
 
+  it('is idempotent across a second run on a repaired legacy layout', async () => {
+    const { db, fake } = createFakeDb({
+      stratos_enrollment: ['did', 'serviceurl', 'createdat', 'updatedat'],
+    })
+
+    await ensureIndexerSchema(db)
+    // the fake throws on a duplicate rename, so a second run
+    // proves that each repair statement is idempotent
+    await ensureIndexerSchema(db)
+
+    expect(fake.columns('stratos_enrollment')).toEqual(
+      [...TARGET_ENROLLMENT_COLUMNS].sort(),
+    )
+  })
+
   it('leaves the current layout untouched apart from the idempotent boundaries add', async () => {
     const { db, fake } = createFakeDb({
       stratos_enrollment: [...TARGET_ENROLLMENT_COLUMNS],
@@ -239,10 +254,18 @@ describe('ensureIndexerSchema enrollment repair', () => {
 
     await ensureIndexerSchema(db)
 
-    const columns = fake.columns('stratos_enrollment')
-    expect(columns).toContain('createdat')
-    expect(columns).toContain('enrolledAt')
-    expect(columns).toContain('boundaries')
+    // the repair keeps the relic column and touches nothing else —
+    // assert the exact residual set the repair guarantees
+    expect(fake.columns('stratos_enrollment')).toEqual(
+      [
+        'boundaries',
+        'createdat',
+        'did',
+        'enrolledAt',
+        'lastChecked',
+        'serviceUrl',
+      ].sort(),
+    )
   })
 
   it('fails startup when the boundaries repair fails', async () => {


### PR DESCRIPTION
Closes #117.

## Summary
- Extend the startup repair map (`LEGACY_COLUMN_RENAMES`, formerly `LEGACY_LOWERCASE_COLUMNS`) so all three historical `stratos_enrollment` layouts converge on the current schema: `createdat`/`createdAt` → `enrolledAt`, `updatedat`/`updatedAt` → `lastChecked`, retaining the existing `enrolledat`/`lastchecked` entries.
- Add an idempotent `ALTER TABLE stratos_enrollment ADD COLUMN IF NOT EXISTS boundaries TEXT` after the rename loop — legacy bootstrap tables predate the column and `CREATE TABLE IF NOT EXISTS` cannot add it.
- All repairs run inside `ensureIndexerSchema`, before any enrollment write.
- New test suite (`tests/db-schema.test.ts`) drives the real repair code through a stateful in-memory Postgres schema simulator and asserts the end-state schema per layout, idempotency, collision no-ops, and failure propagation.

## Notes for reviewers
- The quoted `"createdAt"`/`"updatedAt"` mappings go beyond the issue's literal text: git history (`a87187c`..`a8a1da3`) proves that intermediate layout exists in the wild, and the pre-`a8a1da3` repair converted L1 tables into it.
- Repaired rows keep `boundaries = NULL` until enrollment re-discovery refreshes them (deliberate: no backfill from the dead `stratos_boundary` table).
- An Opus review pass validated the DDL semantics against a real Postgres 16 container: both legacy layouts repair correctly with constraints preserved, enrollment upserts then succeed, and the operation is idempotent and crash-safe. Remaining minor findings (test-simulator identifier-folding fidelity, no DML-level assertion, untested retained entries for other tables) are test-hardening follow-ups, not shipped defects.
- `stratos-indexer` has no Stryker config; adding one is a separate work item.

## Test plan
- [x] `pnpm exec vitest run` in `stratos-indexer` — 70/70 pass (7 new)
- [x] `pnpm prettier --check .` — clean
- [x] `pnpm exec eslint src tests` — 0 errors (4 pre-existing warnings in untouched files)
- [x] Manual validation of repair DDL + subsequent upsert against `postgres:16-alpine` (review pass)

🤖 Generated with Rommie Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup database repair for installations using older schema layouts.
  * Added automatic handling for legacy column names and missing enrollment boundary data.
  * Preserved compatibility with current schemas and mixed legacy/current configurations.
* **Reliability**
  * Improved database initialization behavior across fresh and upgraded installations.
  * Added safeguards to ensure schema update failures are reported clearly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->