### PR TITLE
Make the feedgen service stream and unenroll reconciliation reliable

### DIFF
--- a/stratos-feedgen/src/bin/main.ts
+++ b/stratos-feedgen/src/bin/main.ts
@@ -5,7 +5,11 @@ import { type FeedgenConfig, loadFeedgenConfig } from '../config.js'
 import { createFeedgenStore, type FeedgenStore } from '../db/index.js'
 import { EnrollmentManager } from '../enrollment/index.js'
 import { loadFeedRegistry } from '../feeds/index.js'
-import { Purger, reconcileEnrollments } from '../purge/index.js'
+import {
+  createReconcileScheduler,
+  Purger,
+  reconcileEnrollments,
+} from '../purge/index.js'
 import { createFeedgenServer } from '../server.js'
 import {
   ActorPool,
@@ -143,23 +147,30 @@ async function startSubscription(deps: StartSubscriptionDeps): Promise<{
     actorPool: pool,
   })
 
-  // Startup reconciliation: catch enroll/unenroll (and boundary-shrink)
-  // changes missed while the feedgen was down by diffing the persisted
-  // snapshot against a fresh resolveEnrollments snapshot. Bounded via
-  // batching so upstream resolves don't fan out unbounded on large tenants.
-  const summary = await reconcileEnrollments(
-    { store, purger, client: upstream },
-    configuredBoundaries,
-    {
-      batchSize: parseIntEnv(process.env['FEEDGEN_RECONCILE_BATCH_SIZE']),
-      maxActors: parseIntEnv(process.env['FEEDGEN_RECONCILE_MAX_ACTORS']),
-    },
-  )
-  console.log(
-    `enrollment reconciliation examined ${summary.examined} actors ` +
-      `(${summary.unenrolled} unenrolled, ${summary.shrunk} shrunk, ` +
-      `${summary.postsPurged} posts purged, ${summary.errors} errors)`,
-  )
+  // Reconciliation: catch enroll/unenroll (and boundary-shrink) changes
+  // missed while the feedgen was down or disconnected by diffing the
+  // persisted snapshot against a fresh resolveEnrollments snapshot. Bounded
+  // via batching so upstream resolves don't fan out unbounded on large
+  // tenants.
+  const runReconcile = async (): Promise<void> => {
+    const summary = await reconcileEnrollments(
+      { store, purger, client: upstream },
+      configuredBoundaries,
+      {
+        batchSize: parseIntEnv(process.env['FEEDGEN_RECONCILE_BATCH_SIZE']),
+        maxActors: parseIntEnv(process.env['FEEDGEN_RECONCILE_MAX_ACTORS']),
+      },
+    )
+    console.log(
+      `enrollment reconciliation examined ${summary.examined} actors ` +
+        `(${summary.unenrolled} unenrolled, ${summary.shrunk} shrunk, ` +
+        `${summary.postsPurged} posts purged, ${summary.errors} errors)`,
+    )
+  }
+  await runReconcile()
+  const triggerReconcile = createReconcileScheduler(runReconcile, (err) => {
+    console.error('reconnect reconciliation failed:', err)
+  })
 
   // Seed only AFTER reconciliation so the snapshot already reflects
   // revocations that landed while the feedgen was down - otherwise an actor
@@ -206,6 +217,9 @@ async function startSubscription(deps: StartSubscriptionDeps): Promise<{
     }
   }
 
