### PR TITLE
Distinguish a failed eligibility check from an enrollment denial

### DIFF
--- a/docs/client/api-reference.md
+++ b/docs/client/api-reference.md
@@ -201,8 +201,11 @@ Response: { "imported": <count> }
 GET /xrpc/zone.stratos.enrollment.status?did=<user-did>
 ```
 
-Unauthenticated: returns `{ enrolled: true/false }`.  
-Authenticated: also returns boundaries, signing key, enrollment rkey, and a fresh attestation.
+Unauthenticated, enrolled DID: returns `{ did, enrolled: true, active, enrolledAt, signingKey, enrollmentRkey }`.  
+Unauthenticated, not-enrolled DID: returns `{ did, enrolled: false, eligible }` — `eligible: true`
+means the DID may enroll but has not yet done so (no enrollment row, no PDS enrollment record,
+record writes are denied).  
+Authenticated: also returns boundaries and a fresh attestation for enrolled DIDs.
 
 ### Pull Sync: List Repo Operations
 

--- a/docs/client/api-reference.md
+++ b/docs/client/api-reference.md
@@ -203,9 +203,11 @@ GET /xrpc/zone.stratos.enrollment.status?did=<user-did>
 
 Unauthenticated, enrolled DID: returns `{ did, enrolled: true, active, enrolledAt, signingKey, enrollmentRkey }`.  
 Unauthenticated, not-enrolled DID: returns `{ did, enrolled: false, eligible }` — `eligible: true`
-means the DID may enroll but has not yet done so (no enrollment row, no PDS enrollment record,
-record writes are denied).  
-Authenticated: also returns boundaries and a fresh attestation for enrolled DIDs.
+means the DID may enroll but has not yet done so (no enrollment row, record writes are denied).
+`eligible` is omitted when the eligibility check cannot complete (for example, DID resolution
+fails); do not treat an absent `eligible` as a denial.  
+Authenticated: also returns boundaries for enrolled DIDs, plus a fresh attestation when the DID
+has at least one boundary.
 
 ### Pull Sync: List Repo Operations
 

--- a/lexicons/zone/stratos/enrollment/status.json
+++ b/lexicons/zone/stratos/enrollment/status.json
@@ -31,10 +31,27 @@
               "type": "boolean",
               "description": "Whether the DID is enrolled in this Stratos service."
             },
+            "eligible": {
+              "type": "boolean",
+              "description": "Whether the DID is eligible to enroll. Only included when the DID is not enrolled."
+            },
+            "active": {
+              "type": "boolean",
+              "description": "Whether the enrollment is active. Only included when enrolled."
+            },
             "enrolledAt": {
               "type": "string",
               "format": "datetime",
               "description": "When the DID was enrolled, if enrolled."
+            },
+            "signingKey": {
+              "type": "string",
+              "format": "did",
+              "description": "The service-held signing key DID for this enrollment. Only included when enrolled."
+            },
+            "enrollmentRkey": {
+              "type": "string",
+              "description": "Record key of the zone.stratos.actor.enrollment record on the user's PDS. Only included when enrolled."
             },
             "boundaries": {
               "type": "array",

--- a/lexicons/zone/stratos/enrollment/status.json
+++ b/lexicons/zone/stratos/enrollment/status.json
@@ -33,7 +33,7 @@
             },
             "eligible": {
               "type": "boolean",
-              "description": "Whether the DID is eligible to enroll. Only included when the DID is not enrolled."
+              "description": "Whether the DID is eligible to enroll. Only included when the DID is not enrolled. Omitted when the eligibility check cannot complete."
             },
             "active": {
               "type": "boolean",

--- a/stratos-client/src/lexicons.gen.ts
+++ b/stratos-client/src/lexicons.gen.ts
@@ -466,10 +466,27 @@ export const stratosLexicons: LexiconDoc[] = [
               "type": "boolean",
               "description": "Whether the DID is enrolled in this Stratos service."
             },
+            "eligible": {
+              "type": "boolean",
+              "description": "Whether the DID is eligible to enroll. Only included when the DID is not enrolled."
+            },
+            "active": {
+              "type": "boolean",
+              "description": "Whether the enrollment is active. Only included when enrolled."
+            },
             "enrolledAt": {
               "type": "string",
               "format": "datetime",
               "description": "When the DID was enrolled, if enrolled."
+            },
+            "signingKey": {
+              "type": "string",
+              "format": "did",
+              "description": "The service-held signing key DID for this enrollment. Only included when enrolled."
+            },
+            "enrollmentRkey": {
+              "type": "string",
+              "description": "Record key of the zone.stratos.actor.enrollment record on the user's PDS. Only included when enrolled."
             },
             "boundaries": {
               "type": "array",

--- a/stratos-client/src/lexicons.gen.ts
+++ b/stratos-client/src/lexicons.gen.ts
@@ -468,7 +468,7 @@ export const stratosLexicons: LexiconDoc[] = [
             },
             "eligible": {
               "type": "boolean",
-              "description": "Whether the DID is eligible to enroll. Only included when the DID is not enrolled."
+              "description": "Whether the DID is eligible to enroll. Only included when the DID is not enrolled. Omitted when the eligibility check cannot complete."
             },
             "active": {
               "type": "boolean",

--- a/stratos-core/src/shared/errors.ts
+++ b/stratos-core/src/shared/errors.ts
@@ -44,6 +44,7 @@ export type EnrollmentDenialReason =
   | 'DidNotResolved'
   | 'PdsEndpointNotFound'
   | 'ServiceClosed'
+  | 'VerificationFailed'
 
 /**
  * Error thrown when a boundary is not allowed

--- a/stratos-service/admin-ui/src/lib/api/client.ts
+++ b/stratos-service/admin-ui/src/lib/api/client.ts
@@ -31,6 +31,7 @@ export interface ResolveEnrollmentsResponse {
 export interface EnrollmentStatusResponse {
   did: string
   enrolled: boolean
+  eligible?: boolean
   enrolledAt?: string
   active?: boolean
   signingKey?: string

--- a/stratos-service/src/features/enrollment/handler.ts
+++ b/stratos-service/src/features/enrollment/handler.ts
@@ -1,7 +1,10 @@
 import express, { type Request, type Response } from 'express'
 import { Agent } from '@atproto/api'
 import { InvalidRequestError, Server as XrpcServer } from '@atproto/xrpc-server'
-import { type Enrollment } from '@northskysocial/stratos-core'
+import {
+  type Enrollment,
+  EnrollmentDeniedError,
+} from '@northskysocial/stratos-core'
 import type { AppContext } from '../../context-types.js'
 import { type XrpcServerInternal } from '../../api/types.js'
 import { createXrpcHandler } from '../../api/util.js'
@@ -60,10 +63,16 @@ function registerEnrollmentStatus(server: XrpcServer, ctx: AppContext): void {
               allowListProvider: ctx.allowListProvider,
               logger: ctx.logger,
             })
-            // If verifyEnrolled doesn't throw, they are eligible
             return { did, enrolled: false, eligible: true }
-          } catch {
-            return { did, enrolled: false, eligible: false }
+          } catch (err) {
+            if (
+              err instanceof EnrollmentDeniedError &&
+              err.reason !== 'VerificationFailed'
+            ) {
+              return { did, enrolled: false, eligible: false }
+            }
+            // The check failed; omit eligible rather than claim a denial.
+            return { did, enrolled: false }
           }
         }
 

--- a/stratos-service/src/features/enrollment/handler.ts
+++ b/stratos-service/src/features/enrollment/handler.ts
@@ -61,9 +61,9 @@ function registerEnrollmentStatus(server: XrpcServer, ctx: AppContext): void {
               logger: ctx.logger,
             })
             // If verifyEnrolled doesn't throw, they are eligible
-            return { did, enrolled: true, active: false }
+            return { did, enrolled: false, eligible: true }
           } catch {
-            return { did, enrolled: false }
+            return { did, enrolled: false, eligible: false }
           }
         }
 

--- a/stratos-service/src/features/enrollment/internal/auth.ts
+++ b/stratos-service/src/features/enrollment/internal/auth.ts
@@ -56,9 +56,11 @@ export async function verifyEnrolled(
       throw err
     }
     deps.logger?.error({ err, did }, 'failed to verify enrollment eligibility')
+    // 'VerificationFailed' marks a failed check, not a policy denial.
+    // The status endpoint must not report it as an authoritative denial.
     throw new EnrollmentDeniedError(
       'Enrollment verification failed',
-      'NotInAllowlist',
+      'VerificationFailed',
       { cause: err },
     )
   }

--- a/stratos-service/src/features/enrollment/internal/validation.ts
+++ b/stratos-service/src/features/enrollment/internal/validation.ts
@@ -65,8 +65,9 @@ export async function validateEnrollment(
   try {
     didDoc = await idResolver.did.resolve(did)
   } catch (err) {
-    // DID resolution failed
-    return { allowed: false, reason: 'DidNotResolved', cause: err }
+    // A thrown resolution is a failed check, not proof that the DID
+    // does not resolve. Keep it distinct from 'DidNotResolved'.
+    return { allowed: false, reason: 'VerificationFailed', cause: err }
   }
 
   if (!didDoc) {
@@ -110,6 +111,7 @@ export async function assertEnrollment(
       DidNotResolved: 'Could not resolve your DID document',
       PdsEndpointNotFound: 'Could not find a PDS endpoint in your DID document',
       ServiceClosed: 'This Stratos service is not accepting new enrollments',
+      VerificationFailed: 'Enrollment verification failed',
     }
 
     throw new EnrollmentDeniedError(messages[result.reason!], result.reason!, {

--- a/stratos-service/tests/enrollment-active-gate.test.ts
+++ b/stratos-service/tests/enrollment-active-gate.test.ts
@@ -38,6 +38,32 @@ describe('verifyEnrolled', () => {
     ).rejects.toBeInstanceOf(EnrollmentDeniedError)
   })
 
+  it('wraps a failed eligibility check as VerificationFailed', async () => {
+    // The allow-list provider throws a raw error. verifyEnrolled must wrap
+    // it so callers see a structured denial, not an unhandled failure.
+    const backendError = new Error('allowlist backend unreachable')
+    const failingDeps = {
+      ...deps(null),
+      allowListProvider: {
+        isAllowed: vi.fn(async () => {
+          throw backendError
+        }),
+      } as never,
+    }
+
+    const err = await verifyEnrolled('did:plc:usagi', failingDeps).then(
+      () => null,
+      (e: unknown) => e,
+    )
+
+    expect(err).toBeInstanceOf(EnrollmentDeniedError)
+    expect((err as EnrollmentDeniedError).reason).toBe('VerificationFailed')
+    expect((err as EnrollmentDeniedError).message).toBe(
+      'Enrollment verification failed',
+    )
+    expect((err as Error).cause).toBe(backendError)
+  })
+
   it('does not readmit a deactivated member through auto-enrollment', async () => {
     // Enrollment open to everyone: without the active check, the deactivated
     // member would fall through and be readmitted.

--- a/stratos-service/tests/enrollment-eligibility-status.test.ts
+++ b/stratos-service/tests/enrollment-eligibility-status.test.ts
@@ -95,7 +95,7 @@ function createCtx(opts: {
 }
 
 describe('Enrollment status eligibility', () => {
-  it('reports enrolled: false when user not in DB and not eligible (REPRODUCTION)', async () => {
+  it('reports enrolled: false and eligible: false when user not in DB and not eligible', async () => {
     const xrpc = createMockXrpcServer()
     const ctx = createCtx({
       getEnrollment: async () => null,
@@ -104,13 +104,14 @@ describe('Enrollment status eligibility', () => {
 
     registerEnrollmentHandlers(xrpc as any, ctx)
     const res = await invokeMethod(xrpc, 'zone.stratos.enrollment.status', {
-      did: 'did:plc:not-eligible',
+      did: 'did:plc:shinji-tokyo3',
     })
 
     expect(res.body.enrolled).toBe(false)
+    expect(res.body.eligible).toBe(false)
   })
 
-  it('SHOULD report enrolled: true when user not in DB but is eligible (CURRENTLY FAILS)', async () => {
+  it('reports enrolled: false and eligible: true when user not in DB but is eligible', async () => {
     const xrpc = createMockXrpcServer()
     const ctx = createCtx({
       getEnrollment: async () => null,
@@ -119,11 +120,39 @@ describe('Enrollment status eligibility', () => {
 
     registerEnrollmentHandlers(xrpc as any, ctx)
     const res = await invokeMethod(xrpc, 'zone.stratos.enrollment.status', {
-      did: 'did:plc:eligible-but-not-in-db',
+      did: 'did:plc:asuka-nerv',
     })
 
-    // This is what we want to fix: currently this returns false
-    // because it only checks ctx.enrollmentService.getEnrollment
+    // Eligibility must not be reported as enrollment: an eligible DID has no
+    // enrollment row, cannot write records, and has no PDS enrollment record.
+    expect(res.body.enrolled).toBe(false)
+    expect(res.body.eligible).toBe(true)
+  })
+
+  it('reports enrolled: true with active: false for a deactivated enrollment row', async () => {
+    const xrpc = createMockXrpcServer()
+    const enrolledAt = new Date('2026-01-15T12:00:00.000Z')
+    const ctx = createCtx({
+      getEnrollment: async () => ({
+        did: 'did:plc:rei-nerv',
+        enrolledAt,
+        active: false,
+        signingKeyDid: 'did:key:zRei',
+        enrollmentRkey: 'rkey-rei',
+      }),
+      isEligible: true,
+    })
+
+    registerEnrollmentHandlers(xrpc as any, ctx)
+    const res = await invokeMethod(xrpc, 'zone.stratos.enrollment.status', {
+      did: 'did:plc:rei-nerv',
+    })
+
+    // Deactivated is not the same as not enrolled: the row exists.
     expect(res.body.enrolled).toBe(true)
+    expect(res.body.active).toBe(false)
+    expect(res.body.eligible).toBeUndefined()
+    expect(res.body.enrolledAt).toBe(enrolledAt.toISOString())
+    expect(res.body.enrollmentRkey).toBe('rkey-rei')
   })
 })

--- a/stratos-service/tests/enrollment-eligibility-status.test.ts
+++ b/stratos-service/tests/enrollment-eligibility-status.test.ts
@@ -4,18 +4,33 @@ import { registerEnrollmentHandlers } from '../src/features/index.js'
 import type { AppContext } from '../src/index.js'
 import { EnrollmentDeniedError } from '@northskysocial/stratos-core'
 
+/** The shape `zone.stratos.enrollment.status` returns. */
+interface EnrollmentStatusBody {
+  did?: string
+  enrolled?: boolean
+  eligible?: boolean
+  active?: boolean
+  enrolledAt?: string
+  signingKey?: string
+  enrollmentRkey?: string
+}
+
+type XrpcHandler = (ctx: {
+  params: Record<string, unknown>
+  auth?: unknown
+}) => Promise<{ body: EnrollmentStatusBody }>
+
 interface MockXrpcServer {
-  methods: Record<string, any>
-  method: (nsid: string, config: any) => void
+  methods: Record<string, XrpcHandler>
+  method: (nsid: string, config: { handler: XrpcHandler }) => void
 }
 
 function createMockXrpcServer(): MockXrpcServer {
-  const methods: Record<string, any> = {}
+  const methods: Record<string, XrpcHandler> = {}
   return {
     methods,
-    method: (nsid: string, config: any) => {
-      // The registerEnrollmentHandlers function calls server.method(nsid, config)
-      // where config is { auth, handler }
+    // registerEnrollmentHandlers calls server.method(nsid, { auth, handler }).
+    method: (nsid, config) => {
       methods[nsid] = config.handler
     },
   }
@@ -26,10 +41,9 @@ async function invokeMethod(
   nsid: string,
   params: Record<string, unknown> = {},
   auth?: unknown,
-): Promise<any> {
+): Promise<{ statusCode: number; body: EnrollmentStatusBody }> {
   const handler = server.methods[nsid]
   if (!handler) throw new Error(`Method ${nsid} not registered`)
-  // The handler returned by createXrpcHandler is (handlerCtx) => Promise<HandlerResponse>
   const result = await handler({ params, auth })
   return { statusCode: 200, body: result.body }
 }

--- a/stratos-service/tests/enrollment-eligibility-status.test.ts
+++ b/stratos-service/tests/enrollment-eligibility-status.test.ts
@@ -37,6 +37,8 @@ async function invokeMethod(
 function createCtx(opts: {
   getEnrollment: (did: string) => Promise<any | null>
   isEligible?: boolean
+  resolveThrows?: boolean
+  allowedPdsEndpoints?: string[]
 }): AppContext {
   const app = express()
   ;(app as any)._router = (app as any)._router || express.Router()
@@ -61,7 +63,7 @@ function createCtx(opts: {
     cfg: {
       enrollment: {
         mode: opts.isEligible ? 'open' : 'closed',
-        allowedPdsEndpoints: [],
+        allowedPdsEndpoints: opts.allowedPdsEndpoints ?? [],
         autoEnrollDomains: ['example.com'],
       },
       stratos: {
@@ -71,8 +73,11 @@ function createCtx(opts: {
     },
     idResolver: {
       did: {
-        resolve: async () =>
-          opts.isEligible
+        resolve: async () => {
+          if (opts.resolveThrows) {
+            throw new Error('PLC directory timeout')
+          }
+          return opts.isEligible
             ? {
                 service: [
                   {
@@ -81,7 +86,8 @@ function createCtx(opts: {
                   },
                 ],
               }
-            : null,
+            : null
+        },
       },
     } as any,
     logger: {
@@ -127,6 +133,27 @@ describe('Enrollment status eligibility', () => {
     // enrollment row, cannot write records, and has no PDS enrollment record.
     expect(res.body.enrolled).toBe(false)
     expect(res.body.eligible).toBe(true)
+  })
+
+  it('omits eligible when the eligibility check itself fails', async () => {
+    const xrpc = createMockXrpcServer()
+    // Closed mode with a PDS allowlist forces DID resolution, which throws.
+    const ctx = createCtx({
+      getEnrollment: async () => null,
+      isEligible: false,
+      resolveThrows: true,
+      allowedPdsEndpoints: ['https://pds.example.com'],
+    })
+
+    registerEnrollmentHandlers(xrpc as any, ctx)
+    const res = await invokeMethod(xrpc, 'zone.stratos.enrollment.status', {
+      did: 'did:plc:misato-nerv',
+    })
+
+    // A failed check is not a denial: the endpoint must not report an
+    // authoritative eligible: false when the PLC or PDS is unreachable.
+    expect(res.body.enrolled).toBe(false)
+    expect(res.body.eligible).toBeUndefined()
   })
 
   it('reports enrolled: true with active: false for a deactivated enrollment row', async () => {

--- a/stratos-service/tests/enrollment.test.ts
+++ b/stratos-service/tests/enrollment.test.ts
@@ -358,7 +358,7 @@ describe('enrollment', () => {
 
       const err = await assertEnrollment(
         config,
-        'did:plc:test',
+        'did:plc:motoko',
         mockResolver,
       ).then(
         () => null,

--- a/stratos-service/tests/enrollment.test.ts
+++ b/stratos-service/tests/enrollment.test.ts
@@ -230,7 +230,7 @@ describe('enrollment', () => {
         expect(result.reason).toBe('PdsEndpointNotFound')
       })
 
-      it('should return DidNotResolved on resolution error', async () => {
+      it('should return VerificationFailed on resolution error', async () => {
         const mockResolver = {
           did: {
             resolve: vi.fn().mockRejectedValue(new Error('Network error')),
@@ -239,8 +239,10 @@ describe('enrollment', () => {
 
         const result = await validateEnrollment(pdsConfig, did, mockResolver)
 
+        // A thrown resolution is a failed check, not proof that the
+        // DID does not resolve.
         expect(result.allowed).toBe(false)
-        expect(result.reason).toBe('DidNotResolved')
+        expect(result.reason).toBe('VerificationFailed')
       })
     })
 
@@ -339,6 +341,36 @@ describe('enrollment', () => {
       await expect(
         assertEnrollment(config, 'did:plc:test', mockResolver),
       ).rejects.toThrow(EnrollmentDeniedError)
+    })
+
+    it('should wrap a resolution failure with message and cause', async () => {
+      const config: EnrollmentConfig = {
+        mode: ENROLLMENT_MODE.ALLOWLIST,
+        allowedDids: [],
+        allowedPdsEndpoints: ['https://pds.example.com'],
+      }
+      const resolutionError = new Error('Network error')
+      const mockResolver = {
+        did: {
+          resolve: vi.fn().mockRejectedValue(resolutionError),
+        },
+      } as unknown as IdResolver
+
+      const err = await assertEnrollment(
+        config,
+        'did:plc:test',
+        mockResolver,
+      ).then(
+        () => null,
+        (e: unknown) => e,
+      )
+
+      expect(err).toBeInstanceOf(EnrollmentDeniedError)
+      expect((err as EnrollmentDeniedError).reason).toBe('VerificationFailed')
+      expect((err as EnrollmentDeniedError).message).toBe(
+        'Enrollment verification failed',
+      )
+      expect((err as Error).cause).toBe(resolutionError)
     })
 
     it('should include reason in EnrollmentDeniedError', async () => {

--- a/test/scripts/lib/stratos.ts
+++ b/test/scripts/lib/stratos.ts
@@ -54,6 +54,7 @@ export async function waitForHealthy(
 export async function enrollmentStatus(did: string): Promise<{
   did: string
   enrolled: boolean
+  eligible?: boolean
   active?: boolean
   enrolledAt?: string
   enrollmentRkey?: string
@@ -70,6 +71,7 @@ export async function enrollmentStatus(did: string): Promise<{
   return (await res.json()) as {
     did: string
     enrolled: boolean
+    eligible?: boolean
     active?: boolean
     enrolledAt?: string
     enrollmentRkey?: string

--- a/test/scripts/test-enrollment.ts
+++ b/test/scripts/test-enrollment.ts
@@ -212,9 +212,24 @@ async function run() {
       // DIDs report `enrolled: false, eligible: true`). Requiring
       // enrollmentRkey too keeps the skip robust against older servers.
       if (status?.enrolled && status.enrollmentRkey) {
-        pass(`${userDef.name} already enrolled — OAuth skipped`, userState.did)
-        userState.enrolled = true
-        continue
+        // A service row alone does not prove the enrollment. Check the PDS
+        // record before we skip OAuth. A stale row would otherwise hide a
+        // missing record, and this phase would report a pass it never checked.
+        const existing = await findPdsEnrollmentRkey(
+          userState.did,
+          status.enrollmentRkey,
+        )
+        if (existing.found) {
+          pass(
+            `${userDef.name} already enrolled — OAuth skipped`,
+            userState.did,
+          )
+          userState.enrolled = true
+          continue
+        }
+        info(
+          `${userDef.name} reports enrolled but the PDS record is missing — enrolling again`,
+        )
       }
 
       info(`Enrolling ${userDef.name} (${userState.handle})...`)

--- a/test/scripts/test-enrollment.ts
+++ b/test/scripts/test-enrollment.ts
@@ -7,8 +7,8 @@ import {
   chromium,
   type Page,
 } from 'npm:playwright@1.58.2'
-import { STRATOS_URL, TEST_USERS } from './lib/config.ts'
-import { enrollmentStatus } from './lib/stratos.ts'
+import { PDS_URL, STRATOS_URL, TEST_USERS } from './lib/config.ts'
+import { enrollmentStatus, listPdsRecords } from './lib/stratos.ts'
 import { loadState, saveState } from './lib/state.ts'
 import {
   fillSignInForm,
@@ -158,6 +158,32 @@ async function checkEnrollmentStatus(did: string) {
   }
 }
 
+/**
+ * Look up the user's `zone.stratos.actor.enrollment` records on the PDS and
+ * check whether one matches the rkey the status endpoint reported.
+ */
+async function findPdsEnrollmentRkey(
+  did: string,
+  expectedRkey: string,
+): Promise<{ found: boolean; rkeys: string[] }> {
+  try {
+    const listing = await listPdsRecords(
+      PDS_URL,
+      did,
+      'zone.stratos.actor.enrollment',
+    )
+    const rkeys = listing.records.map(
+      (record) => record.uri.split('/').pop() ?? '',
+    )
+    return { found: rkeys.includes(expectedRkey), rkeys }
+  } catch (err) {
+    error(`PDS listRecords failed for ${did}`, {
+      error: err instanceof Error ? err.message : String(err),
+    })
+    return { found: false, rkeys: [] }
+  }
+}
+
 async function run() {
   section('Phase 2: OAuth Enrollment')
 
@@ -182,10 +208,9 @@ async function run() {
       }
 
       const status = await checkEnrollmentStatus(userState.did)
-      // `enrolled: true` alone is ambiguous — the status endpoint reports
-      // eligible-but-not-yet-enrolled DIDs the same way (active: false, no
-      // rkey). Only an existing enrollment record (enrollmentRkey present)
-      // means OAuth has actually run and we can safely skip it.
+      // `enrolled: true` now means an enrollment row exists (eligible-only
+      // DIDs report `enrolled: false, eligible: true`). Requiring
+      // enrollmentRkey too keeps the skip robust against older servers.
       if (status?.enrolled && status.enrollmentRkey) {
         pass(`${userDef.name} already enrolled — OAuth skipped`, userState.did)
         userState.enrolled = true
@@ -214,19 +239,33 @@ async function run() {
       }
 
       const finalStatus = await checkEnrollmentStatus(userState.did)
-      // Require the enrollment record rkey — `enrolled` alone also covers
-      // eligible-but-not-enrolled DIDs (see the skip check above).
-      if (finalStatus?.enrolled && finalStatus.enrollmentRkey) {
-        userState.enrolled = true
-        pass(`${userDef.name} enrolled successfully`, userState.did)
-      } else {
+      // Require the enrollment record rkey — see the skip check above.
+      if (!finalStatus?.enrolled || !finalStatus.enrollmentRkey) {
         fail(
           `${userDef.name} enrollment — OAuth succeeded but no enrollment record`,
           `enrolled=${finalStatus?.enrolled ?? 'unknown'}, rkey=${
             finalStatus?.enrollmentRkey ?? 'none'
           }`,
         )
+        continue
       }
+
+      // Verify the real side effect in this phase: the enrollment record must
+      // exist on the user's PDS with the rkey the status endpoint reported.
+      const pdsRkey = await findPdsEnrollmentRkey(
+        userState.did,
+        finalStatus.enrollmentRkey,
+      )
+      if (!pdsRkey.found) {
+        fail(
+          `${userDef.name} enrollment — no matching PDS enrollment record`,
+          `expected rkey=${finalStatus.enrollmentRkey}, PDS has [${pdsRkey.rkeys.join(', ')}]`,
+        )
+        continue
+      }
+
+      userState.enrolled = true
+      pass(`${userDef.name} enrolled successfully`, userState.did)
     }
   } finally {
     await browser.close()

--- a/test/scripts/test-unenrollment.ts
+++ b/test/scripts/test-unenrollment.ts
@@ -50,12 +50,14 @@ async function run() {
     await unenroll(userState.did)
     pass('Unenrollment request succeeded')
 
-    // 3. Verify Stratos status
+    // 3. Verify Stratos status — unenroll hard-deletes the enrollment row,
+    // so the truthful contract state is enrolled: false (re-enrollment stays
+    // possible, which eligible reports separately).
     const statusAfter = await enrollmentStatus(userState.did)
-    if (statusAfter.active !== false) {
-      throw new Error('User is still active in Stratos after unenrollment')
+    if (statusAfter.enrolled) {
+      throw new Error('User is still enrolled in Stratos after unenrollment')
     }
-    pass('User is inactive in Stratos')
+    pass('User is no longer enrolled in Stratos')
 
     // 4. Verify PDS record deletion
     const recordAfter = await getEnrollmentRecord(userState.did)

--- a/webapp/src/lib/stratos.ts
+++ b/webapp/src/lib/stratos.ts
@@ -51,6 +51,8 @@ export interface StratosServiceStatus {
   eligible?: boolean
   enrolledAt?: string
   active?: boolean
+  /** The service-held signing key DID. Present only when enrolled. */
+  signingKey?: string
   enrollmentRkey?: string
 }
 

--- a/webapp/src/lib/stratos.ts
+++ b/webapp/src/lib/stratos.ts
@@ -48,8 +48,10 @@ export interface StratosEnrollment {
 
 export interface StratosServiceStatus {
   enrolled: boolean
+  eligible?: boolean
   enrolledAt?: string
   active?: boolean
+  enrollmentRkey?: string
 }
 
 /**


### PR DESCRIPTION
Closes #99.

## Summary

`zone.stratos.enrollment.status` reported a *failed* eligibility check as `eligible: false` — indistinguishable from an authoritative policy denial. A DID resolution error therefore told the caller "you may not enroll" when the truthful answer was "we could not determine that."

- Adds the `VerificationFailed` denial reason (`stratos-core/src/shared/errors.ts`).
- `validateEnrollment` now returns `VerificationFailed` when DID resolution *throws*, keeping it distinct from `DidNotResolved`, which means resolution succeeded and returned nothing.
- The status endpoint omits `eligible` entirely when the check cannot complete, and keeps an explicit `eligible: false` for a genuine denial.
- Lexicon and client docs updated to state that an absent `eligible` must not be read as a denial.

Contract follows Option A as agreed — the lexicon's own description of `enrolled` ("Whether the DID is enrolled in this Stratos service") already ratifies it.

## Verification

- `stratos-core` and `stratos-service` typecheck clean
- 37 tests pass across the four enrollment suites
- Scoped Stryker run covered the final state of the change

## Follow-ups (deliberately not in this PR)

- The `attestation` field on the status lexicon is deferred, as agreed.
- The root `codegen` script is broken; noted here rather than fixed, to keep this change scoped.
- The full-stack E2E was **not** run — the docker/ngrok stack was not available in this environment. Stating that explicitly rather than implying coverage.

🤖 Generated with Rommie Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enrollment status now reports whether unenrolled users are eligible.
  * Enrolled status includes active state and available enrollment metadata, including signing key details.
  * Enrollment verification failures are distinguished from policy-based denials.

* **Bug Fixes**
  * Corrected status reporting for eligible but unenrolled and deactivated enrollments.
  * Improved handling of DID resolution and eligibility-check failures.

* **Documentation**
  * Updated API documentation to describe enrollment responses, eligibility, metadata, and attestation conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->