+  // Startup already reconciled moments before the first open; only later
+  // opens (reconnects) can hide a missed unenroll behind them.
+  let firstOpen = true
   const serviceStream = new ServiceStream(
     {
       stratosServiceUrl: cfg.stratosServiceUrl,
@@ -224,6 +238,13 @@ async function startSubscription(deps: StartSubscriptionDeps): Promise<{
       onUnenroll: async (did) => {
         // purgeActor invalidates the boundary cache as part of the purge.
         await purger.purgeActor(did)
+      },
+      onSessionEstablished: () => {
+        if (firstOpen) {
+          firstOpen = false
+          return
+        }
+        triggerReconcile()
       },
     },
     (err) => {

--- a/stratos-feedgen/src/bin/main.ts
+++ b/stratos-feedgen/src/bin/main.ts
@@ -217,9 +217,6 @@ async function startSubscription(deps: StartSubscriptionDeps): Promise<{
     }
   }
 
-  // Startup already reconciled moments before the first open; only later
-  // opens (reconnects) can hide a missed unenroll behind them.
-  let firstOpen = true
   const serviceStream = new ServiceStream(
     {
       stratosServiceUrl: cfg.stratosServiceUrl,
@@ -239,11 +236,12 @@ async function startSubscription(deps: StartSubscriptionDeps): Promise<{
         // purgeActor invalidates the boundary cache as part of the purge.
         await purger.purgeActor(did)
       },
+      // Every open triggers a reconcile: a reconnect can hide a missed
+      // unenroll, and the startup reconcile can itself run against a
+      // degraded upstream (per-actor resolve failures are only counted).
+      // The scheduler coalesces, so a healthy boot pays one bounded extra
+      // run.
       onSessionEstablished: () => {
-        if (firstOpen) {
-          firstOpen = false
-          return
-        }
         triggerReconcile()
       },
     },

--- a/stratos-feedgen/src/purge/index.ts
+++ b/stratos-feedgen/src/purge/index.ts
@@ -1,2 +1,3 @@
 export * from './purger.js'
 export * from './reconcile.js'
+export * from './reconcile-scheduler.js'

--- a/stratos-feedgen/src/purge/reconcile-scheduler.ts
+++ b/stratos-feedgen/src/purge/reconcile-scheduler.ts
@@ -1,0 +1,40 @@
+export type ReconcileTrigger = () => void
+
+/**
+ * Serializes reconcile runs: a trigger during an in-flight run is coalesced
+ * into exactly one follow-up run, so a reconnect storm cannot stack N
+ * concurrent reconciles. Rejections are reported via `onError`, never thrown —
+ * the next trigger retries.
+ */
+export function createReconcileScheduler(
+  run: () => Promise<void>,
+  onError: (err: Error) => void = defaultOnError,
+): ReconcileTrigger {
+  let running = false
+  let followUpRequested = false
+
+  const launch = (): void => {
+    running = true
+    run()
+      .catch((err: unknown) => onError(err as Error))
+      .finally(() => {
+        running = false
+        if (followUpRequested) {
+          followUpRequested = false
+          launch()
+        }
+      })
+  }
+
+  return () => {
+    if (running) {
+      followUpRequested = true
+      return
+    }
+    launch()
+  }
+}
+
+function defaultOnError(err: Error): void {
+  console.error('reconcile run failed:', err)
+}

--- a/stratos-feedgen/src/purge/reconcile.ts
+++ b/stratos-feedgen/src/purge/reconcile.ts
@@ -53,6 +53,13 @@ const DEFAULT_BATCH_SIZE = 25
  * Only boundaries the feedgen actually tracks (`configuredBoundaries`) are
  * considered for the shrink case: a boundary the feedgen never synced can't
  * hold derived state to purge.
+ *
+ * Race guard: reconcile runs concurrently with live frame dispatch on the
+ * same connection, so a resolve can report `enrolled: false` moments before
+ * the live `enroll` frame for a re-enrolled actor is applied. Before any
+ * purge, the actor's `enrolled_actor` row is re-read; a row written at or
+ * after run start (or already deleted) means live state is fresher, and the
+ * purge is skipped. A skipped purge is safe — the next reconcile converges.
  */
 export async function reconcileEnrollments(
   deps: ReconcileDeps,
@@ -70,6 +77,7 @@ export async function reconcileEnrollments(
   const log = deps.log ?? defaultLog
   const onError = deps.onError ?? defaultOnError
 
+  const runStartedAt = new Date().toISOString()
   const all = await deps.store.listEnrolledActors()
   const actors = maxActors > 0 ? all.slice(0, maxActors) : all
 
@@ -107,7 +115,13 @@ export async function reconcileEnrollments(
         onError(entry.actor.did, entry.error)
         continue
       }
-      await reconcileActor(deps, configuredBoundaries, entry, summary)
+      await reconcileActor(
+        deps,
+        configuredBoundaries,
+        entry,
+        summary,
+        runStartedAt,
+      )
     }
   }
 
@@ -127,10 +141,12 @@ async function reconcileActor(
   configuredBoundaries: Set<string>,
   entry: { actor: EnrolledActor; fresh: ResolveEnrollmentsResult },
   summary: ReconcileSummary,
+  runStartedAt: string,
 ): Promise<void> {
   const { actor, fresh } = entry
 
   if (!fresh.enrolled) {
+    if (await touchedSinceRunStart(deps.store, actor.did, runStartedAt)) return
     const counts = await deps.purger.purgeActor(actor.did, 'reconcile-unenroll')
     summary.unenrolled++
     summary.postsPurged += counts.posts
@@ -144,6 +160,7 @@ async function reconcileActor(
     (b) => configuredBoundaries.has(b) && !freshSet.has(b),
   )
   if (lost.length > 0) {
+    if (await touchedSinceRunStart(deps.store, actor.did, runStartedAt)) return
     summary.shrunk++
     for (const boundary of lost) {
       const counts = await deps.purger.purgeActorBoundary(
@@ -168,6 +185,22 @@ async function reconcileActor(
       lastSeenAt: new Date().toISOString(),
     })
   }
+}
+
+/**
+ * Whether a live enroll/boundary frame wrote the actor's row at or after run
+ * start, or a live unenroll already removed it. In both cases the fresh
+ * upstream snapshot for this actor is stale and the purge must be skipped —
+ * `lastSeenAt` is only written by the live frame path and by reconcile
+ * itself, so it is a reliable touched-since marker.
+ */
+async function touchedSinceRunStart(
+  store: FeedgenStore,
+  did: string,
+  runStartedAt: string,
+): Promise<boolean> {
+  const current = await store.getEnrolledActor(did)
+  return current === null || current.lastSeenAt >= runStartedAt
 }
 
 function defaultLog(summary: ReconcileSummary): void {

--- a/stratos-feedgen/src/subscription/service-stream.ts
+++ b/stratos-feedgen/src/subscription/service-stream.ts
@@ -18,6 +18,14 @@ export interface ServiceStreamCallbacks {
     did: string,
     boundaries: string[],
   ) => void | Promise<void>
+  /**
+   * Fired on every socket open — the initial connect and each reconnect. The
+   * reconnect case is the hook for recovering events the stream cannot replay
+   * (a missed `unenroll` leaves no trace in the snapshot replay); consumers
+   * trigger their reconciliation here. A rejection is reported via `onError`
+   * and never tears down the stream.
+   */
+  onSessionEstablished?: () => void | Promise<void>
 }
 
 export interface ServiceStreamConfig {
@@ -171,6 +179,9 @@ export class ServiceStream {
 
     ws.addEventListener('open', () => {
       this.armStabilityReset()
+      void Promise.resolve()
+        .then(() => this.callbacks.onSessionEstablished?.())
+        .catch((err: unknown) => this.onError?.(err as Error))
     })
 
     ws.onmessage = (e: MessageEventLike) => {
@@ -267,7 +278,9 @@ export class ServiceStream {
    * lossless for enroll and boundary changes: this stream has no cursor, and
    * the upstream replays every current enrollment on connect
    * (`createServiceSubscriptionHandler` in the service's `subscribe-records`),
-   * so the reconnect restores the full set.
+   * so the reconnect restores those. A discarded `unenroll` is NOT replayed —
+   * the actor is simply absent from the snapshot — so consumers hang their
+   * reconciliation off `onSessionEstablished` to purge missed unenrolls.
    */
   private failConnection(): void {
     this.queue = []
@@ -313,6 +326,7 @@ export class ServiceStream {
   }
 
   private async handleMessage(data: Uint8Array): Promise<void> {
+    let enrollment: EnrollmentMessage
     try {
       // atproto subscription framing: two concatenated DAG-CBOR values, the
       // first being a header `{op, t}` and the second being the body.
@@ -322,28 +336,50 @@ export class ServiceStream {
       ]
       if (header['t'] !== '#enrollment') return
       const [body] = decodeFirst(rest) as [Record<string, unknown>, Uint8Array]
-      const enrollment = body as unknown as EnrollmentMessage
-      switch (enrollment.action) {
-        case 'enroll':
-          await this.callbacks.onEnroll(
-            enrollment.did,
-            enrollment.boundaries ?? [],
-          )
-          break
-        case 'unenroll':
-          await this.callbacks.onUnenroll(enrollment.did)
-          break
-        case 'boundaries':
-          // optional so consumers that don't track boundary changes can
-          // omit it. An unknown/future action simply falls through as a no-op.
-          await this.callbacks.onBoundariesChanged?.(
-            enrollment.did,
-            enrollment.boundaries ?? [],
-          )
-          break
-      }
+      enrollment = body as unknown as EnrollmentMessage
     } catch (err) {
+      // A malformed frame would only be resent verbatim by a reconnect
+      // (poison loop), and replay restores the same state anyway — log and
+      // skip it rather than dropping the connection.
       this.onError?.(err as Error)
+      return
+    }
+    try {
+      await this.dispatch(enrollment)
+    } catch (err) {
+      // A failed handler means the event was NOT applied. Dropping the
+      // connection is the retry: the reconnect's snapshot replay redelivers
+      // enroll/boundary state, and reconciliation covers unenrolls.
+      this.onError?.(
+        new StratosError(
+          `enrollment ${enrollment.action} handler failed; dropping connection to retry`,
+          'SERVICE_STREAM_HANDLER_FAILED',
+          { cause: err },
+        ),
+      )
+      this.failConnection()
+    }
+  }
+
+  private async dispatch(enrollment: EnrollmentMessage): Promise<void> {
+    switch (enrollment.action) {
+      case 'enroll':
+        await this.callbacks.onEnroll(
+          enrollment.did,
+          enrollment.boundaries ?? [],
+        )
+        break
+      case 'unenroll':
+        await this.callbacks.onUnenroll(enrollment.did)
+        break
+      case 'boundaries':
+        // optional so consumers that don't track boundary changes can
+        // omit it. An unknown/future action simply falls through as a no-op.
+        await this.callbacks.onBoundariesChanged?.(
+          enrollment.did,
+          enrollment.boundaries ?? [],
+        )
+        break
     }
   }
 }

--- a/stratos-feedgen/src/subscription/service-stream.ts
+++ b/stratos-feedgen/src/subscription/service-stream.ts
@@ -178,6 +178,9 @@ export class ServiceStream {
     this.ws = ws
 
     ws.addEventListener('open', () => {
+      // A socket that opens after stop() or after being superseded must not
+      // arm timers or fire session hooks against torn-down state.
+      if (this.ws !== ws) return
       this.armStabilityReset()
       void Promise.resolve()
         .then(() => this.callbacks.onSessionEstablished?.())

--- a/stratos-feedgen/tests/reconcile-scheduler.test.ts
+++ b/stratos-feedgen/tests/reconcile-scheduler.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createReconcileScheduler } from '../src/purge/index.js'
+
+function makeControlledRun(): {
+  run: () => Promise<void>
+  starts: number
+  finish: () => void
+} {
+  const state = {
+    run: async () => {},
+    starts: 0,
+    finish: () => {},
+    pending: [] as Array<() => void>,
+  }
+  state.run = () => {
+    state.starts++
+    return new Promise<void>((resolve) => state.pending.push(resolve))
+  }
+  state.finish = () => {
+    state.pending.shift()?.()
+  }
+  return state
+}
+
+describe('createReconcileScheduler', () => {
+  it('runs immediately when idle', async () => {
+    const ctl = makeControlledRun()
+    const trigger = createReconcileScheduler(ctl.run)
+    trigger()
+    expect(ctl.starts).toBe(1)
+    ctl.finish()
+    // Let the run's completion settle so the scheduler is idle again.
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    trigger()
+    expect(ctl.starts).toBe(2)
+    ctl.finish()
+  })
+
+  it('coalesces triggers during an in-flight run into exactly one follow-up', async () => {
+    const ctl = makeControlledRun()
+    const trigger = createReconcileScheduler(ctl.run)
+    trigger()
+    expect(ctl.starts).toBe(1)
+
+    // A burst of reconnects while the run is still in flight.
+    trigger()
+    trigger()
+    trigger()
+    expect(ctl.starts).toBe(1)
+
+    ctl.finish()
+    await vi.waitFor(() => expect(ctl.starts).toBe(2))
+    ctl.finish()
+
+    // No third run: the burst coalesced into the single follow-up.
+    await new Promise((resolve) => setTimeout(resolve, 10))
+    expect(ctl.starts).toBe(2)
+  })
+
+  it('reports a rejected run via onError instead of throwing', async () => {
+    const errors: Error[] = []
+    const trigger = createReconcileScheduler(
+      async () => {
+        throw new Error('upstream unreachable')
+      },
+      (err) => errors.push(err),
+    )
+    expect(() => trigger()).not.toThrow()
+    await vi.waitFor(() => expect(errors).toHaveLength(1))
+    expect(errors[0].message).toBe('upstream unreachable')
+
+    // A rejection must not wedge the scheduler: the next trigger runs again.
+    trigger()
+    await vi.waitFor(() => expect(errors).toHaveLength(2))
+  })
+
+  it('still runs the coalesced follow-up after the in-flight run rejects', async () => {
+    const errors: Error[] = []
+    let calls = 0
+    const first: { reject: ((err: Error) => void) | null } = { reject: null }
+    const trigger = createReconcileScheduler(
+      () => {
+        calls++
+        if (calls === 1) {
+          return new Promise<void>((_resolve, reject) => {
+            first.reject = reject
+          })
+        }
+        return Promise.resolve()
+      },
+      (err) => errors.push(err),
+    )
+    trigger()
+    trigger()
+    expect(calls).toBe(1)
+    first.reject?.(new Error('mid-run failure'))
+    await vi.waitFor(() => expect(calls).toBe(2))
+    expect(errors.map((e) => e.message)).toEqual(['mid-run failure'])
+  })
+})

--- a/stratos-feedgen/tests/reconcile.test.ts
+++ b/stratos-feedgen/tests/reconcile.test.ts
@@ -299,6 +299,136 @@ describe('reconcile on reconnect', () => {
     expect(await store.getCursor(SPIKE)).toBeNull()
   })
 
+  it('skips the purge when a live enroll for the actor lands mid-reconcile', async () => {
+    // Race: the resolve snapshot says SPIKE unenrolled, but before reconcile
+    // acts on it the live stream applies his re-enroll (fresh row write).
+    // Purging now would destroy live state that nothing re-adds until the
+    // next reconnect.
+    await store.upsertEnrolledActor(actor(SPIKE, ['crew']))
+    await store.upsertPost(post(SPIKE, '1', ['crew']))
+
+    const client = {
+      resolveEnrollments: vi.fn(async (did: string) => {
+        // Simulate the live enroll frame applied while the resolve is in
+        // flight: the enroll path upserts the row with a current lastSeenAt.
+        await store.upsertEnrolledActor({
+          did: SPIKE,
+          boundaries: ['crew'],
+          enrolledAt: '2024-01-01T00:00:00.000Z',
+          lastSeenAt: new Date().toISOString(),
+        })
+        return { did, enrolled: false, boundaries: [] }
+      }),
+    }
+    const purger = new Purger({ store, audit: () => {} })
+    const purgeActor = vi.spyOn(purger, 'purgeActor')
+
+    const summary = await reconcileEnrollments(
+      { store, purger, client, log: () => {} },
+      new Set(['crew']),
+    )
+
+    expect(purgeActor).not.toHaveBeenCalled()
+    expect(summary.unenrolled).toBe(0)
+    expect(await store.getEnrolledActor(SPIKE)).not.toBeNull()
+    expect(
+      await store.getPost(`at://${SPIKE}/zone.stratos.feed.post/1`),
+    ).not.toBeNull()
+  })
+
+  it('treats a row written in the same millisecond as run start as touched', async () => {
+    // The live enroll frame and the reconcile run start can share one
+    // millisecond, so an equal timestamp must count as touched or the purge
+    // wrongly proceeds.
+    vi.useFakeTimers({ now: new Date('2026-08-24T12:00:00.000Z') })
+    try {
+      await store.upsertEnrolledActor(actor(SPIKE, ['crew']))
+
+      const client = {
+        resolveEnrollments: vi.fn(async (did: string) => {
+          await store.upsertEnrolledActor({
+            did: SPIKE,
+            boundaries: ['crew'],
+            enrolledAt: '2024-01-01T00:00:00.000Z',
+            lastSeenAt: new Date().toISOString(),
+          })
+          return { did, enrolled: false, boundaries: [] }
+        }),
+      }
+      const purger = new Purger({ store, audit: () => {} })
+      const purgeActor = vi.spyOn(purger, 'purgeActor')
+
+      const summary = await reconcileEnrollments(
+        { store, purger, client, log: () => {} },
+        new Set(['crew']),
+      )
+
+      expect(purgeActor).not.toHaveBeenCalled()
+      expect(summary.unenrolled).toBe(0)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('skips the boundary purge when a live boundary change lands mid-reconcile', async () => {
+    // Race variant: the resolve snapshot says FAYE lost 'bounty', but the
+    // live stream re-granted it while the resolve was in flight.
+    await store.upsertEnrolledActor(actor(FAYE, ['crew', 'bounty']))
+    await store.upsertPost(post(FAYE, '1', ['bounty']))
+
+    const client = {
+      resolveEnrollments: vi.fn(async (did: string) => {
+        await store.upsertEnrolledActor({
+          did: FAYE,
+          boundaries: ['crew', 'bounty'],
+          enrolledAt: '2024-01-01T00:00:00.000Z',
+          lastSeenAt: new Date().toISOString(),
+        })
+        return { did, enrolled: true, boundaries: ['crew'] }
+      }),
+    }
+    const purger = new Purger({ store, audit: () => {} })
+    const purgeActorBoundary = vi.spyOn(purger, 'purgeActorBoundary')
+
+    const summary = await reconcileEnrollments(
+      { store, purger, client, log: () => {} },
+      new Set(['crew', 'bounty']),
+    )
+
+    expect(purgeActorBoundary).not.toHaveBeenCalled()
+    expect(summary.shrunk).toBe(0)
+    expect(
+      await store.getPost(`at://${FAYE}/zone.stratos.feed.post/1`),
+    ).not.toBeNull()
+    expect((await store.getEnrolledActor(FAYE))!.boundaries.sort()).toEqual([
+      'bounty',
+      'crew',
+    ])
+  })
+
+  it('skips the purge when a live unenroll already removed the actor mid-reconcile', async () => {
+    // The live unenroll frame won the race and fully purged SPIKE; a second
+    // purge for a missing row must be skipped rather than re-run or crash.
+    await store.upsertEnrolledActor(actor(SPIKE, ['crew']))
+
+    const client = {
+      resolveEnrollments: vi.fn(async (did: string) => {
+        await store.deleteEnrolledActor(SPIKE)
+        return { did, enrolled: false, boundaries: [] }
+      }),
+    }
+    const purger = new Purger({ store, audit: () => {} })
+    const purgeActor = vi.spyOn(purger, 'purgeActor')
+
+    const summary = await reconcileEnrollments(
+      { store, purger, client, log: () => {} },
+      new Set(['crew']),
+    )
+
+    expect(purgeActor).not.toHaveBeenCalled()
+    expect(summary.unenrolled).toBe(0)
+  })
+
   it('never purges actors upstream still reports enrolled', async () => {
     // Safety property: reconciliation diffs against authoritative per-DID
     // resolves, never against the replay stream, so an active actor survives

--- a/stratos-feedgen/tests/reconcile.test.ts
+++ b/stratos-feedgen/tests/reconcile.test.ts
@@ -8,7 +8,11 @@ import {
   migrateSqliteDb,
   SqliteFeedgenStore,
 } from '../src/db/index.js'
-import { Purger, reconcileEnrollments } from '../src/purge/index.js'
+import {
+  createReconcileScheduler,
+  Purger,
+  reconcileEnrollments,
+} from '../src/purge/index.js'
 import type { ResolveEnrollmentsResult } from '../src/upstream/index.js'
 
 const SPIKE = 'did:plc:spikespiegel' // will be reported unenrolled
@@ -250,5 +254,90 @@ describe('reconcileEnrollments', () => {
       await store.getPost(`at://${FAYE}/zone.stratos.feed.post/1`),
     ).toBeNull()
     expect((await store.getEnrolledActor(FAYE))?.boundaries).toEqual(['crew'])
+  })
+})
+
+describe('reconcile on reconnect', () => {
+  it('purges an actor whose unenroll was missed during a disconnect gap', async () => {
+    // The stream missed SPIKE's unenroll: the local snapshot still holds him,
+    // but upstream says he is gone. The reconnect trigger must purge him.
+    await store.upsertEnrolledActor(actor(SPIKE, ['crew']))
+    await store.upsertPost(post(SPIKE, '1', ['crew']))
+    await store.upsertCursor(SPIKE, 1, '2024-01-01T00:00:00.000Z')
+
+    const client = {
+      resolveEnrollments: vi.fn(async (did: string) => ({
+        did,
+        enrolled: false,
+        boundaries: [],
+      })),
+    }
+    const removedFromPool: string[] = []
+    const purger = new Purger({
+      store,
+      actorPool: { removeActor: (did) => removedFromPool.push(did) },
+      audit: () => {},
+    })
+    const purgeActor = vi.spyOn(purger, 'purgeActor')
+
+    const trigger = createReconcileScheduler(async () => {
+      await reconcileEnrollments(
+        { store, purger, client, log: () => {} },
+        new Set(['crew']),
+      )
+    })
+    trigger()
+
+    await vi.waitFor(async () =>
+      expect(await store.getEnrolledActor(SPIKE)).toBeNull(),
+    )
+    expect(purgeActor).toHaveBeenCalledWith(SPIKE, 'reconcile-unenroll')
+    expect(removedFromPool).toEqual([SPIKE])
+    expect(
+      await store.getPost(`at://${SPIKE}/zone.stratos.feed.post/1`),
+    ).toBeNull()
+    expect(await store.getCursor(SPIKE)).toBeNull()
+  })
+
+  it('never purges actors upstream still reports enrolled', async () => {
+    // Safety property: reconciliation diffs against authoritative per-DID
+    // resolves, never against the replay stream, so an active actor survives
+    // no matter when the trigger fires relative to replay.
+    await store.upsertEnrolledActor(actor(VASH, ['crew']))
+    await store.upsertEnrolledActor(actor(FAYE, ['crew', 'bounty']))
+    await store.upsertPost(post(VASH, '1', ['crew']))
+
+    const boundaries: Record<string, string[]> = {
+      [VASH]: ['crew'],
+      [FAYE]: ['crew', 'bounty'],
+    }
+    const client = {
+      resolveEnrollments: vi.fn(async (did: string) => ({
+        did,
+        enrolled: true,
+        boundaries: boundaries[did],
+      })),
+    }
+    const purger = new Purger({ store, audit: () => {} })
+    const purgeActor = vi.spyOn(purger, 'purgeActor')
+
+    const runs: unknown[] = []
+    const trigger = createReconcileScheduler(async () => {
+      const summary = await reconcileEnrollments(
+        { store, purger, client, log: () => {} },
+        new Set(['crew', 'bounty']),
+      )
+      runs.push(summary)
+    })
+    trigger()
+
+    await vi.waitFor(() => expect(runs).toHaveLength(1))
+    expect(client.resolveEnrollments).toHaveBeenCalledTimes(2)
+    expect(purgeActor).not.toHaveBeenCalled()
+    expect(await store.getEnrolledActor(VASH)).not.toBeNull()
+    expect(await store.getEnrolledActor(FAYE)).not.toBeNull()
+    expect(
+      await store.getPost(`at://${VASH}/zone.stratos.feed.post/1`),
+    ).not.toBeNull()
   })
 })

--- a/stratos-feedgen/tests/service-stream.test.ts
+++ b/stratos-feedgen/tests/service-stream.test.ts
@@ -692,10 +692,358 @@ describe('ServiceStream', () => {
     stream.stop()
   })
 
+  it('drops the connection when an enroll handler fails, then retries via replay', async () => {
+    const mint = makeMintToken()
+    const errors: Error[] = []
+    const enrolls: string[] = []
+    let failNext = true
+    const stream = new ServiceStream(
+      {
+        stratosServiceUrl: 'http://stratos.test',
+        mintToken: mint.fn,
+        baseDelayMs: 1000,
+        maxDelayMs: 1000,
+        jitterRatio: 0,
+      },
+      {
+        onEnroll: async (did) => {
+          if (failNext) {
+            failNext = false
+            throw new Error('sqlite is busy')
+          }
+          enrolls.push(did)
+        },
+        onUnenroll: () => {},
+      },
+      (err) => {
+        errors.push(err)
+      },
+      { wsCtor: FakeWebSocket as never, rng: () => 0.5 },
+    )
+
+    stream.start()
+    await vi.waitFor(() => expect(FakeWebSocket.instances).toHaveLength(1))
+    const first = FakeWebSocket.instances[0]
+    first.open()
+
+    const frame = encodeEnrollmentFrame({
+      did: 'did:plc:shinji',
+      action: 'enroll',
+      boundaries: ['nerv'],
+    })
+    first.send(frame)
+
+    // The event was NOT applied, so the connection must go down for a retry.
+    await vi.waitFor(() =>
+      expect(codesOf(errors)).toContain('SERVICE_STREAM_HANDLER_FAILED'),
+    )
+    const failed = errors.find(
+      (err) => (err as StratosError).code === 'SERVICE_STREAM_HANDLER_FAILED',
+    )
+    expect(failed?.message).toContain('enrollment enroll handler failed')
+    expect((failed?.cause as Error).message).toBe('sqlite is busy')
+    expect(first.readyState).toBe(WS_CLOSED)
+    expect(enrolls).toEqual([])
+
+    // Reconnect; the server snapshot replay resends the enroll frame.
+    await vi.advanceTimersByTimeAsync(1000)
+    await vi.waitFor(() => expect(FakeWebSocket.instances).toHaveLength(2))
+    const second = FakeWebSocket.instances[1]
+    second.open()
+    second.send(frame)
+    await vi.waitFor(() => expect(enrolls).toEqual(['did:plc:shinji']))
+    stream.stop()
+  })
+
+  it('drops the connection when an unenroll handler fails', async () => {
+    const mint = makeMintToken()
+    const errors: Error[] = []
+    const stream = new ServiceStream(
+      {
+        stratosServiceUrl: 'http://stratos.test',
+        mintToken: mint.fn,
+        baseDelayMs: 1000,
+        maxDelayMs: 1000,
+        jitterRatio: 0,
+      },
+      {
+        onEnroll: () => {},
+        onUnenroll: async () => {
+          throw new Error('purge failed')
+        },
+      },
+      (err) => {
+        errors.push(err)
+      },
+      { wsCtor: FakeWebSocket as never, rng: () => 0.5 },
+    )
+
+    stream.start()
+    await vi.waitFor(() => expect(FakeWebSocket.instances).toHaveLength(1))
+    const ws = FakeWebSocket.instances[0]
+    ws.open()
+
+    ws.send(
+      encodeEnrollmentFrame({ did: 'did:plc:misato', action: 'unenroll' }),
+    )
+
+    await vi.waitFor(() =>
+      expect(codesOf(errors)).toContain('SERVICE_STREAM_HANDLER_FAILED'),
+    )
+    expect(ws.readyState).toBe(WS_CLOSED)
+
+    // A reconnect is scheduled: reconcile-on-reconnect covers the unenroll.
+    await vi.advanceTimersByTimeAsync(1000)
+    await vi.waitFor(() => expect(FakeWebSocket.instances).toHaveLength(2))
+    stream.stop()
+  })
+
+  it('fires onSessionEstablished on every open, initial and reconnect', async () => {
+    const mint = makeMintToken()
+    let sessions = 0
+    const stream = new ServiceStream(
+      {
+        stratosServiceUrl: 'http://stratos.test',
+        mintToken: mint.fn,
+        baseDelayMs: 1000,
+        maxDelayMs: 1000,
+        jitterRatio: 0,
+      },
+      {
+        onEnroll: () => {},
+        onUnenroll: () => {},
+        onSessionEstablished: () => {
+          sessions++
+        },
+      },
+      undefined,
+      { wsCtor: FakeWebSocket as never, rng: () => 0.5 },
+    )
+
+    stream.start()
+    await vi.waitFor(() => expect(FakeWebSocket.instances).toHaveLength(1))
+    FakeWebSocket.instances[0].open()
+    await vi.waitFor(() => expect(sessions).toBe(1))
+
+    FakeWebSocket.instances[0].close()
+    await vi.advanceTimersByTimeAsync(1000)
+    await vi.waitFor(() => expect(FakeWebSocket.instances).toHaveLength(2))
+    FakeWebSocket.instances[1].open()
+    await vi.waitFor(() => expect(sessions).toBe(2))
+    stream.stop()
+  })
+
+  it('routes an onSessionEstablished rejection to onError without killing the stream', async () => {
+    const mint = makeMintToken()
+    const errors: Error[] = []
+    const enrolls: string[] = []
+    const stream = new ServiceStream(
+      { stratosServiceUrl: 'http://stratos.test', mintToken: mint.fn },
+      {
+        onEnroll: (did) => {
+          enrolls.push(did)
+        },
+        onUnenroll: () => {},
+        onSessionEstablished: async () => {
+          throw new Error('reconcile blew up')
+        },
+      },
+      (err) => {
+        errors.push(err)
+      },
+      { wsCtor: FakeWebSocket as never, rng: () => 0.5 },
+    )
+
+    stream.start()
+    await vi.waitFor(() => expect(FakeWebSocket.instances).toHaveLength(1))
+    const ws = FakeWebSocket.instances[0]
+    ws.open()
+
+    await vi.waitFor(() =>
+      expect(errors.map((e) => e.message)).toContain('reconcile blew up'),
+    )
+    expect(stream.isConnected()).toBe(true)
+    ws.send(encodeEnrollmentFrame({ did: 'did:plc:sakura', action: 'enroll' }))
+    await vi.waitFor(() => expect(enrolls).toEqual(['did:plc:sakura']))
+    stream.stop()
+  })
+
+  it('survives an onSessionEstablished rejection even without an onError sink', async () => {
+    const mint = makeMintToken()
+    const enrolls: string[] = []
+    const stream = new ServiceStream(
+      { stratosServiceUrl: 'http://stratos.test', mintToken: mint.fn },
+      {
+        onEnroll: (did) => {
+          enrolls.push(did)
+        },
+        onUnenroll: () => {},
+        onSessionEstablished: async () => {
+          throw new Error('reconcile blew up')
+        },
+      },
+      undefined,
+      { wsCtor: FakeWebSocket as never, rng: () => 0.5 },
+    )
+
+    stream.start()
+    await vi.waitFor(() => expect(FakeWebSocket.instances).toHaveLength(1))
+    const ws = FakeWebSocket.instances[0]
+    ws.open()
+
+    ws.send(encodeEnrollmentFrame({ did: 'did:plc:ranma', action: 'enroll' }))
+    await vi.waitFor(() => expect(enrolls).toEqual(['did:plc:ranma']))
+    expect(stream.isConnected()).toBe(true)
+    stream.stop()
+  })
+
+  it('ignores frames that are not #enrollment messages', async () => {
+    const mint = makeMintToken()
+    const errors: Error[] = []
+    const enrolls: string[] = []
+    const stream = new ServiceStream(
+      { stratosServiceUrl: 'http://stratos.test', mintToken: mint.fn },
+      {
+        onEnroll: (did) => {
+          enrolls.push(did)
+        },
+        onUnenroll: () => {},
+      },
+      (err) => {
+        errors.push(err)
+      },
+      { wsCtor: FakeWebSocket as never, rng: () => 0.5 },
+    )
+
+    stream.start()
+    await vi.waitFor(() => expect(FakeWebSocket.instances).toHaveLength(1))
+    const ws = FakeWebSocket.instances[0]
+    ws.open()
+
+    // A header-only frame of another type must be skipped silently — decoding
+    // past the header would misread it (there is no body to decode).
+    ws.send(cborEncode({ op: 1, t: '#info' }))
+    ws.send(encodeEnrollmentFrame({ did: 'did:plc:akane', action: 'enroll' }))
+
+    await vi.waitFor(() => expect(enrolls).toEqual(['did:plc:akane']))
+    expect(errors).toEqual([])
+    stream.stop()
+  })
+
+  it('defaults a missing boundaries field to an empty set', async () => {
+    const mint = makeMintToken()
+    const enrolls: Array<{ did: string; boundaries: string[] }> = []
+    const changes: Array<{ did: string; boundaries: string[] }> = []
+    const stream = new ServiceStream(
+      { stratosServiceUrl: 'http://stratos.test', mintToken: mint.fn },
+      {
+        onEnroll: (did, boundaries) => {
+          enrolls.push({ did, boundaries })
+        },
+        onUnenroll: () => {},
+        onBoundariesChanged: (did, boundaries) => {
+          changes.push({ did, boundaries })
+        },
+      },
+      undefined,
+      { wsCtor: FakeWebSocket as never, rng: () => 0.5 },
+    )
+
+    stream.start()
+    await vi.waitFor(() => expect(FakeWebSocket.instances).toHaveLength(1))
+    const ws = FakeWebSocket.instances[0]
+    ws.open()
+
+    const frameWithoutBoundaries = (action: string): Uint8Array => {
+      const header = cborEncode({ op: 1, t: '#enrollment' })
+      const body = cborEncode({
+        $type: 'zone.stratos.sync.subscribeRecords#enrollment',
+        did: 'did:plc:ryoga',
+        action,
+        time: new Date().toISOString(),
+      })
+      const out = new Uint8Array(header.length + body.length)
+      out.set(header, 0)
+      out.set(body, header.length)
+      return out
+    }
+    ws.send(frameWithoutBoundaries('enroll'))
+    ws.send(frameWithoutBoundaries('boundaries'))
+
+    await vi.waitFor(() => {
+      expect(enrolls).toEqual([{ did: 'did:plc:ryoga', boundaries: [] }])
+      expect(changes).toEqual([{ did: 'did:plc:ryoga', boundaries: [] }])
+    })
+    stream.stop()
+  })
+
+  it('drops the connection on handler failure even without an onError sink', async () => {
+    const mint = makeMintToken()
+    const stream = new ServiceStream(
+      {
+        stratosServiceUrl: 'http://stratos.test',
+        mintToken: mint.fn,
+        baseDelayMs: 1000,
+        maxDelayMs: 1000,
+        jitterRatio: 0,
+      },
+      {
+        onEnroll: async () => {
+          throw new Error('sqlite is busy')
+        },
+        onUnenroll: () => {},
+      },
+      undefined,
+      { wsCtor: FakeWebSocket as never, rng: () => 0.5 },
+    )
+
+    stream.start()
+    await vi.waitFor(() => expect(FakeWebSocket.instances).toHaveLength(1))
+    const ws = FakeWebSocket.instances[0]
+    ws.open()
+
+    ws.send(encodeEnrollmentFrame({ did: 'did:plc:tenchi', action: 'enroll' }))
+
+    // Error reporting is optional; the retry-via-reconnect behavior is not.
+    await vi.waitFor(() => expect(ws.readyState).toBe(WS_CLOSED))
+    await vi.advanceTimersByTimeAsync(1000)
+    await vi.waitFor(() => expect(FakeWebSocket.instances).toHaveLength(2))
+    stream.stop()
+  })
+
+  it('skips a malformed frame and keeps consuming even without an onError sink', async () => {
+    const mint = makeMintToken()
+    const enrolls: string[] = []
+    const stream = new ServiceStream(
+      { stratosServiceUrl: 'http://stratos.test', mintToken: mint.fn },
+      {
+        onEnroll: (did) => {
+          enrolls.push(did)
+        },
+        onUnenroll: () => {},
+      },
+      undefined,
+      { wsCtor: FakeWebSocket as never, rng: () => 0.5 },
+    )
+
+    stream.start()
+    await vi.waitFor(() => expect(FakeWebSocket.instances).toHaveLength(1))
+    const ws = FakeWebSocket.instances[0]
+    ws.open()
+
+    ws.send(new Uint8Array([0xff, 0xff, 0xff, 0xff]))
+    ws.send(encodeEnrollmentFrame({ did: 'did:plc:ryoko', action: 'enroll' }))
+
+    await vi.waitFor(() => expect(enrolls).toEqual(['did:plc:ryoko']))
+    expect(stream.isConnected()).toBe(true)
+    stream.stop()
+  })
+
   it('drops the connection when the enrollment queue overflows', async () => {
     const mint = makeMintToken()
     const errors: Error[] = []
     const gate = makeGate()
+    let sessions = 0
     const stream = new ServiceStream(
       { stratosServiceUrl: 'http://stratos.test', mintToken: mint.fn },
       {
@@ -703,6 +1051,9 @@ describe('ServiceStream', () => {
           await gate.wait()
         },
         onUnenroll: () => {},
+        onSessionEstablished: () => {
+          sessions++
+        },
       },
       (err) => {
         errors.push(err)
@@ -738,11 +1089,15 @@ describe('ServiceStream', () => {
 
     // Reconnect replays every CURRENT enrollment from scratch, which restores
     // dropped enrolls and boundary sets. A dropped `unenroll` is not restored —
-    // the actor is simply absent from the replay — and waits for reconcile.
+    // the actor is simply absent from the replay — so the reopen must fire
+    // onSessionEstablished, the hook the reconcile purge hangs off.
     await vi.advanceTimersByTimeAsync(6_000)
     await vi.waitFor(() =>
       expect(FakeWebSocket.instances.length).toBeGreaterThan(1),
     )
+    expect(sessions).toBe(1)
+    FakeWebSocket.instances[1].open()
+    await vi.waitFor(() => expect(sessions).toBe(2))
     stream.stop()
   })
 

--- a/stratos-feedgen/tests/service-stream.test.ts
+++ b/stratos-feedgen/tests/service-stream.test.ts
@@ -1209,6 +1209,35 @@ describe('ServiceStream', () => {
     stream.stop()
   })
 
+  it('does not fire onSessionEstablished when the socket opens after stop()', async () => {
+    const mint = makeMintToken()
+    let sessions = 0
+    const stream = new ServiceStream(
+      { stratosServiceUrl: 'http://stratos.test', mintToken: mint.fn },
+      {
+        onEnroll: () => {},
+        onUnenroll: () => {},
+        onSessionEstablished: () => {
+          sessions++
+        },
+      },
+      undefined,
+      { wsCtor: FakeWebSocket as never, rng: () => 0.5 },
+    )
+
+    stream.start()
+    await vi.waitFor(() => expect(FakeWebSocket.instances).toHaveLength(1))
+    const ws = FakeWebSocket.instances[0]
+
+    // Shutdown lands while the connect handshake is still in flight; the
+    // late open must not fire the session hook against torn-down state.
+    stream.stop()
+    ws.open()
+
+    await vi.advanceTimersByTimeAsync(100)
+    expect(sessions).toBe(0)
+  })
+
   it('ignores frames from a socket that was already dropped', async () => {
     const mint = makeMintToken()
     const enrolls: string[] = []

--- a/stratos-service/src/features/enrollment/handler.ts
+++ b/stratos-service/src/features/enrollment/handler.ts
@@ -8,42 +8,64 @@ import { createXrpcHandler } from '../../api/util.js'
 import { serviceDIDToRkey } from '../../oauth'
 import { verifyEnrolled } from './internal/auth.js'
 
+const RESOLVE_CACHE_TTL_MS = 60 * 1000
+const RESOLVE_CACHE_MAX_ENTRIES = 10_000
+
 /**
  * Positive `resolveEnrollments` response cache, keyed by DID.
  *
- * Shared between the resolve handler and every handler that mutates
- * enrollment or boundary state: a mutation must call `invalidate`, or a
- * downstream reconcile that resolves within the TTL reads stale
- * `enrolled: true` state and purges nothing.
+ * Every handler that mutates enrollment or boundary state must call
+ * `invalidate`, or a downstream reconcile that resolves within the TTL reads
+ * stale `enrolled: true` state and purges nothing.
  *
- * A per-DID generation fences the resolve handler's read-then-set window:
- * `set` writes only while the caller's generation is still current, so a
- * resolution that started before an invalidation cannot re-insert the stale
- * boundary set it read.
+ * An epoch fences the resolve handler's read-then-set window: every
+ * invalidation bumps it and `set` writes only while the caller's epoch is
+ * still current, so a resolution that started before an invalidation cannot
+ * re-insert the stale boundary set it read. One counter for all DIDs keeps
+ * the fence state constant-size; the cost is only a skipped cache insert
+ * when an unrelated invalidation lands mid-resolve.
+ *
+ * Expired entries are evicted on read and the map is capped (oldest insert
+ * evicted first), so the cache cannot grow for the life of the process.
  */
-class ResolveEnrollmentsCache {
+export class ResolveEnrollmentsCache {
   private readonly entries = new Map<
     string,
-    { boundaries: string[]; timestamp: number }
+    { boundaries: string[]; expiresAt: number }
   >()
-  private readonly generations = new Map<string, number>()
+  private currentEpoch = 0
 
-  get(did: string): { boundaries: string[]; timestamp: number } | undefined {
-    return this.entries.get(did)
+  constructor(
+    private readonly ttlMs: number,
+    private readonly maxEntries: number,
+  ) {}
+
+  get(did: string): string[] | undefined {
+    const entry = this.entries.get(did)
+    if (!entry) return undefined
+    if (Date.now() >= entry.expiresAt) {
+      this.entries.delete(did)
+      return undefined
+    }
+    return entry.boundaries
   }
 
-  generation(did: string): number {
-    return this.generations.get(did) ?? 0
+  epoch(): number {
+    return this.currentEpoch
   }
 
-  set(did: string, boundaries: string[], generation: number): void {
-    if (generation !== this.generation(did)) return
-    this.entries.set(did, { boundaries, timestamp: Date.now() })
+  set(did: string, boundaries: string[], epoch: number): void {
+    if (epoch !== this.currentEpoch) return
+    if (!this.entries.has(did) && this.entries.size >= this.maxEntries) {
+      const oldest = this.entries.keys().next().value
+      if (oldest !== undefined) this.entries.delete(oldest)
+    }
+    this.entries.set(did, { boundaries, expiresAt: Date.now() + this.ttlMs })
   }
 
   invalidate(did: string): void {
     this.entries.delete(did)
-    this.generations.set(did, this.generation(did) + 1)
+    this.currentEpoch++
   }
 }
 
@@ -57,7 +79,10 @@ export function registerEnrollmentHandlers(
   server: XrpcServer,
   ctx: AppContext,
 ): void {
-  const resolveCache = new ResolveEnrollmentsCache()
+  const resolveCache = new ResolveEnrollmentsCache(
+    RESOLVE_CACHE_TTL_MS,
+    RESOLVE_CACHE_MAX_ENTRIES,
+  )
   registerEnrollmentStatus(server, ctx)
   registerEnrollmentUnenroll(server, ctx, resolveCache)
   registerResolveEnrollmentsHandler(ctx, resolveCache)
@@ -187,7 +212,6 @@ async function tryCreateAttestation(
  * Register handler for unenrollment
  * @param server - XRPC server
  * @param ctx - Application context
- * @param resolveCache - Shared resolveEnrollments cache to invalidate
  */
 function registerEnrollmentUnenroll(
   server: XrpcServer,
@@ -251,14 +275,11 @@ function registerEnrollmentUnenroll(
 /**
  * Register handlers for enrollment-related operations
  * @param ctx - Application context
- * @param cache - Shared resolveEnrollments cache
  */
 function registerResolveEnrollmentsHandler(
   ctx: AppContext,
   cache: ResolveEnrollmentsCache,
 ): void {
-  const CACHE_TTL = 60 * 1000 // 1 minute
-
   ctx.app.get(
     '/xrpc/zone.stratos.identity.resolveEnrollments',
     async (req: Request, res: Response) => {
@@ -272,24 +293,20 @@ function registerResolveEnrollmentsHandler(
         }
 
         const cached = cache.get(did)
-        if (cached && Date.now() - cached.timestamp < CACHE_TTL) {
-          return res.json({
-            did,
-            enrolled: true,
-            boundaries: cached.boundaries,
-          })
+        if (cached) {
+          return res.json({ did, enrolled: true, boundaries: cached })
         }
 
         // Snapshot before the awaits: an invalidation that lands while the
-        // resolution is in flight bumps the generation and voids this write.
-        const generation = cache.generation(did)
+        // resolution is in flight bumps the epoch and voids this write.
+        const epoch = cache.epoch()
         const enrolled = await ctx.enrollmentService.isEnrolled(did)
         if (!enrolled) {
           return res.json({ did, enrolled: false, boundaries: [] })
         }
 
         const boundaries = await ctx.boundaryResolver.getBoundaries(did)
-        cache.set(did, boundaries, generation)
+        cache.set(did, boundaries, epoch)
         res.json({ did, enrolled: true, boundaries })
       } catch (err) {
         ctx.logger?.error(
@@ -311,7 +328,6 @@ function registerResolveEnrollmentsHandler(
 /**
  * Register handlers for admin boundary-related operations
  * @param ctx - Application context
- * @param resolveCache - Shared resolveEnrollments cache to invalidate
  */
 function registerAdminBoundaryHandlers(
   ctx: AppContext,
@@ -526,7 +542,6 @@ function registerRemoveAdminHandler(ctx: AppContext): void {
  * place, unlike unenrollment, which the member drives themselves and which
  * also removes their PDS enrollment record.
  * @param ctx - Application context
- * @param resolveCache - Shared resolveEnrollments cache to invalidate
  */
 function registerSetActiveHandler(
   ctx: AppContext,
@@ -599,7 +614,6 @@ const adminJsonParser = express.json({ limit: '100kb' })
 /**
  * Register handler for adding a boundary
  * @param ctx - Application context
- * @param resolveCache - Shared resolveEnrollments cache to invalidate
  */
 function registerAddBoundaryHandler(
   ctx: AppContext,
@@ -688,7 +702,6 @@ function registerAddBoundaryHandler(
 /**
  * Register remove boundary handler for admin
  * @param ctx - The application context
- * @param resolveCache - Shared resolveEnrollments cache to invalidate
  */
 function registerRemoveBoundaryHandler(
   ctx: AppContext,
@@ -770,7 +783,6 @@ function registerRemoveBoundaryHandler(
 /**
  * Register handler for setting boundaries
  * @param ctx - Application context
- * @param resolveCache - Shared resolveEnrollments cache to invalidate
  */
 function registerSetBoundariesHandler(
   ctx: AppContext,

--- a/stratos-service/src/features/enrollment/handler.ts
+++ b/stratos-service/src/features/enrollment/handler.ts
@@ -9,6 +9,19 @@ import { serviceDIDToRkey } from '../../oauth'
 import { verifyEnrolled } from './internal/auth.js'
 
 /**
+ * Positive `resolveEnrollments` response cache, keyed by DID.
+ *
+ * Shared between the resolve handler and every handler that mutates
+ * enrollment or boundary state: a mutation must delete the DID's entry, or a
+ * downstream reconcile that resolves within the TTL reads stale
+ * `enrolled: true` state and purges nothing.
+ */
+type ResolveEnrollmentsCache = Map<
+  string,
+  { boundaries: string[]; timestamp: number }
+>
+
+/**
  * Register all enrollment-related XRPC handlers
  *
  * @param server - XRPC server
@@ -18,10 +31,11 @@ export function registerEnrollmentHandlers(
   server: XrpcServer,
   ctx: AppContext,
 ): void {
+  const resolveCache: ResolveEnrollmentsCache = new Map()
   registerEnrollmentStatus(server, ctx)
-  registerEnrollmentUnenroll(server, ctx)
-  registerResolveEnrollmentsHandler(ctx)
-  registerAdminBoundaryHandlers(ctx)
+  registerEnrollmentUnenroll(server, ctx, resolveCache)
+  registerResolveEnrollmentsHandler(ctx, resolveCache)
+  registerAdminBoundaryHandlers(ctx, resolveCache)
   registerListEnrollmentsHandler(ctx)
   registerListDomainsHandler(ctx)
 }
@@ -147,8 +161,13 @@ async function tryCreateAttestation(
  * Register handler for unenrollment
  * @param server - XRPC server
  * @param ctx - Application context
+ * @param resolveCache - Shared resolveEnrollments cache to invalidate
  */
-function registerEnrollmentUnenroll(server: XrpcServer, ctx: AppContext): void {
+function registerEnrollmentUnenroll(
+  server: XrpcServer,
+  ctx: AppContext,
+  resolveCache: ResolveEnrollmentsCache,
+): void {
   const xrpc = server as unknown as XrpcServerInternal
   const { authVerifier } = ctx
 
@@ -175,6 +194,7 @@ function registerEnrollmentUnenroll(server: XrpcServer, ctx: AppContext): void {
 
         // 2. Perform hard delete: local enrollment record and actor data
         await ctx.enrollmentService.unenroll(did!)
+        resolveCache.delete(did!)
 
         // 3. Delete signing key (if it exists)
         try {
@@ -205,9 +225,12 @@ function registerEnrollmentUnenroll(server: XrpcServer, ctx: AppContext): void {
 /**
  * Register handlers for enrollment-related operations
  * @param ctx - Application context
+ * @param cache - Shared resolveEnrollments cache
  */
-function registerResolveEnrollmentsHandler(ctx: AppContext): void {
-  const cache = new Map<string, { boundaries: string[]; timestamp: number }>()
+function registerResolveEnrollmentsHandler(
+  ctx: AppContext,
+  cache: ResolveEnrollmentsCache,
+): void {
   const CACHE_TTL = 60 * 1000 // 1 minute
 
   ctx.app.get(
@@ -259,12 +282,16 @@ function registerResolveEnrollmentsHandler(ctx: AppContext): void {
 /**
  * Register handlers for admin boundary-related operations
  * @param ctx - Application context
+ * @param resolveCache - Shared resolveEnrollments cache to invalidate
  */
-function registerAdminBoundaryHandlers(ctx: AppContext): void {
-  registerAddBoundaryHandler(ctx)
-  registerRemoveBoundaryHandler(ctx)
-  registerSetBoundariesHandler(ctx)
-  registerSetActiveHandler(ctx)
+function registerAdminBoundaryHandlers(
+  ctx: AppContext,
+  resolveCache: ResolveEnrollmentsCache,
+): void {
+  registerAddBoundaryHandler(ctx, resolveCache)
+  registerRemoveBoundaryHandler(ctx, resolveCache)
+  registerSetBoundariesHandler(ctx, resolveCache)
+  registerSetActiveHandler(ctx, resolveCache)
   registerAdminUserHandlers(ctx)
 }
 
@@ -470,8 +497,12 @@ function registerRemoveAdminHandler(ctx: AppContext): void {
  * place, unlike unenrollment, which the member drives themselves and which
  * also removes their PDS enrollment record.
  * @param ctx - Application context
+ * @param resolveCache - Shared resolveEnrollments cache to invalidate
  */
-function registerSetActiveHandler(ctx: AppContext): void {
+function registerSetActiveHandler(
+  ctx: AppContext,
+  resolveCache: ResolveEnrollmentsCache,
+): void {
   ctx.app.post(
     '/xrpc/zone.stratos.admin.setActive',
     adminJsonParser,
@@ -506,6 +537,7 @@ function registerSetActiveHandler(ctx: AppContext): void {
 
         if (enrollment.active !== active) {
           await ctx.enrollmentStore.updateEnrollment(did, { active })
+          resolveCache.delete(did)
         }
 
         ctx.logger?.info(
@@ -538,8 +570,12 @@ const adminJsonParser = express.json({ limit: '100kb' })
 /**
  * Register handler for adding a boundary
  * @param ctx - Application context
+ * @param resolveCache - Shared resolveEnrollments cache to invalidate
  */
-function registerAddBoundaryHandler(ctx: AppContext): void {
+function registerAddBoundaryHandler(
+  ctx: AppContext,
+  resolveCache: ResolveEnrollmentsCache,
+): void {
   ctx.app.post(
     '/xrpc/zone.stratos.admin.addBoundary',
     adminJsonParser,
@@ -585,6 +621,7 @@ function registerAddBoundaryHandler(ctx: AppContext): void {
 
         const priorBoundaries = await ctx.enrollmentStore.getBoundaries(did)
         await ctx.enrollmentStore.addBoundary(did, boundary)
+        resolveCache.delete(did)
         const boundaries = await ctx.enrollmentStore.getBoundaries(did)
 
         emitBoundaryChangeEvent(ctx, did, boundaries, priorBoundaries)
@@ -622,8 +659,12 @@ function registerAddBoundaryHandler(ctx: AppContext): void {
 /**
  * Register remove boundary handler for admin
  * @param ctx - The application context
+ * @param resolveCache - Shared resolveEnrollments cache to invalidate
  */
-function registerRemoveBoundaryHandler(ctx: AppContext): void {
+function registerRemoveBoundaryHandler(
+  ctx: AppContext,
+  resolveCache: ResolveEnrollmentsCache,
+): void {
   // POST /xrpc/zone.stratos.admin.removeBoundary
   ctx.app.post(
     '/xrpc/zone.stratos.admin.removeBoundary',
@@ -662,6 +703,7 @@ function registerRemoveBoundaryHandler(ctx: AppContext): void {
 
         const priorBoundaries = await ctx.enrollmentStore.getBoundaries(did)
         await ctx.enrollmentStore.removeBoundary(did, boundary)
+        resolveCache.delete(did)
         const boundaries = await ctx.enrollmentStore.getBoundaries(did)
 
         emitBoundaryChangeEvent(ctx, did, boundaries, priorBoundaries)
@@ -699,8 +741,12 @@ function registerRemoveBoundaryHandler(ctx: AppContext): void {
 /**
  * Register handler for setting boundaries
  * @param ctx - Application context
+ * @param resolveCache - Shared resolveEnrollments cache to invalidate
  */
-function registerSetBoundariesHandler(ctx: AppContext): void {
+function registerSetBoundariesHandler(
+  ctx: AppContext,
+  resolveCache: ResolveEnrollmentsCache,
+): void {
   ctx.app.post(
     '/xrpc/zone.stratos.admin.setBoundaries',
     adminJsonParser,
@@ -747,6 +793,7 @@ function registerSetBoundariesHandler(ctx: AppContext): void {
 
         const priorBoundaries = await ctx.enrollmentStore.getBoundaries(did)
         await ctx.enrollmentStore.setBoundaries(did, boundaries)
+        resolveCache.delete(did)
 
         // Re-read the EFFECTIVE persisted set: the store decorator force-includes
         // the reserved all-members domain, so the requested `boundaries` may omit

--- a/stratos-service/src/features/enrollment/handler.ts
+++ b/stratos-service/src/features/enrollment/handler.ts
@@ -12,14 +12,40 @@ import { verifyEnrolled } from './internal/auth.js'
  * Positive `resolveEnrollments` response cache, keyed by DID.
  *
  * Shared between the resolve handler and every handler that mutates
- * enrollment or boundary state: a mutation must delete the DID's entry, or a
+ * enrollment or boundary state: a mutation must call `invalidate`, or a
  * downstream reconcile that resolves within the TTL reads stale
  * `enrolled: true` state and purges nothing.
+ *
+ * A per-DID generation fences the resolve handler's read-then-set window:
+ * `set` writes only while the caller's generation is still current, so a
+ * resolution that started before an invalidation cannot re-insert the stale
+ * boundary set it read.
  */
-type ResolveEnrollmentsCache = Map<
-  string,
-  { boundaries: string[]; timestamp: number }
->
+class ResolveEnrollmentsCache {
+  private readonly entries = new Map<
+    string,
+    { boundaries: string[]; timestamp: number }
+  >()
+  private readonly generations = new Map<string, number>()
+
+  get(did: string): { boundaries: string[]; timestamp: number } | undefined {
+    return this.entries.get(did)
+  }
+
+  generation(did: string): number {
+    return this.generations.get(did) ?? 0
+  }
+
+  set(did: string, boundaries: string[], generation: number): void {
+    if (generation !== this.generation(did)) return
+    this.entries.set(did, { boundaries, timestamp: Date.now() })
+  }
+
+  invalidate(did: string): void {
+    this.entries.delete(did)
+    this.generations.set(did, this.generation(did) + 1)
+  }
+}
 
 /**
  * Register all enrollment-related XRPC handlers
@@ -31,7 +57,7 @@ export function registerEnrollmentHandlers(
   server: XrpcServer,
   ctx: AppContext,
 ): void {
-  const resolveCache: ResolveEnrollmentsCache = new Map()
+  const resolveCache = new ResolveEnrollmentsCache()
   registerEnrollmentStatus(server, ctx)
   registerEnrollmentUnenroll(server, ctx, resolveCache)
   registerResolveEnrollmentsHandler(ctx, resolveCache)
@@ -194,7 +220,7 @@ function registerEnrollmentUnenroll(
 
         // 2. Perform hard delete: local enrollment record and actor data
         await ctx.enrollmentService.unenroll(did!)
-        resolveCache.delete(did!)
+        resolveCache.invalidate(did!)
 
         // 3. Delete signing key (if it exists)
         try {
@@ -254,13 +280,16 @@ function registerResolveEnrollmentsHandler(
           })
         }
 
+        // Snapshot before the awaits: an invalidation that lands while the
+        // resolution is in flight bumps the generation and voids this write.
+        const generation = cache.generation(did)
         const enrolled = await ctx.enrollmentService.isEnrolled(did)
         if (!enrolled) {
           return res.json({ did, enrolled: false, boundaries: [] })
         }
 
         const boundaries = await ctx.boundaryResolver.getBoundaries(did)
-        cache.set(did, { boundaries, timestamp: Date.now() })
+        cache.set(did, boundaries, generation)
         res.json({ did, enrolled: true, boundaries })
       } catch (err) {
         ctx.logger?.error(
@@ -537,7 +566,7 @@ function registerSetActiveHandler(
 
         if (enrollment.active !== active) {
           await ctx.enrollmentStore.updateEnrollment(did, { active })
-          resolveCache.delete(did)
+          resolveCache.invalidate(did)
         }
 
         ctx.logger?.info(
@@ -621,7 +650,7 @@ function registerAddBoundaryHandler(
 
         const priorBoundaries = await ctx.enrollmentStore.getBoundaries(did)
         await ctx.enrollmentStore.addBoundary(did, boundary)
-        resolveCache.delete(did)
+        resolveCache.invalidate(did)
         const boundaries = await ctx.enrollmentStore.getBoundaries(did)
 
         emitBoundaryChangeEvent(ctx, did, boundaries, priorBoundaries)
@@ -703,7 +732,7 @@ function registerRemoveBoundaryHandler(
 
         const priorBoundaries = await ctx.enrollmentStore.getBoundaries(did)
         await ctx.enrollmentStore.removeBoundary(did, boundary)
-        resolveCache.delete(did)
+        resolveCache.invalidate(did)
         const boundaries = await ctx.enrollmentStore.getBoundaries(did)
 
         emitBoundaryChangeEvent(ctx, did, boundaries, priorBoundaries)
@@ -793,7 +822,7 @@ function registerSetBoundariesHandler(
 
         const priorBoundaries = await ctx.enrollmentStore.getBoundaries(did)
         await ctx.enrollmentStore.setBoundaries(did, boundaries)
-        resolveCache.delete(did)
+        resolveCache.invalidate(did)
 
         // Re-read the EFFECTIVE persisted set: the store decorator force-includes
         // the reserved all-members domain, so the requested `boundaries` may omit

--- a/stratos-service/tests/enrollment-status.test.ts
+++ b/stratos-service/tests/enrollment-status.test.ts
@@ -1,10 +1,11 @@
 import { EventEmitter } from 'node:events'
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import * as fc from 'fast-check'
 import express from 'express'
 import type { Server as XrpcServer } from '@atproto/xrpc-server'
 import type { AppContext } from '../src/index.js'
 import { registerEnrollmentHandlers } from '../src/features/index.js'
+import { ResolveEnrollmentsCache } from '../src/features/enrollment/handler.js'
 import type { Enrollment } from '@northskysocial/stratos-core'
 
 function didArb(): fc.Arbitrary<string> {
@@ -464,9 +465,15 @@ describe('resolveEnrollments endpoint', () => {
     registerEnrollmentHandlers(xrpc as any, ctx)
 
     await invokeResolveRoute(ctx, { did: 'did:plc:bulmabrief' })
-    await invokeResolveRoute(ctx, { did: 'did:plc:bulmabrief' })
+    const hit = await invokeResolveRoute(ctx, { did: 'did:plc:bulmabrief' })
 
     expect(callCount).toBe(1)
+    // The cache-hit path must return the full response, not just short-circuit.
+    expect(hit.body).toEqual({
+      did: 'did:plc:bulmabrief',
+      enrolled: true,
+      boundaries: ['west-city.jp'],
+    })
   })
 })
 
@@ -502,7 +509,7 @@ function invokeAdminPost(
       },
     } as unknown as express.Response
     app(req, res, ((err?: unknown) => {
-      if (err) reject(err)
+      if (err) reject(err instanceof Error ? err : new Error(String(err)))
     }) as express.NextFunction)
   })
 }
@@ -743,5 +750,81 @@ describe('resolveEnrollments cache invalidation', () => {
       'tokyo-3.nerv.jp',
       'geofront.nerv.jp',
     ])
+  })
+})
+
+describe('ResolveEnrollmentsCache bounds', () => {
+  const ASUKA = 'did:plc:asukalangley'
+  const SHINJI = 'did:plc:shinjiikari'
+  const KAWORU = 'did:plc:kaworunagisa'
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('evicts an expired entry on read', () => {
+    vi.useFakeTimers()
+    const cache = new ResolveEnrollmentsCache(1000, 10)
+    cache.set(ASUKA, ['tokyo-3.nerv.jp'], cache.epoch())
+    expect(cache.get(ASUKA)).toEqual(['tokyo-3.nerv.jp'])
+
+    vi.advanceTimersByTime(1000)
+    expect(cache.get(ASUKA)).toBeUndefined()
+    // The expired row must be gone, not merely masked: a leftover row per
+    // resolved DID would accumulate for the life of the process.
+    const entries = (cache as unknown as { entries: Map<string, unknown> })
+      .entries
+    expect(entries.size).toBe(0)
+  })
+
+  it('serves an entry for the full TTL', () => {
+    vi.useFakeTimers()
+    const cache = new ResolveEnrollmentsCache(1000, 10)
+    cache.set(ASUKA, ['tokyo-3.nerv.jp'], cache.epoch())
+
+    vi.advanceTimersByTime(999)
+    expect(cache.get(ASUKA)).toEqual(['tokyo-3.nerv.jp'])
+  })
+
+  it('caps stored entries by evicting the oldest insert', () => {
+    const cache = new ResolveEnrollmentsCache(60_000, 2)
+    cache.set(ASUKA, ['tokyo-3.nerv.jp'], cache.epoch())
+    cache.set(SHINJI, ['geofront.nerv.jp'], cache.epoch())
+    cache.set(KAWORU, ['seele.nerv.jp'], cache.epoch())
+
+    expect(cache.get(ASUKA)).toBeUndefined()
+    expect(cache.get(SHINJI)).toEqual(['geofront.nerv.jp'])
+    expect(cache.get(KAWORU)).toEqual(['seele.nerv.jp'])
+    const entries = (cache as unknown as { entries: Map<string, unknown> })
+      .entries
+    expect(entries.size).toBe(2)
+  })
+
+  it('overwrites an existing DID at the cap without evicting', () => {
+    const cache = new ResolveEnrollmentsCache(60_000, 2)
+    cache.set(ASUKA, ['tokyo-3.nerv.jp'], cache.epoch())
+    cache.set(SHINJI, ['geofront.nerv.jp'], cache.epoch())
+    cache.set(SHINJI, ['seele.nerv.jp'], cache.epoch())
+
+    expect(cache.get(ASUKA)).toEqual(['tokyo-3.nerv.jp'])
+    expect(cache.get(SHINJI)).toEqual(['seele.nerv.jp'])
+  })
+
+  it('rejects a write fenced against a stale epoch', () => {
+    const cache = new ResolveEnrollmentsCache(60_000, 10)
+    const epoch = cache.epoch()
+    // Any invalidation voids in-flight writes, including for other DIDs.
+    cache.invalidate(SHINJI)
+    cache.set(ASUKA, ['tokyo-3.nerv.jp'], epoch)
+
+    expect(cache.get(ASUKA)).toBeUndefined()
+  })
+
+  it('accepts a write when no invalidation intervened', () => {
+    const cache = new ResolveEnrollmentsCache(60_000, 10)
+    const epoch = cache.epoch()
+    cache.set(ASUKA, ['tokyo-3.nerv.jp'], epoch)
+
+    expect(cache.get(ASUKA)).toEqual(['tokyo-3.nerv.jp'])
   })
 })

--- a/stratos-service/tests/enrollment-status.test.ts
+++ b/stratos-service/tests/enrollment-status.test.ts
@@ -1,3 +1,4 @@
+import { EventEmitter } from 'node:events'
 import { describe, expect, it } from 'vitest'
 import * as fc from 'fast-check'
 import express from 'express'
@@ -465,5 +466,244 @@ describe('resolveEnrollments endpoint', () => {
     await invokeResolveRoute(ctx, { did: 'did:plc:bulmabrief' })
 
     expect(callCount).toBe(1)
+  })
+})
+
+// --- resolveEnrollments cache invalidation tests ---
+
+function invokeAdminPost(
+  ctx: AppContext,
+  path: string,
+  body: Record<string, unknown>,
+): Promise<MockResponse> {
+  const app = ctx.app
+  return new Promise((resolve, reject) => {
+    let statusCode = 200
+    const req = {
+      query: {},
+      body,
+      // Signals body-parser that the body is already parsed, so the
+      // adminJsonParser middleware passes it through untouched.
+      _body: true,
+      headers: {},
+      method: 'POST',
+      url: path,
+    } as unknown as express.Request
+    const res = {
+      status(code: number) {
+        statusCode = code
+        return res
+      },
+      json(responseBody: unknown) {
+        resolve({ statusCode, body: responseBody })
+        return res
+      },
+      setHeader() {
+        return res
+      },
+    } as unknown as express.Response
+    app(req, res, ((err?: unknown) => {
+      if (err) reject(err)
+    }) as express.NextFunction)
+  })
+}
+
+describe('resolveEnrollments cache invalidation', () => {
+  const REI = 'did:plc:reiayanami'
+  const MISATO = 'did:plc:misatokatsuragi'
+
+  interface HarnessState {
+    enrolled: boolean
+    active: boolean
+    boundaries: string[]
+    boundaryReads: number
+  }
+
+  function createHarness(initialBoundaries: string[] = ['tokyo-3.nerv.jp']): {
+    ctx: AppContext
+    xrpc: MockXrpcServer
+    state: HarnessState
+  } {
+    const state: HarnessState = {
+      enrolled: true,
+      active: true,
+      boundaries: [...initialBoundaries],
+      boundaryReads: 0,
+    }
+    const app = express()
+    const ctx = {
+      app,
+      enrollmentService: {
+        isEnrolled: async () => state.enrolled,
+        getEnrollment: async () => null,
+        unenroll: async () => {
+          state.enrolled = false
+          state.boundaries = []
+        },
+      },
+      boundaryResolver: {
+        getBoundaries: async () => {
+          state.boundaryReads++
+          return [...state.boundaries]
+        },
+      },
+      // getEnrollment intentionally returns no signingKeyDid or
+      // enrollmentRkey so the PDS write/delete paths short-circuit.
+      enrollmentStore: {
+        isEnrolled: async () => state.enrolled,
+        getEnrollment: async () =>
+          state.enrolled
+            ? {
+                did: REI,
+                enrolledAt: '2026-01-01T00:00:00.000Z',
+                pdsEndpoint: 'https://pds.tokyo-3.nerv.jp',
+                active: state.active,
+              }
+            : null,
+        getBoundaries: async () => [...state.boundaries],
+        addBoundary: async (_did: string, boundary: string) => {
+          state.boundaries.push(boundary)
+        },
+        removeBoundary: async (_did: string, boundary: string) => {
+          state.boundaries = state.boundaries.filter((b) => b !== boundary)
+        },
+        setBoundaries: async (_did: string, boundaries: string[]) => {
+          state.boundaries = [...boundaries]
+        },
+        updateEnrollment: async (_did: string, patch: { active?: boolean }) => {
+          if (patch.active !== undefined) state.active = patch.active
+        },
+      },
+      actorStore: { deleteSigningKey: async () => {} },
+      oauthClient: { revoke: async () => {}, restore: async () => {} },
+      enrollmentEvents: new EventEmitter(),
+      authVerifier: {
+        optionalStandard: async () => ({ credentials: { type: 'none' } }),
+        standard: async () => ({ credentials: { type: 'user', did: REI } }),
+        admin: async () => ({ credentials: { type: 'admin', did: MISATO } }),
+      },
+      createAttestation: async () => ({
+        sig: new Uint8Array([0xde, 0xad]),
+        signingKey: 'did:key:zDnaeServiceKey',
+      }),
+      serviceDid: 'did:web:stratos.nerv.jp',
+      cfg: {
+        service: { publicUrl: 'https://stratos.nerv.jp' },
+        adminDids: [],
+        stratos: { allowedDomains: ['tokyo-3.nerv.jp', 'geofront.nerv.jp'] },
+      },
+      logger: {
+        debug: () => {},
+        info: () => {},
+        warn: () => {},
+        error: () => {},
+      },
+    } as unknown as AppContext
+    const xrpc = createMockXrpcServer()
+    registerEnrollmentHandlers(xrpc as any, ctx)
+    return { ctx, xrpc, state }
+  }
+
+  interface ResolveBody {
+    did: string
+    enrolled: boolean
+    boundaries: string[]
+  }
+
+  it('returns enrolled false after unenroll within the cache TTL', async () => {
+    const { ctx, xrpc } = createHarness()
+
+    const before = await invokeResolveRoute(ctx, { did: REI })
+    expect((before.body as ResolveBody).enrolled).toBe(true)
+    expect((before.body as ResolveBody).boundaries).toEqual(['tokyo-3.nerv.jp'])
+
+    const unenroll = await invokeMethod(
+      xrpc,
+      'zone.stratos.enrollment.unenroll',
+      {},
+      { credentials: { type: 'user', did: REI } },
+    )
+    expect((unenroll.body as { success: boolean }).success).toBe(true)
+
+    const after = await invokeResolveRoute(ctx, { did: REI })
+    expect((after.body as ResolveBody).enrolled).toBe(false)
+    expect((after.body as ResolveBody).boundaries).toEqual([])
+  })
+
+  it('returns the added boundary after addBoundary within the cache TTL', async () => {
+    const { ctx } = createHarness()
+
+    const before = await invokeResolveRoute(ctx, { did: REI })
+    expect((before.body as ResolveBody).boundaries).toEqual(['tokyo-3.nerv.jp'])
+
+    const admin = await invokeAdminPost(
+      ctx,
+      '/xrpc/zone.stratos.admin.addBoundary',
+      { did: REI, boundary: 'geofront.nerv.jp' },
+    )
+    expect(admin.statusCode).toBe(200)
+
+    const after = await invokeResolveRoute(ctx, { did: REI })
+    expect((after.body as ResolveBody).boundaries).toEqual([
+      'tokyo-3.nerv.jp',
+      'geofront.nerv.jp',
+    ])
+  })
+
+  it('drops the removed boundary after removeBoundary within the cache TTL', async () => {
+    const { ctx } = createHarness(['tokyo-3.nerv.jp', 'geofront.nerv.jp'])
+
+    const before = await invokeResolveRoute(ctx, { did: REI })
+    expect((before.body as ResolveBody).boundaries).toEqual([
+      'tokyo-3.nerv.jp',
+      'geofront.nerv.jp',
+    ])
+
+    const admin = await invokeAdminPost(
+      ctx,
+      '/xrpc/zone.stratos.admin.removeBoundary',
+      { did: REI, boundary: 'geofront.nerv.jp' },
+    )
+    expect(admin.statusCode).toBe(200)
+
+    const after = await invokeResolveRoute(ctx, { did: REI })
+    expect((after.body as ResolveBody).boundaries).toEqual(['tokyo-3.nerv.jp'])
+  })
+
+  it('returns the replacement set after setBoundaries within the cache TTL', async () => {
+    const { ctx } = createHarness()
+
+    const before = await invokeResolveRoute(ctx, { did: REI })
+    expect((before.body as ResolveBody).boundaries).toEqual(['tokyo-3.nerv.jp'])
+
+    const admin = await invokeAdminPost(
+      ctx,
+      '/xrpc/zone.stratos.admin.setBoundaries',
+      { did: REI, boundaries: ['geofront.nerv.jp'] },
+    )
+    expect(admin.statusCode).toBe(200)
+
+    const after = await invokeResolveRoute(ctx, { did: REI })
+    expect((after.body as ResolveBody).boundaries).toEqual(['geofront.nerv.jp'])
+  })
+
+  it('re-reads the store after setActive within the cache TTL', async () => {
+    const { ctx, state } = createHarness()
+
+    await invokeResolveRoute(ctx, { did: REI })
+    expect(state.boundaryReads).toBe(1)
+
+    const admin = await invokeAdminPost(
+      ctx,
+      '/xrpc/zone.stratos.admin.setActive',
+      { did: REI, active: false },
+    )
+    expect(admin.statusCode).toBe(200)
+
+    const after = await invokeResolveRoute(ctx, { did: REI })
+    expect(after.statusCode).toBe(200)
+    // A cached entry would serve the second resolve without touching the
+    // store; the invalidation forces a fresh boundary read.
+    expect(state.boundaryReads).toBe(2)
   })
 })

--- a/stratos-service/tests/enrollment-status.test.ts
+++ b/stratos-service/tests/enrollment-status.test.ts
@@ -509,7 +509,15 @@ function invokeAdminPost(
       },
     } as unknown as express.Response
     app(req, res, ((err?: unknown) => {
-      if (err) reject(err instanceof Error ? err : new Error(String(err)))
+      if (err) {
+        reject(
+          err instanceof Error
+            ? err
+            : new Error(
+                typeof err === 'string' ? err : 'route middleware failed',
+              ),
+        )
+      }
     }) as express.NextFunction)
   })
 }

--- a/stratos-service/tests/enrollment-status.test.ts
+++ b/stratos-service/tests/enrollment-status.test.ts
@@ -2,6 +2,7 @@ import { EventEmitter } from 'node:events'
 import { describe, expect, it } from 'vitest'
 import * as fc from 'fast-check'
 import express from 'express'
+import type { Server as XrpcServer } from '@atproto/xrpc-server'
 import type { AppContext } from '../src/index.js'
 import { registerEnrollmentHandlers } from '../src/features/index.js'
 import type { Enrollment } from '@northskysocial/stratos-core'
@@ -469,8 +470,6 @@ describe('resolveEnrollments endpoint', () => {
   })
 })
 
-// --- resolveEnrollments cache invalidation tests ---
-
 function invokeAdminPost(
   ctx: AppContext,
   path: string,
@@ -600,7 +599,7 @@ describe('resolveEnrollments cache invalidation', () => {
       },
     } as unknown as AppContext
     const xrpc = createMockXrpcServer()
-    registerEnrollmentHandlers(xrpc as any, ctx)
+    registerEnrollmentHandlers(xrpc as unknown as XrpcServer, ctx)
     return { ctx, xrpc, state }
   }
 
@@ -705,5 +704,44 @@ describe('resolveEnrollments cache invalidation', () => {
     // A cached entry would serve the second resolve without touching the
     // store; the invalidation forces a fresh boundary read.
     expect(state.boundaryReads).toBe(2)
+  })
+
+  it('refuses to cache a boundary set resolved before an in-flight mutation', async () => {
+    const { ctx } = createHarness()
+
+    let releaseResolve!: () => void
+    const gate = new Promise<void>((resolve) => (releaseResolve = resolve))
+    const resolver = ctx.boundaryResolver as {
+      getBoundaries: (did: string) => Promise<string[]>
+    }
+    const readBoundaries = resolver.getBoundaries
+    // First call: park a resolution that already read the pre-mutation set.
+    // Later calls fall through to the live store.
+    resolver.getBoundaries = async () => {
+      resolver.getBoundaries = readBoundaries
+      await gate
+      return ['tokyo-3.nerv.jp']
+    }
+
+    const inFlight = invokeResolveRoute(ctx, { did: REI })
+
+    const admin = await invokeAdminPost(
+      ctx,
+      '/xrpc/zone.stratos.admin.addBoundary',
+      { did: REI, boundary: 'geofront.nerv.jp' },
+    )
+    expect(admin.statusCode).toBe(200)
+
+    releaseResolve()
+    const stale = await inFlight
+    expect((stale.body as ResolveBody).boundaries).toEqual(['tokyo-3.nerv.jp'])
+
+    // The stale write must not have landed: the next resolve within the TTL
+    // reads the store again and sees the mutation.
+    const after = await invokeResolveRoute(ctx, { did: REI })
+    expect((after.body as ResolveBody).boundaries).toEqual([
+      'tokyo-3.nerv.jp',
+      'geofront.nerv.jp',
+    ])
   })
 })


### PR DESCRIPTION
Closes #119
Closes #103

## Summary
- Fail the service stream on handler errors instead of silently advancing the cursor, and trigger enrollment reconciliation on every session establishment (reconnect included) so missed unenroll frames converge.
- Guard reconcile purges against live enrollment races: before purging, reconcile re-reads the `enrolled_actor` row and skips actors touched at or after run start (`lastSeenAt` marker, same-millisecond safe). A skipped purge converges on the next run.
- Invalidate the service's `resolveEnrollments` positive cache on all five enrollment mutations (unenroll, setActive flip, addBoundary, removeBoundary, setBoundaries) so downstream reconciles stop seeing up to 60s of stale enrolled state.
- Stale-socket hardening: the WebSocket `open` handler now ignores sockets already detached by `stop()`.

## Review
Local Opus review pass: 3 majors found, all fixed in the follow-up commits (`4ebceb3`, `d6d3ac0`) plus the stale-socket minor. Race coverage includes live enroll / boundary re-grant / concurrent unenroll mid-reconcile and a frozen-clock same-millisecond purge test.

## Verification
- tsc, prettier, eslint (baseline warnings only) clean in both packages
- vitest: feedgen 203 passed | 26 skipped (testcontainers-gated); service 989 passed
- Scoped Stryker: feedgen `reconcile.ts` + `service-stream.ts` 75.77 ≥ 60 with zero survivors on changed lines; service `enrollment/handler.ts` 61.80 ≥ 60, no survivors on inserted lines
- `src/bin/main.ts` sits outside the feedgen Stryker mutate scope, so the reconnect-trigger change is covered by tests but not mutation-tested

## Test plan
- [ ] Kill the feedgen's upstream WebSocket mid-run; confirm a reconcile fires on reconnect and unenrolled actors are purged
- [ ] Unenroll a user, then hit `resolveEnrollments` within 60s; confirm the fresh state is served

🤖 Generated with Rommie Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synchronization after service-stream connections and reconnects, reducing missed enrollment removals.
  * Prevented stale reconciliation data from purging actors or boundaries after newer updates.
  * Improved handling of malformed messages and callback failures during streaming.
  * Ensured enrollment and boundary changes are reflected promptly in cached status results.
  * Prevented outdated socket events from triggering unnecessary processing.
  * Added safeguards to keep cached enrollment results current and within limits.

* **Reliability**
  * Added serialized reconciliation with coalesced follow-up runs and recovery after failures.
  * Improved reconnect behavior and protection against stale updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->