### PR TITLE
Prove mixed-mode spaces interop and publish the #atproto key fragment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,13 +11,49 @@ through `zone.stratos.actor.enrollment` records.
 
 ### Key Concepts
 
-| Concept            | Description                                                                                                                                             |
-| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Boundary**       | Access control scope (e.g., "engineering", "leadership"). Records have boundaries; viewers must share at least one.                                     |
-| **Enrollment**     | User registration with a Stratos service via OAuth. Creates profile record on user's PDS.                                                               |
-| **Hydration**      | Clients or AppViews fetch Stratos-backed records and filter by viewer boundaries.                                                                       |
-| **Profile Record** | `zone.stratos.actor.enrollment` - published to user's PDS for endpoint discovery and enrollment verification.                                           |
-| **Sync Stream**    | `zone.stratos.sync.subscribeRecords` - actor-scoped WebSocket stream consumed by sync clients (the standalone `stratos-indexer` and `stratos-feedgen`). |
+| Concept            | Description                                                                                                                                                                                     |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Boundary**       | Access control scope (e.g., "engineering", "leadership"). Records have boundaries; viewers must share at least one.                                                                             |
+| **Enrollment**     | User registration with a Stratos service via OAuth. Creates profile record on user's PDS.                                                                                                       |
+| **Hydration**      | Clients or AppViews fetch Stratos-backed records and filter by viewer boundaries.                                                                                                               |
+| **Profile Record** | `zone.stratos.actor.enrollment` - published to user's PDS for endpoint discovery and enrollment verification.                                                                                   |
+| **Sync Stream**    | `zone.stratos.sync.subscribeRecords` - actor-scoped WebSocket stream consumed by sync clients (the standalone `stratos-indexer` and `stratos-feedgen`).                                         |
+| **Custody**        | Which party holds a user's records. `stratos` = Stratos hosts the repo and signs. `pds` = the user's own spaces-capable PDS hosts the repo and the user signs.                                  |
+| **Space**          | An upstream permissioned-data container (proposal 0016). Stratos is always the space **authority**. For a `pds`-custody user it is only the authority, and the user's PDS is the repo **host**. |
+
+### Mixed-mode custody
+
+Stratos supports two custody classes at once. Read the class before you change
+any write, sync, or boundary code.
+
+| User's PDS     | Custody   | Repo host          | Who signs                    |
+| -------------- | --------- | ------------------ | ---------------------------- |
+| non-spaces     | `stratos` | Stratos            | Stratos, per-actor P-256 key |
+| spaces-capable | `pds`     | the user's own PDS | the user                     |
+
+Three rules follow. They are load-bearing, and each was proven against the
+upstream alpha PDS rather than read from the spec.
+
+1. **Never trust a boundary on a `pds`-custody record.** A repo host does not
+   authorize writes against the space authority. Any account can write records
+   into a Stratos-owned space URI in its own repo. A boundary on such a record is
+   a user-supplied claim. Always re-derive the boundary from Stratos enrollment
+   state. See `stratos-feedgen/src/subscription/indexer.ts` for the ingest path.
+2. **Membership decides whose repo the syncer reads.** It is the only write-side
+   control that exists. Removing a member does not stop them writing; it stops us
+   reading. The syncer iterates the member list. Do not add writer discovery.
+3. **A space record URI has seven segments and starts with the authority**:
+   `at://{authorityDid}/space/{type}/{skey}/{authorDid}/{collection}/{rkey}`.
+   A custody record keeps the familiar `at://{authorDid}/{collection}/{rkey}`.
+   Code that takes the first segment as the author is wrong for a space record.
+
+`zone.stratos.space.feed` must stay published as a `com.atproto.lexicon.schema`
+record with `defs.main.type` of `space`. A user's PDS resolves that NSID before
+it grants a space scope. If the record is missing, authorization fails with
+`invalid_scope`, and nothing in the Stratos logs explains why.
+
+Interop regression scripts live in `test/spike/spaces/`. Run them when you change
+credentials, host discovery, or ingest.
 
 ### Packages
 
@@ -442,6 +478,42 @@ When modifying `stratos-client/` exports or XRPC endpoints, update `stratos-clie
 
 Minimal comments. Only explain _why_, not _what_. Never generate: commented-out code, restated
 JSDoc, section divider comments (`// ====`), or TODOs without issue refs.
+
+---
+
+## Commit and Pull Request Guidelines
+
+**Do not copy the tone of the existing git history.** An agent wrote much of it.
+It is not a sample of the maintainer's voice.
+
+Write in the maintainer's voice, inside the Simplified Technical English rules.
+The two fit together like this.
+
+The rules, which are not negotiable: imperative mood, present tense, one idea per
+sentence, 20 words or fewer per sentence, the same word for the same thing every
+time, no idiom and no metaphor.
+
+The voice, which comes from how the maintainer writes:
+
+- Say the decision flatly. "Error ordering is fine for beta." Not "it may be
+  worth considering whether error ordering is acceptable".
+- Give the reason in the same breath, and keep it to one short sentence. State a
+  general principle when there is one.
+- Use "we" for a product or team decision. Use the imperative for an instruction.
+- Use plain domain words: boundary, custody, spaces PDS, feedgen, sync, enroll,
+  flow. Do not reach for a longer word.
+- No hedging, no pleasantries, no emphasis markup, no filler.
+- Name the concrete thing that changed. Do not restate the diff.
+
+Mechanics:
+
+- Subject line: sentence case. Use a `fix:`, `chore:`, or `ci:` prefix for
+  infrastructure. Use a plain imperative for a behaviour change.
+- Add a body only when the reason is not evident from the subject.
+- **Do not add a `Co-Authored-By` trailer.**
+
+Stack dependent pull requests with the `gh-stack` extension. Open the stack once
+the work is complete, not one PR at a time.
 
 ---
 

--- a/stratos-service/src/index.ts
+++ b/stratos-service/src/index.ts
@@ -28,6 +28,7 @@ import { registerHandlers } from './api'
 import { registerSubscribeRecords } from './subscription'
 import { createAdminAuthRoutes, createOAuthRoutes } from './oauth'
 import { DiskBlobStore, S3BlobStoreAdapter } from './infra/blobstore'
+import { SPACE_CREDENTIAL_KID } from './infra/auth/space-credential-verifier.js'
 import { signAndPersistCommit, StratosBlockStoreReader } from './features'
 import { reconcileServiceEnrollments } from './features/enrollment'
 
@@ -284,20 +285,35 @@ export class StratosServer {
       const serviceEndpoint = cfg.service.publicUrl
       const publicKeyMultibase = ctx.signingDidKey.slice('did:key:'.length)
 
+      // A foreign spaces PDS accepts only the `#atproto` or `#atproto_space`
+      // key fragment when it verifies a space credential. Publish `#atproto`
+      // as well, so a foreign host can verify credentials that this service
+      // mints. Both entries carry the same key.
+      const verificationMethod = [
+        {
+          id: `${serviceDid}#${cfg.service.serviceFragment}`,
+          type: 'Multikey',
+          controller: serviceDid,
+          publicKeyMultibase,
+        },
+      ]
+      const spaceKeyFragment = SPACE_CREDENTIAL_KID.slice('#'.length)
+      if (cfg.service.serviceFragment !== spaceKeyFragment) {
+        verificationMethod.push({
+          id: `${serviceDid}#${spaceKeyFragment}`,
+          type: 'Multikey',
+          controller: serviceDid,
+          publicKeyMultibase,
+        })
+      }
+
       res.json({
         '@context': [
           'https://www.w3.org/ns/did/v1',
           'https://w3id.org/security/multikey/v1',
         ],
         id: serviceDid,
-        verificationMethod: [
-          {
-            id: `${serviceDid}#${cfg.service.serviceFragment}`,
-            type: 'Multikey',
-            controller: serviceDid,
-            publicKeyMultibase,
-          },
-        ],
+        verificationMethod,
         service: [
           {
             id: '#stratos',

--- a/test/docker-compose.spaces.yml
+++ b/test/docker-compose.spaces.yml
@@ -1,0 +1,40 @@
+# Spike-only: the upstream alpha "spaces" PDS.
+#
+# Usage:
+#   docker compose -f docker-compose.spaces.yml up -d
+#
+# The PDS runs on the host network on purpose. The upstream did:web resolver
+# downgrades to plain HTTP only when the host is literally `localhost`
+# (packages/identity/src/did/web-resolver.ts). Host networking therefore lets
+# the PDS resolve `did:web:localhost%3A3100` to a Stratos on the host, with no
+# TLS and no tunnel.
+#
+# Image tag comes from the upstream workflow at commit 89deb9fac.
+services:
+  pds-spaces:
+    image: ghcr.io/bluesky-social/atproto:pds-spaces-alpha
+    container_name: stratos-spike-pds-spaces
+    restart: 'no'
+    network_mode: host
+    # The image runs as `node`, but a fresh named volume is owned by root, so
+    # the PDS cannot create its SQLite files. Root is acceptable here because
+    # this container is throwaway spike infrastructure.
+    user: '0:0'
+    environment:
+      PDS_PORT: 3010
+      PDS_HOSTNAME: localhost
+      PDS_DATA_DIRECTORY: /pds
+      PDS_BLOBSTORE_DISK_LOCATION: /pds/blocks
+      PDS_JWT_SECRET: spike-jwt-secret-do-not-use-outside-tests
+      PDS_ADMIN_PASSWORD: spike-admin
+      # Deterministic so a spike script can re-derive the DID without a restart.
+      PDS_PLC_ROTATION_KEY_K256_PRIVATE_KEY_HEX: 3ee7e0ba1e6b6b1a8b0d8e4f7a2c9d1e5f8a3b6c9d2e5f8a1b4c7d0e3f6a9b2c
+      PDS_DEV_MODE: 'true'
+      PDS_SERVICE_HANDLE_DOMAINS: .spike.test
+      LOG_ENABLED: 'true'
+      LOG_LEVEL: info
+    volumes:
+      - pds-spaces-data:/pds
+
+volumes:
+  pds-spaces-data:

--- a/test/spike/spaces/a2-foreign-credential.ts
+++ b/test/spike/spaces/a2-foreign-credential.ts
@@ -137,8 +137,7 @@ async function main() {
     // verified the credential if a BAD credential gets a different answer.
     // Flip one signature character to keep the shape and break the signature.
     const lastChar = credential.slice(-1)
-    const tampered =
-      credential.slice(0, -1) + (lastChar === 'A' ? 'B' : 'A')
+    const tampered = credential.slice(0, -1) + (lastChar === 'A' ? 'B' : 'A')
     const controlProof = await createDpopProof(dpopKey, {
       htm: 'GET',
       htu: url.toString(),

--- a/test/spike/spaces/a2-foreign-credential.ts
+++ b/test/spike/spaces/a2-foreign-credential.ts
@@ -1,0 +1,227 @@
+/**
+ * Spike A2 — does the upstream alpha spaces PDS accept a space credential that
+ * Stratos minted?
+ *
+ * This is the primary risk in the mixed-mode design. Stratos is the space
+ * AUTHORITY and a foreign PDS is the repo HOST. The host must verify a
+ * Stratos-signed credential against the Stratos DID document, with no contact
+ * back to Stratos.
+ *
+ * The script:
+ *   1. Makes a Secp256k1 authority key and serves a `did:web` document for it,
+ *      in the same shape that `stratos-service/src/index.ts` now serves.
+ *   2. Mints a credential with the REAL minter, so the wire shape under test is
+ *      the shipped one.
+ *   3. Builds an ES256 DPoP proof the way upstream `packages/space/src/dpop.ts`
+ *      does, and calls `com.atproto.space.getRecord` on the alpha PDS.
+ *
+ * PASS = any non-auth error, such as a missing space or repo. That proves the
+ * host verified the credential and moved on to look for data.
+ * FAIL = an auth error. That kills the design as drawn.
+ *
+ * Run: pnpm exec tsx test/spike/spaces/a2-foreign-credential.ts
+ */
+import { createServer } from 'node:http'
+import { createHash, randomBytes } from 'node:crypto'
+import { Secp256k1Keypair } from '@atproto/crypto'
+import { JoseKey } from '@atproto/jwk-jose'
+import { mintSpaceCredential } from '../../../stratos-service/src/features/space-credential/minter.js'
+
+const DID_DOC_PORT = 3100
+const PDS_URL = 'http://localhost:3010'
+// The upstream did:web resolver rewrites https to http only for `localhost`,
+// so the authority must be addressed by that exact hostname.
+const AUTHORITY_DID = `did:web:localhost%3A${DID_DOC_PORT}`
+
+// Mirrors the `#atproto_pns` default in stratos-service/src/config.ts.
+const LEGACY_FRAGMENT = 'atproto_pns'
+const SPACE_FRAGMENT = 'atproto'
+
+const log = (step: string, detail: unknown) =>
+  console.log(`\n── ${step}\n`, detail)
+
+async function main() {
+  const authorityKey = await Secp256k1Keypair.create({ exportable: true })
+  const publicKeyMultibase = authorityKey.did().slice('did:key:'.length)
+
+  // Step 1 — serve the DID document exactly as stratos-service now builds it.
+  const didDoc = {
+    '@context': [
+      'https://www.w3.org/ns/did/v1',
+      'https://w3id.org/security/multikey/v1',
+    ],
+    id: AUTHORITY_DID,
+    verificationMethod: [
+      {
+        id: `${AUTHORITY_DID}#${LEGACY_FRAGMENT}`,
+        type: 'Multikey',
+        controller: AUTHORITY_DID,
+        publicKeyMultibase,
+      },
+      {
+        id: `${AUTHORITY_DID}#${SPACE_FRAGMENT}`,
+        type: 'Multikey',
+        controller: AUTHORITY_DID,
+        publicKeyMultibase,
+      },
+    ],
+    service: [
+      {
+        id: '#stratos',
+        type: 'StratosService',
+        serviceEndpoint: `http://localhost:${DID_DOC_PORT}`,
+      },
+    ],
+  }
+
+  let didDocRequests = 0
+  const server = createServer((req, res) => {
+    if (req.url === '/.well-known/did.json') {
+      didDocRequests += 1
+      res.setHeader('content-type', 'application/did+ld+json')
+      res.end(JSON.stringify(didDoc))
+      return
+    }
+    res.statusCode = 404
+    res.end('not found')
+  })
+  await new Promise<void>((resolve) =>
+    server.listen(DID_DOC_PORT, '0.0.0.0', resolve),
+  )
+  log('authority DID document served', {
+    did: AUTHORITY_DID,
+    alg: authorityKey.jwtAlg,
+    fragments: didDoc.verificationMethod.map((v) => v.id),
+  })
+
+  try {
+    // Step 2 — DPoP key and the real minter.
+    const dpopKey = await JoseKey.generate(['ES256'])
+    const jkt = await dpopThumbprint(dpopKey)
+    const spaceUri = `at://${AUTHORITY_DID}/space/zone.stratos.space.feed/spike`
+
+    const { credential, payload } = await mintSpaceCredential({
+      signingKey: authorityKey,
+      issuerDid: AUTHORITY_DID,
+      spaceUri,
+      ttlSeconds: 300,
+      jkt,
+    })
+    log('credential minted by the real Stratos minter', payload)
+
+    // Step 3 — call the foreign host.
+    const url = new URL(`${PDS_URL}/xrpc/com.atproto.space.getRecord`)
+    url.searchParams.set('space', spaceUri)
+    url.searchParams.set('repo', AUTHORITY_DID)
+    url.searchParams.set('collection', 'zone.stratos.feed.post')
+    url.searchParams.set('rkey', 'spike')
+
+    const proof = await createDpopProof(dpopKey, {
+      htm: 'GET',
+      htu: url.toString(),
+      credential,
+    })
+
+    const res = await fetch(url, {
+      method: 'GET',
+      headers: {
+        authorization: `DPoP ${credential}`,
+        dpop: proof,
+      },
+    })
+    const body = await res.text()
+
+    log('foreign PDS response', { status: res.status, body })
+
+    // Negative control. A "repo not found" answer only proves the host
+    // verified the credential if a BAD credential gets a different answer.
+    // Flip one signature character to keep the shape and break the signature.
+    const lastChar = credential.slice(-1)
+    const tampered =
+      credential.slice(0, -1) + (lastChar === 'A' ? 'B' : 'A')
+    const controlProof = await createDpopProof(dpopKey, {
+      htm: 'GET',
+      htu: url.toString(),
+      credential: tampered,
+    })
+    const controlRes = await fetch(url, {
+      method: 'GET',
+      headers: {
+        authorization: `DPoP ${tampered}`,
+        dpop: controlProof,
+      },
+    })
+    const controlBody = await controlRes.text()
+    log('negative control — tampered signature', {
+      status: controlRes.status,
+      body: controlBody,
+    })
+
+    const authFailure = res.status === 401
+    const controlRejected = controlRes.status === 401
+    console.log(`\n${'='.repeat(60)}`)
+    console.log(`DID document fetched by the PDS: ${didDocRequests} time(s)`)
+    if (didDocRequests === 0) {
+      console.log(
+        'RESULT: INCONCLUSIVE — the PDS never fetched the authority document.',
+      )
+    } else if (authFailure) {
+      console.log('RESULT: FAIL — the host rejected the credential.')
+    } else if (!controlRejected) {
+      console.log(
+        'RESULT: INCONCLUSIVE — a tampered credential got the same answer, ' +
+          'so the endpoint answers before it checks auth.',
+      )
+    } else {
+      console.log(
+        'RESULT: PASS — the host verified the credential and looked for data. ' +
+          'A tampered credential is rejected, so auth really ran.',
+      )
+    }
+    console.log('='.repeat(60))
+  } finally {
+    server.close()
+  }
+}
+
+/** SHA-256 JWK thumbprint of the DPoP key, per RFC 9449. */
+async function dpopThumbprint(key: JoseKey): Promise<string> {
+  const jwk = key.bareJwk
+  if (!jwk) throw new Error('DPoP key has no public JWK')
+  // RFC 7638 requires the canonical member order for an EC key.
+  const canonical = JSON.stringify({
+    crv: jwk.crv,
+    kty: jwk.kty,
+    x: jwk.x,
+    y: jwk.y,
+  })
+  return createHash('sha256').update(canonical).digest('base64url')
+}
+
+/** Mirrors createDpopProof in upstream packages/space/src/dpop.ts. */
+async function createDpopProof(
+  key: JoseKey,
+  opts: { htm: string; htu: string; credential?: string },
+): Promise<string> {
+  const parsed = new URL(opts.htu)
+  const claims: Record<string, unknown> = {
+    jti: randomBytes(16).toString('hex'),
+    htm: opts.htm,
+    htu: parsed.origin + parsed.pathname,
+    iat: Math.floor(Date.now() / 1000),
+  }
+  if (opts.credential !== undefined) {
+    claims.ath = createHash('sha256')
+      .update(opts.credential)
+      .digest('base64url')
+  }
+  return key.createJwt(
+    { alg: 'ES256', typ: 'dpop+jwt', jwk: key.bareJwk },
+    claims,
+  )
+}
+
+main().catch((err) => {
+  console.error('spike failed:', err)
+  process.exitCode = 1
+})

--- a/test/spike/spaces/a3-feedgen-delegation.ts
+++ b/test/spike/spaces/a3-feedgen-delegation.ts
@@ -1,0 +1,135 @@
+/**
+ * Spike A3 — can the feed generator's `did:web` self-mint a delegation token
+ * that Stratos accepts?
+ *
+ * The feedgen has a `did:web` and no PDS, so it cannot use
+ * `com.atproto.space.getDelegationToken`, which is the PDS convenience for
+ * accounts whose key the PDS custodies. Upstream places no DID-method limit on
+ * a delegation issuer, so the feedgen should be able to sign its own token.
+ *
+ * This drives the REAL Stratos verifier, `verifyDelegationToken`, against a
+ * token signed by a `did:web` key whose document the script serves. It answers
+ * the kill criterion directly: does Stratos reject a `did:web` issuer?
+ *
+ * Run from stratos-service: pnpm exec tsx ../test/spike/spaces/a3-feedgen-delegation.ts
+ */
+import { createServer } from 'node:http'
+import { randomUUID } from 'node:crypto'
+import { Secp256k1Keypair } from '@atproto/crypto'
+import { IdResolver } from '@atproto/identity'
+import {
+  ATPROTO_KID,
+  verifyDelegationToken,
+} from '../../../stratos-service/src/infra/auth/delegation-verifier.js'
+
+const FEEDGEN_PORT = 3200
+const FEEDGEN_DID = `did:web:localhost%3A${FEEDGEN_PORT}`
+// Stratos is the space authority. It is not booted here; only its DID string
+// matters, because the verifier compares `sub`/`aud` against it.
+const STRATOS_DID = 'did:web:localhost%3A3100'
+const DELEGATION_TYP = 'atproto-space-delegation+jwt'
+
+const b64urlJson = (v: unknown) =>
+  Buffer.from(JSON.stringify(v)).toString('base64url')
+
+const log = (step: string, detail: unknown) =>
+  console.log(`\n── ${step}\n`, detail)
+
+async function main() {
+  // The feedgen signs with a Secp256k1 key (stratos-feedgen/src/bin/main.ts:23)
+  // and publishes `#atproto` (stratos-feedgen/src/server.ts:69).
+  const feedgenKey = await Secp256k1Keypair.create({ exportable: true })
+  const publicKeyMultibase = feedgenKey.did().slice('did:key:'.length)
+
+  const didDoc = {
+    '@context': [
+      'https://www.w3.org/ns/did/v1',
+      'https://w3id.org/security/multikey/v1',
+    ],
+    id: FEEDGEN_DID,
+    verificationMethod: [
+      {
+        id: `${FEEDGEN_DID}#atproto`,
+        type: 'Multikey',
+        controller: FEEDGEN_DID,
+        publicKeyMultibase,
+      },
+    ],
+    service: [
+      {
+        id: '#stratos_feedgen',
+        type: 'NorthskyStratosFeedGen',
+        serviceEndpoint: `http://localhost:${FEEDGEN_PORT}`,
+      },
+    ],
+  }
+
+  const server = createServer((req, res) => {
+    if (req.url === '/.well-known/did.json') {
+      res.setHeader('content-type', 'application/did+ld+json')
+      res.end(JSON.stringify(didDoc))
+      return
+    }
+    res.statusCode = 404
+    res.end('not found')
+  })
+  await new Promise<void>((resolve) =>
+    server.listen(FEEDGEN_PORT, '0.0.0.0', resolve),
+  )
+  log('feedgen DID document served', {
+    did: FEEDGEN_DID,
+    alg: feedgenKey.jwtAlg,
+  })
+
+  try {
+    const spaceUri = `at://${STRATOS_DID}/space/zone.stratos.space.feed/spike`
+    const now = Math.floor(Date.now() / 1000)
+    const header = {
+      typ: DELEGATION_TYP,
+      alg: feedgenKey.jwtAlg,
+      kid: ATPROTO_KID,
+    }
+    const payload = {
+      iss: FEEDGEN_DID,
+      sub: spaceUri,
+      aud: `${STRATOS_DID}#atproto_space_host`,
+      iat: now,
+      exp: now + 300,
+      jti: randomUUID(),
+    }
+    const signingInput = `${b64urlJson(header)}.${b64urlJson(payload)}`
+    const sig = await feedgenKey.sign(new TextEncoder().encode(signingInput))
+    const token = `${signingInput}.${Buffer.from(sig).toString('base64url')}`
+
+    log('self-minted delegation token', payload)
+
+    const idResolver = new IdResolver()
+    const result = await verifyDelegationToken(token, {
+      serviceDid: STRATOS_DID,
+      idResolver,
+    })
+
+    log('Stratos verifyDelegationToken accepted it', result)
+    console.log(`\n${'='.repeat(60)}`)
+    console.log(
+      'RESULT: PASS — Stratos accepts a did:web self-minted delegation token.',
+    )
+    console.log('='.repeat(60))
+  } catch (err) {
+    log('Stratos rejected the token', {
+      name: (err as Error).name,
+      message: (err as Error).message,
+    })
+    console.log(`\n${'='.repeat(60)}`)
+    console.log('RESULT: FAIL — Stratos rejects a did:web delegation issuer.')
+    console.log('='.repeat(60))
+    process.exitCode = 1
+  } finally {
+    server.close()
+  }
+}
+
+main().catch((err) => {
+  console.error('spike failed:', err)
+  process.exitCode = 1
+})

--- a/test/spike/spaces/a4-host-discovery.ts
+++ b/test/spike/spaces/a4-host-discovery.ts
@@ -106,31 +106,50 @@ async function main() {
           : undefined
       },
     }
-    const spaceUri = 'at://did:web:localhost%3A3100/space/zone.stratos.space.feed/spike'
+    const spaceUri =
+      'at://did:web:localhost%3A3100/space/zone.stratos.space.feed/spike'
 
     const viaDoc = await resolveRepoHost(spaceUri, MEMBER_DID, {
-      overrides: { async get() { return undefined } },
+      overrides: {
+        async get() {
+          return undefined
+        },
+      },
       dids,
     })
     log('no override — resolved from the DID document', viaDoc)
 
     const viaOverride = await resolveRepoHost(spaceUri, MEMBER_DID, {
-      overrides: { async get() { return 'http://host.example:9999' } },
+      overrides: {
+        async get() {
+          return 'http://host.example:9999'
+        },
+      },
       dids,
     })
     log('override present — override wins', viaOverride)
 
-    const unknown = await resolveRepoHost(spaceUri, 'did:web:localhost%3A3999', {
-      overrides: { async get() { return undefined } },
-      dids,
-    })
+    const unknown = await resolveRepoHost(
+      spaceUri,
+      'did:web:localhost%3A3999',
+      {
+        overrides: {
+          async get() {
+            return undefined
+          },
+        },
+        dids,
+      },
+    )
     log('unresolvable member', unknown)
 
     // The resolved host must actually be reachable and be a spaces PDS.
     let reachable = false
     let spacesCapable = false
     if (viaDoc) {
-      const health = await fetch(`${viaDoc.host}/xrpc/_health`).catch(() => undefined)
+      const health = await fetch(`${viaDoc.host}/xrpc/_health`).catch(
+        () => undefined,
+      )
       reachable = health?.ok ?? false
       const probe = await fetch(
         `${viaDoc.host}/xrpc/com.atproto.space.getRecord`,

--- a/test/spike/spaces/a4-host-discovery.ts
+++ b/test/spike/spaces/a4-host-discovery.ts
@@ -1,0 +1,174 @@
+/**
+ * Spike A4 — repo-host discovery.
+ *
+ * Upstream does not say how a syncer finds WHICH host holds a member's repo
+ * for a space. `com.atproto.space.listRepos` returns only `{did, rev, hash}`,
+ * and no space lexicon or table carries a host field. Stratos therefore sets
+ * the convention:
+ *
+ *   1. An authority-recorded override, if Stratos has one for this member.
+ *   2. Otherwise the `#atproto_pds` service endpoint in the member's DID
+ *      document. This is the only convention upstream implies, though upstream
+ *      applies it to notify targets rather than to repo hosts.
+ *
+ * This script exercises both arms against served DID documents. The resolver
+ * below is the prototype for the pure module in `stratos-core/src/spaces/`.
+ *
+ * Run from stratos-service: pnpm exec tsx ../test/spike/spaces/a4-host-discovery.ts
+ */
+import { createServer } from 'node:http'
+import { IdResolver } from '@atproto/identity'
+
+const MEMBER_PORT = 3300
+const MEMBER_DID = `did:web:localhost%3A${MEMBER_PORT}`
+const MEMBER_PDS = 'http://localhost:3010'
+
+/** How a repo host was determined. Worth surfacing in the admin interface. */
+export type HostSource = 'authority-override' | 'did-document'
+
+export interface ResolvedRepoHost {
+  host: string
+  source: HostSource
+}
+
+/** Reads a Stratos-recorded host override for a member of a space. */
+export interface HostOverrideReader {
+  get(spaceUri: string, memberDid: string): Promise<string | undefined>
+}
+
+/** Resolves the DID document service endpoint for a member. */
+export interface DidPdsReader {
+  getPdsEndpoint(memberDid: string): Promise<string | undefined>
+}
+
+/**
+ * Resolve the repo host for one member of one space.
+ *
+ * The override wins so an operator can correct a member whose repo does not
+ * live on the PDS named in their DID document.
+ */
+export async function resolveRepoHost(
+  spaceUri: string,
+  memberDid: string,
+  deps: { overrides: HostOverrideReader; dids: DidPdsReader },
+): Promise<ResolvedRepoHost | undefined> {
+  const override = await deps.overrides.get(spaceUri, memberDid)
+  if (override) return { host: override, source: 'authority-override' }
+
+  const endpoint = await deps.dids.getPdsEndpoint(memberDid)
+  if (endpoint) return { host: endpoint, source: 'did-document' }
+
+  return undefined
+}
+
+const log = (step: string, detail: unknown) =>
+  console.log(`\n── ${step}\n`, detail)
+
+async function main() {
+  const didDoc = {
+    '@context': ['https://www.w3.org/ns/did/v1'],
+    id: MEMBER_DID,
+    verificationMethod: [],
+    service: [
+      {
+        id: '#atproto_pds',
+        type: 'AtprotoPersonalDataServer',
+        serviceEndpoint: MEMBER_PDS,
+      },
+    ],
+  }
+
+  const server = createServer((req, res) => {
+    if (req.url === '/.well-known/did.json') {
+      res.setHeader('content-type', 'application/did+ld+json')
+      res.end(JSON.stringify(didDoc))
+      return
+    }
+    res.statusCode = 404
+    res.end('not found')
+  })
+  await new Promise<void>((resolve) =>
+    server.listen(MEMBER_PORT, '0.0.0.0', resolve),
+  )
+
+  try {
+    const idResolver = new IdResolver()
+    const dids: DidPdsReader = {
+      async getPdsEndpoint(did) {
+        // A member whose document will not resolve must yield "unknown host",
+        // never an exception. One unreachable member must not stop a sync pass.
+        const doc = await idResolver.did.resolve(did).catch(() => undefined)
+        const entry = doc?.service?.find(
+          (s) => s.id === '#atproto_pds' || s.id === `${did}#atproto_pds`,
+        )
+        return typeof entry?.serviceEndpoint === 'string'
+          ? entry.serviceEndpoint
+          : undefined
+      },
+    }
+    const spaceUri = 'at://did:web:localhost%3A3100/space/zone.stratos.space.feed/spike'
+
+    const viaDoc = await resolveRepoHost(spaceUri, MEMBER_DID, {
+      overrides: { async get() { return undefined } },
+      dids,
+    })
+    log('no override — resolved from the DID document', viaDoc)
+
+    const viaOverride = await resolveRepoHost(spaceUri, MEMBER_DID, {
+      overrides: { async get() { return 'http://host.example:9999' } },
+      dids,
+    })
+    log('override present — override wins', viaOverride)
+
+    const unknown = await resolveRepoHost(spaceUri, 'did:web:localhost%3A3999', {
+      overrides: { async get() { return undefined } },
+      dids,
+    })
+    log('unresolvable member', unknown)
+
+    // The resolved host must actually be reachable and be a spaces PDS.
+    let reachable = false
+    let spacesCapable = false
+    if (viaDoc) {
+      const health = await fetch(`${viaDoc.host}/xrpc/_health`).catch(() => undefined)
+      reachable = health?.ok ?? false
+      const probe = await fetch(
+        `${viaDoc.host}/xrpc/com.atproto.space.getRecord`,
+      ).catch(() => undefined)
+      // A spaces PDS validates params and reports the missing key. A plain PDS
+      // reports the method is not implemented.
+      const body = probe ? await probe.text() : ''
+      spacesCapable = body.includes('Missing required key')
+      log('reachability and capability probe', {
+        host: viaDoc.host,
+        reachable,
+        probeStatus: probe?.status,
+        probeBody: body.slice(0, 120),
+        spacesCapable,
+      })
+    }
+
+    const pass =
+      viaDoc?.source === 'did-document' &&
+      viaOverride?.source === 'authority-override' &&
+      unknown === undefined &&
+      reachable &&
+      spacesCapable
+
+    console.log(`\n${'='.repeat(60)}`)
+    console.log(
+      pass
+        ? 'RESULT: PASS — both arms resolve, and the host is a reachable spaces PDS.'
+        : 'RESULT: FAIL — see the steps above.',
+    )
+    console.log('='.repeat(60))
+    if (!pass) process.exitCode = 1
+  } finally {
+    server.close()
+  }
+}
+
+main().catch((err) => {
+  console.error('spike failed:', err)
+  process.exitCode = 1
+})

--- a/test/spike/spaces/a5-foreign-repo.ts
+++ b/test/spike/spaces/a5-foreign-repo.ts
@@ -1,0 +1,265 @@
+/**
+ * Spike A5 — write a record into a member's OWN PDS repo for a Stratos-owned
+ * space, then read it back as the syncer.
+ *
+ * This closes the mixed-mode loop on the read side. Stratos is the space
+ * AUTHORITY; the member's PDS is the repo HOST. The syncer holds only a
+ * credential the authority minted, and must be able to pull the member's ops
+ * from a host it does not control.
+ *
+ * The public alpha PDS must resolve the authority DID document, so the
+ * document is exposed through an ngrok tunnel and the authority DID is
+ * `did:web:<tunnel-host>`.
+ *
+ * Accounts come from ops/alpha-users.json, which stays outside this repo.
+ * Writes are deliberately minimal: one record.
+ *
+ * Run from stratos-service: pnpm exec tsx ../test/spike/spaces/a5-foreign-repo.ts
+ */
+import { createServer } from 'node:http'
+import { createHash, randomBytes } from 'node:crypto'
+import { readFileSync } from 'node:fs'
+import { config as loadEnv } from 'dotenv'
+import ngrok from '@ngrok/ngrok'
+import { Secp256k1Keypair } from '@atproto/crypto'
+import { JoseKey } from '@atproto/jwk-jose'
+import { mintSpaceCredential } from '../../../stratos-service/src/features/space-credential/minter.js'
+
+const REPO_ROOT = new URL('../../../', import.meta.url).pathname
+const ACCOUNTS_PATH = `${REPO_ROOT}../ops/alpha-users.json`
+const DID_DOC_PORT = 3400
+const SPACE_TYPE = 'zone.stratos.space.feed'
+const SPACE_SKEY = 'spike'
+const COLLECTION = 'zone.stratos.feed.post'
+
+loadEnv({ path: `${REPO_ROOT}.env` })
+
+const log = (step: string, detail: unknown) =>
+  console.log(`\n── ${step}\n`, detail)
+
+interface AlphaAccounts {
+  pds: string
+  accounts: { username: string; password: string }[]
+}
+
+async function main() {
+  const cfg = JSON.parse(
+    readFileSync(ACCOUNTS_PATH, 'utf8'),
+  ) as AlphaAccounts
+  const pdsUrl = `https://${cfg.pds}`
+  const account = cfg.accounts[0]
+  if (!account) throw new Error('no accounts in alpha-users.json')
+
+  // The authority key. In production this is the Stratos service signing key.
+  const authorityKey = await Secp256k1Keypair.create({ exportable: true })
+  const publicKeyMultibase = authorityKey.did().slice('did:key:'.length)
+
+  let didDoc: unknown
+  const server = createServer((req, res) => {
+    if (req.url === '/.well-known/did.json') {
+      res.setHeader('content-type', 'application/did+ld+json')
+      res.end(JSON.stringify(didDoc))
+      return
+    }
+    res.statusCode = 404
+    res.end('not found')
+  })
+  await new Promise<void>((resolve) =>
+    server.listen(DID_DOC_PORT, '127.0.0.1', resolve),
+  )
+
+  const listener = await ngrok.forward({
+    addr: DID_DOC_PORT,
+    authtoken: process.env.NGROK_AUTHTOKEN,
+    domain: process.env.NGROK_SERVICE_DOMAIN,
+  })
+  const tunnelUrl = listener.url()
+  if (!tunnelUrl) throw new Error('ngrok gave no URL')
+  const authorityHost = new URL(tunnelUrl).host
+  const AUTHORITY_DID = `did:web:${authorityHost}`
+
+  didDoc = {
+    '@context': [
+      'https://www.w3.org/ns/did/v1',
+      'https://w3id.org/security/multikey/v1',
+    ],
+    id: AUTHORITY_DID,
+    verificationMethod: [
+      {
+        id: `${AUTHORITY_DID}#atproto_pns`,
+        type: 'Multikey',
+        controller: AUTHORITY_DID,
+        publicKeyMultibase,
+      },
+      {
+        id: `${AUTHORITY_DID}#atproto`,
+        type: 'Multikey',
+        controller: AUTHORITY_DID,
+        publicKeyMultibase,
+      },
+    ],
+    service: [
+      { id: '#stratos', type: 'StratosService', serviceEndpoint: tunnelUrl },
+    ],
+  }
+  log('authority exposed', { AUTHORITY_DID, alg: authorityKey.jwtAlg })
+
+  const spaceUri = `at://${AUTHORITY_DID}/space/${SPACE_TYPE}/${SPACE_SKEY}`
+
+  try {
+    // 1. Session on the member's own PDS. A password session is not an OAuth
+    //    credential, so assertSpaceScope short-circuits (space/util.ts:93).
+    const sessionRes = await fetch(
+      `${pdsUrl}/xrpc/com.atproto.server.createSession`,
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          identifier: account.username,
+          password: account.password,
+        }),
+      },
+    )
+    const session = (await sessionRes.json()) as {
+      did?: string
+      accessJwt?: string
+      error?: string
+      message?: string
+    }
+    if (!sessionRes.ok || !session.accessJwt || !session.did) {
+      log('session failed', { status: sessionRes.status, body: session })
+      throw new Error('could not authenticate to the alpha PDS')
+    }
+    const memberDid = session.did
+    log('session established', { handle: account.username, did: memberDid })
+
+    // 2. Write into the member's OWN repo, in the Stratos-owned space.
+    const rkey = `spike${Date.now()}`
+    const writeRes = await fetch(
+      `${pdsUrl}/xrpc/com.atproto.space.createRecord`,
+      {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          authorization: `Bearer ${session.accessJwt}`,
+        },
+        body: JSON.stringify({
+          space: spaceUri,
+          repo: memberDid,
+          collection: COLLECTION,
+          rkey,
+          validate: false,
+          record: {
+            $type: COLLECTION,
+            text: 'mixed-mode spike: written to the member PDS',
+            createdAt: new Date().toISOString(),
+          },
+        }),
+      },
+    )
+    const written = await writeRes.json()
+    log('space createRecord on the member PDS', {
+      status: writeRes.status,
+      body: written,
+    })
+    if (!writeRes.ok) throw new Error('write to the member repo failed')
+
+    // 3. Read it back as the SYNCER, holding only an authority-minted
+    //    credential. This is the feedgen's position.
+    const dpopKey = await JoseKey.generate(['ES256'])
+    const jkt = await dpopThumbprint(dpopKey)
+    const { credential } = await mintSpaceCredential({
+      signingKey: authorityKey,
+      issuerDid: AUTHORITY_DID,
+      spaceUri,
+      ttlSeconds: 300,
+      jkt,
+    })
+
+    const opsUrl = new URL(`${pdsUrl}/xrpc/com.atproto.space.listRepoOps`)
+    opsUrl.searchParams.set('space', spaceUri)
+    opsUrl.searchParams.set('repo', memberDid)
+    const opsRes = await fetch(opsUrl, {
+      headers: {
+        authorization: `DPoP ${credential}`,
+        dpop: await createDpopProof(dpopKey, {
+          htm: 'GET',
+          htu: opsUrl.toString(),
+          credential,
+        }),
+      },
+    })
+    const ops = await opsRes.json()
+    log('listRepoOps as the syncer', { status: opsRes.status, body: ops })
+
+    const getUrl = new URL(`${pdsUrl}/xrpc/com.atproto.space.getRecord`)
+    getUrl.searchParams.set('space', spaceUri)
+    getUrl.searchParams.set('repo', memberDid)
+    getUrl.searchParams.set('collection', COLLECTION)
+    getUrl.searchParams.set('rkey', rkey)
+    const getRes = await fetch(getUrl, {
+      headers: {
+        authorization: `DPoP ${credential}`,
+        dpop: await createDpopProof(dpopKey, {
+          htm: 'GET',
+          htu: getUrl.toString(),
+          credential,
+        }),
+      },
+    })
+    const got = await getRes.json()
+    log('getRecord as the syncer', { status: getRes.status, body: got })
+
+    const pass = opsRes.ok && getRes.ok
+    console.log(`\n${'='.repeat(60)}`)
+    console.log(
+      pass
+        ? 'RESULT: PASS — the syncer read a member repo it does not host.'
+        : 'RESULT: FAIL — see the steps above.',
+    )
+    console.log('='.repeat(60))
+    if (!pass) process.exitCode = 1
+  } finally {
+    await listener.close().catch(() => {})
+    server.close()
+  }
+}
+
+async function dpopThumbprint(key: JoseKey): Promise<string> {
+  const jwk = key.bareJwk
+  if (!jwk) throw new Error('DPoP key has no public JWK')
+  const canonical = JSON.stringify({
+    crv: jwk.crv,
+    kty: jwk.kty,
+    x: jwk.x,
+    y: jwk.y,
+  })
+  return createHash('sha256').update(canonical).digest('base64url')
+}
+
+async function createDpopProof(
+  key: JoseKey,
+  opts: { htm: string; htu: string; credential?: string },
+): Promise<string> {
+  const parsed = new URL(opts.htu)
+  const claims: Record<string, unknown> = {
+    jti: randomBytes(16).toString('hex'),
+    htm: opts.htm,
+    htu: parsed.origin + parsed.pathname,
+    iat: Math.floor(Date.now() / 1000),
+  }
+  if (opts.credential !== undefined) {
+    claims.ath = createHash('sha256')
+      .update(opts.credential)
+      .digest('base64url')
+  }
+  return key.createJwt(
+    { alg: 'ES256', typ: 'dpop+jwt', jwk: key.bareJwk },
+    claims,
+  )
+}
+
+main().catch((err) => {
+  console.error('spike failed:', err)
+  process.exitCode = 1
+})

--- a/test/spike/spaces/a5-foreign-repo.ts
+++ b/test/spike/spaces/a5-foreign-repo.ts
@@ -43,9 +43,7 @@ interface AlphaAccounts {
 }
 
 async function main() {
-  const cfg = JSON.parse(
-    readFileSync(ACCOUNTS_PATH, 'utf8'),
-  ) as AlphaAccounts
+  const cfg = JSON.parse(readFileSync(ACCOUNTS_PATH, 'utf8')) as AlphaAccounts
   const pdsUrl = `https://${cfg.pds}`
   const account = cfg.accounts[0]
   if (!account) throw new Error('no accounts in alpha-users.json')

--- a/test/spike/spaces/a6-write-authorization.ts
+++ b/test/spike/spaces/a6-write-authorization.ts
@@ -1,0 +1,109 @@
+/**
+ * Spike A6 — does a repo host check space membership on WRITE?
+ *
+ * "We only ever use OAuth" answers whether OUR client is correctly scoped. It
+ * does not answer whether the host authorizes the write against the space
+ * authority. This script tests that directly: a second account writes into a
+ * space whose authority DID cannot be resolved at all and which has no member
+ * list anywhere.
+ *
+ * If the write succeeds, the host authorizes writes purely from the caller's
+ * own OAuth/session scope. Membership is then enforced only when a READER asks
+ * the authority for a credential. Stratos must therefore treat "a record is in
+ * this repo for my space" as an unverified claim until it checks its own
+ * membership and boundary state.
+ *
+ * Run from stratos-service: pnpm exec tsx ../test/spike/spaces/a6-write-authorization.ts
+ */
+import { readFileSync } from 'node:fs'
+
+const REPO_ROOT = new URL('../../../', import.meta.url).pathname
+const ACCOUNTS_PATH = `${REPO_ROOT}../ops/alpha-users.json`
+const COLLECTION = 'zone.stratos.feed.post'
+
+// Deliberately unresolvable: no DNS, no DID document, no member list.
+const UNRESOLVABLE_AUTHORITY = 'did:web:authority-that-does-not-exist.invalid'
+
+const log = (step: string, detail: unknown) =>
+  console.log(`\n── ${step}\n`, detail)
+
+interface AlphaAccounts {
+  pds: string
+  accounts: { username: string; password: string }[]
+}
+
+async function main() {
+  const cfg = JSON.parse(readFileSync(ACCOUNTS_PATH, 'utf8')) as AlphaAccounts
+  const pdsUrl = `https://${cfg.pds}`
+  // The SECOND account, unrelated to the A5 writer.
+  const account = cfg.accounts[1] ?? cfg.accounts[0]
+  if (!account) throw new Error('no accounts in alpha-users.json')
+
+  const sessionRes = await fetch(
+    `${pdsUrl}/xrpc/com.atproto.server.createSession`,
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        identifier: account.username,
+        password: account.password,
+      }),
+    },
+  )
+  const session = (await sessionRes.json()) as {
+    did?: string
+    accessJwt?: string
+  }
+  if (!sessionRes.ok || !session.accessJwt || !session.did) {
+    throw new Error('could not authenticate the second account')
+  }
+  log('second account session', {
+    handle: account.username,
+    did: session.did,
+  })
+
+  const spaceUri = `at://${UNRESOLVABLE_AUTHORITY}/space/zone.stratos.space.feed/nobody`
+  const res = await fetch(`${pdsUrl}/xrpc/com.atproto.space.createRecord`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      authorization: `Bearer ${session.accessJwt}`,
+    },
+    body: JSON.stringify({
+      space: spaceUri,
+      repo: session.did,
+      collection: COLLECTION,
+      rkey: `unauth${Date.now()}`,
+      validate: false,
+      record: {
+        $type: COLLECTION,
+        text: 'write-authorization probe',
+        createdAt: new Date().toISOString(),
+      },
+    }),
+  })
+  const body = await res.json()
+  log('write into an unresolvable, unowned space', {
+    space: spaceUri,
+    status: res.status,
+    body,
+  })
+
+  console.log(`\n${'='.repeat(60)}`)
+  if (res.ok) {
+    console.log(
+      'RESULT: the host does NOT authorize writes against the space authority.',
+    )
+    console.log(
+      'Presence of a record in a repo is NOT evidence of membership.',
+    )
+  } else {
+    console.log('RESULT: the host DID reject the write. Detail above.')
+  }
+  console.log('='.repeat(60))
+}
+
+main().catch((err) => {
+  console.error('spike failed:', err)
+  process.exitCode = 1
+})

--- a/test/spike/spaces/a6-write-authorization.ts
+++ b/test/spike/spaces/a6-write-authorization.ts
@@ -94,9 +94,7 @@ async function main() {
     console.log(
       'RESULT: the host does NOT authorize writes against the space authority.',
     )
-    console.log(
-      'Presence of a record in a repo is NOT evidence of membership.',
-    )
+    console.log('Presence of a record in a repo is NOT evidence of membership.')
   } else {
     console.log('RESULT: the host DID reject the write. Detail above.')
   }

--- a/test/spike/spaces/a6-write-authorization.ts
+++ b/test/spike/spaces/a6-write-authorization.ts
@@ -97,6 +97,9 @@ async function main() {
     console.log('Presence of a record in a repo is NOT evidence of membership.')
   } else {
     console.log('RESULT: the host DID reject the write. Detail above.')
+    // The whole mixed-mode boundary rule rests on this staying true. If a
+    // host starts authorizing writes, that is a finding, not a passing run.
+    process.exitCode = 1
   }
   console.log('='.repeat(60))
 }

--- a/test/spike/spaces/b1-oauth-space-scope.ts
+++ b/test/spike/spaces/b1-oauth-space-scope.ts
@@ -1,0 +1,165 @@
+/**
+ * Spike B1 — will a PDS accept an OAuth space scope?
+ *
+ * The webapp must ask a spaces user's own PDS for permission to write space
+ * records. This drives a Pushed Authorization Request, which is where a bad
+ * scope is rejected, so it needs no browser.
+ *
+ * It runs the same request against a spaces PDS and two ordinary ones. If only
+ * the spaces PDS accepts the scope, the PAR is a semantic capability probe and
+ * is far better than the error-ordering probe recorded in the plan.
+ *
+ * Run from stratos-service: pnpm exec tsx ../test/spike/spaces/b1-oauth-space-scope.ts
+ */
+const REDIRECT_URI = 'http://127.0.0.1:8080/callback'
+const AUTHORITY = 'did:web:stratos.test'
+const SPACE_TYPE = 'zone.stratos.space.feed'
+const COLLECTION = 'zone.stratos.feed.post'
+
+const SPACE_SCOPE =
+  `space:${SPACE_TYPE}` +
+  `?authority=${AUTHORITY}` +
+  `&skey=spike` +
+  `&collection=${COLLECTION}` +
+  `&action=create&action=read&action=update&action=delete`
+
+const HOSTS = [
+  { name: 'alpha spaces PDS', url: 'https://spaces-alpha.host.bsky.network' },
+  { name: 'bsky.social', url: 'https://bsky.social' },
+  { name: 'nihilist.cloud', url: 'https://nihilist.cloud' },
+]
+
+const log = (step: string, detail: unknown) =>
+  console.log(`\n── ${step}\n`, detail)
+
+/** Loopback client id, per the atproto OAuth profile for native clients. */
+function loopbackClientId(scope: string): string {
+  const params = new URLSearchParams({ redirect_uri: REDIRECT_URI, scope })
+  return `http://localhost?${params.toString()}`
+}
+
+async function par(
+  authServer: string,
+  scope: string,
+): Promise<{ status: number; body: unknown }> {
+  const meta = await fetch(
+    `${authServer}/.well-known/oauth-authorization-server`,
+  ).then(
+    (r) =>
+      r.json() as Promise<{ pushed_authorization_request_endpoint: string }>,
+  )
+
+  const clientId = loopbackClientId(scope)
+  const form = new URLSearchParams({
+    client_id: clientId,
+    redirect_uri: REDIRECT_URI,
+    response_type: 'code',
+    scope,
+    state: 'spike-state',
+    code_challenge: 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM',
+    code_challenge_method: 'S256',
+  })
+
+  const res = await fetch(meta.pushed_authorization_request_endpoint, {
+    method: 'POST',
+    headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    body: form.toString(),
+  })
+  let body: unknown
+  try {
+    body = await res.json()
+  } catch {
+    body = await res.text()
+  }
+  return { status: res.status, body }
+}
+
+async function main() {
+  log('space scope under test', SPACE_SCOPE)
+
+  const results: Record<string, { baseline: number; space: number }> = {}
+
+  for (const host of HOSTS) {
+    // Baseline: a scope every PDS understands, to separate "scope rejected"
+    // from "this client shape is rejected".
+    const baseline = await par(host.url, 'atproto').catch((e) => ({
+      status: -1,
+      body: String(e),
+    }))
+    const withSpace = await par(host.url, `atproto ${SPACE_SCOPE}`).catch(
+      (e) => ({ status: -1, body: String(e) }),
+    )
+
+    log(host.name, {
+      baselineStatus: baseline.status,
+      baselineBody: summarize(baseline.body),
+      spaceStatus: withSpace.status,
+      spaceBody: summarize(withSpace.body),
+    })
+    results[host.name] = {
+      baseline: baseline.status,
+      space: withSpace.status,
+    }
+  }
+
+  const alpha = results['alpha spaces PDS']
+  const others = HOSTS.slice(1).map((h) => results[h.name])
+
+  const alphaAccepts = alpha?.space === 201 || alpha?.space === 200
+  const othersReject = others.every(
+    (r) => r && r.space !== 201 && r.space !== 200,
+  )
+  const baselinesOk = [alpha, ...others].every(
+    (r) => r && (r.baseline === 201 || r.baseline === 200),
+  )
+
+  console.log(`\n${'='.repeat(64)}`)
+  console.log(`baselines all accepted:            ${baselinesOk}`)
+  console.log(`spaces PDS accepts space scope:    ${alphaAccepts}`)
+  console.log(`ordinary PDSs reject space scope:  ${othersReject}`)
+  if (baselinesOk && alphaAccepts && othersReject) {
+    console.log('RESULT: PASS — and PAR is a clean semantic capability probe.')
+  } else if (alphaAccepts) {
+    console.log(
+      'RESULT: PARTIAL — the scope works, but PAR does not discriminate.',
+    )
+  } else {
+    console.log('RESULT: FAIL — the spaces PDS did not accept the scope.')
+  }
+  console.log('='.repeat(64))
+}
+
+function summarize(body: unknown): string {
+  const s = typeof body === 'string' ? body : JSON.stringify(body)
+  return s.length > 220 ? `${s.slice(0, 220)}…` : s
+}
+
+main().catch((err) => {
+  console.error('spike failed:', err)
+  process.exitCode = 1
+})
+
+/**
+ * Follow-up probe: PAR only parks the request. The authorization endpoint is
+ * where an unsupported scope surfaces. Exported for the second-pass script.
+ */
+export async function probeAuthorize(
+  authServer: string,
+  scope: string,
+): Promise<{ status: number; location?: string; snippet: string }> {
+  const parsed = await par(authServer, scope)
+  const requestUri = (parsed.body as { request_uri?: string }).request_uri
+  if (!requestUri) {
+    return { status: parsed.status, snippet: summarize(parsed.body) }
+  }
+  const url = new URL(`${authServer}/oauth/authorize`)
+  url.searchParams.set('client_id', loopbackClientId(scope))
+  url.searchParams.set('request_uri', requestUri)
+  const res = await fetch(url, { redirect: 'manual' })
+  const text = await res.text().catch(() => '')
+  return {
+    status: res.status,
+    location: res.headers.get('location') ?? undefined,
+    snippet: text.slice(0, 300).replace(/\s+/g, ' '),
+  }
+}

--- a/test/spike/spaces/b1b-authorize-probe.ts
+++ b/test/spike/spaces/b1b-authorize-probe.ts
@@ -26,12 +26,22 @@ function loopbackClientId(scope: string): string {
 
 /** The provider renders errors into a JSON blob inside the HTML shell. */
 function extractError(html: string): string {
-  const hydration = html.match(
-    /__NEXT_HYDRATION_DATA__|"error"\s*:\s*"([^"]+)"/,
-  )
-  if (hydration?.[1]) {
-    const desc = html.match(/"error_description"\s*:\s*"([^"]+)"/)
-    return `${hydration[1]}${desc ? `: ${desc[1]}` : ''}`
+  // Parse the provider's error blob as one object. Two independent regexes
+  // can pair an `error` from one place with a `description` from another.
+  const blob = html.match(/window\["__errorData"\]=JSON\.parse\("(.*?)"\);/)
+  if (blob?.[1]) {
+    try {
+      const parsed: unknown = JSON.parse(JSON.parse(`"${blob[1]}"`))
+      if (typeof parsed === 'object' && parsed !== null) {
+        const { error, error_description: desc } = parsed as {
+          error?: string
+          error_description?: string
+        }
+        if (error) return desc ? `${error}: ${desc}` : error
+      }
+    } catch {
+      // Fall through to the title.
+    }
   }
   const title = html.match(/<title>([^<]*)<\/title>/)
   return title?.[1]?.trim() || html.slice(0, 160).replace(/\s+/g, ' ')

--- a/test/spike/spaces/b1b-authorize-probe.ts
+++ b/test/spike/spaces/b1b-authorize-probe.ts
@@ -1,0 +1,114 @@
+/**
+ * Spike B1b — does the AUTHORIZATION endpoint accept a space scope?
+ *
+ * A Pushed Authorization Request only parks the parameters; spike B1 showed
+ * every PDS returns 201 there, so PAR proves nothing. The authorization
+ * endpoint is where an unsupported scope is reported. This script reads the
+ * real error out of the response instead of judging by status code alone.
+ *
+ * Run from stratos-service: pnpm exec tsx ../test/spike/spaces/b1b-authorize-probe.ts
+ */
+const REDIRECT_URI = 'http://127.0.0.1:8080/callback'
+const SPACE_SCOPE =
+  'space:zone.stratos.space.feed?authority=did:web:stratos.test&skey=spike' +
+  '&collection=zone.stratos.feed.post&action=create&action=read'
+
+const HOSTS = [
+  ['alpha spaces PDS', 'https://spaces-alpha.host.bsky.network'],
+  ['bsky.social', 'https://bsky.social'],
+  ['nihilist.cloud', 'https://nihilist.cloud'],
+] as const
+
+function loopbackClientId(scope: string): string {
+  const params = new URLSearchParams({ redirect_uri: REDIRECT_URI, scope })
+  return `http://localhost?${params.toString()}`
+}
+
+/** The provider renders errors into a JSON blob inside the HTML shell. */
+function extractError(html: string): string {
+  const hydration = html.match(
+    /__NEXT_HYDRATION_DATA__|"error"\s*:\s*"([^"]+)"/,
+  )
+  if (hydration?.[1]) {
+    const desc = html.match(/"error_description"\s*:\s*"([^"]+)"/)
+    return `${hydration[1]}${desc ? `: ${desc[1]}` : ''}`
+  }
+  const title = html.match(/<title>([^<]*)<\/title>/)
+  return title?.[1]?.trim() || html.slice(0, 160).replace(/\s+/g, ' ')
+}
+
+async function probe(authServer: string, scope: string) {
+  const meta = (await fetch(
+    `${authServer}/.well-known/oauth-authorization-server`,
+  ).then((r) => r.json())) as {
+    pushed_authorization_request_endpoint: string
+    authorization_endpoint: string
+  }
+
+  const clientId = loopbackClientId(scope)
+  const parRes = await fetch(meta.pushed_authorization_request_endpoint, {
+    method: 'POST',
+    headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      client_id: clientId,
+      redirect_uri: REDIRECT_URI,
+      response_type: 'code',
+      scope,
+      state: 'spike',
+      code_challenge: 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM',
+      code_challenge_method: 'S256',
+    }).toString(),
+  })
+  const parBody = (await parRes.json()) as {
+    request_uri?: string
+    error?: string
+    error_description?: string
+  }
+  if (!parBody.request_uri) {
+    return {
+      stage: 'par',
+      status: parRes.status,
+      detail: `${parBody.error}: ${parBody.error_description}`,
+    }
+  }
+
+  const url = new URL(meta.authorization_endpoint)
+  url.searchParams.set('client_id', clientId)
+  url.searchParams.set('request_uri', parBody.request_uri)
+  const res = await fetch(url, { redirect: 'manual' })
+  const text = await res.text().catch(() => '')
+  return {
+    stage: 'authorize',
+    status: res.status,
+    detail: res.status >= 400 ? extractError(text) : 'rendered a consent page',
+  }
+}
+
+async function main() {
+  console.log('space scope:', SPACE_SCOPE, '\n')
+  for (const [name, url] of HOSTS) {
+    const base = await probe(url, 'atproto').catch((e) => ({
+      stage: 'error',
+      status: -1,
+      detail: String(e),
+    }))
+    const spaced = await probe(url, `atproto ${SPACE_SCOPE}`).catch((e) => ({
+      stage: 'error',
+      status: -1,
+      detail: String(e),
+    }))
+    console.log(`=== ${name}`)
+    console.log(
+      `  atproto only : [${base.stage} ${base.status}] ${base.detail}`,
+    )
+    console.log(
+      `  + space scope: [${spaced.stage} ${spaced.status}] ${spaced.detail}`,
+    )
+    console.log()
+  }
+}
+
+main().catch((err) => {
+  console.error('spike failed:', err)
+  process.exitCode = 1
+})

--- a/test/spike/spaces/b3-feedgen-foreign-ingest.ts
+++ b/test/spike/spaces/b3-feedgen-foreign-ingest.ts
@@ -1,0 +1,417 @@
+/**
+ * Spike B3 — the feed generator syncs a foreign spaces repo into its own index,
+ * alongside a Stratos-custody post, and serves them as one boundary feed.
+ *
+ * This is the mixed-mode proof from the syncer's seat. The feedgen holds only a
+ * credential the Stratos authority minted; the record it ingests lives on a PDS
+ * the feedgen does not control.
+ *
+ * It also demonstrates the boundary rule that spike A6 forced. A repo host does
+ * not authorize writes against the space authority, so the boundary on a spaces
+ * record is a user-supplied claim. The ingest below therefore takes the
+ * boundary from Stratos's member state and IGNORES any boundary on the record.
+ * Contrast `stratos-feedgen/src/subscription/indexer.ts:47`, which reads the
+ * boundary out of the record — correct today, unsafe for a spaces user.
+ *
+ * Run from stratos-feedgen: pnpm exec tsx ../test/spike/spaces/b3-feedgen-foreign-ingest.ts
+ */
+import { createServer } from 'node:http'
+import { createHash, randomBytes } from 'node:crypto'
+import { readFileSync, mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { config as loadEnv } from 'dotenv'
+import ngrok from '@ngrok/ngrok'
+import { webcrypto } from 'node:crypto'
+import { Secp256k1Keypair } from '@atproto/crypto'
+import {
+  createSqliteDb,
+  migrateSqliteDb,
+  SqliteFeedgenStore,
+} from '../../../stratos-feedgen/src/db/sqlite.js'
+
+const REPO_ROOT = new URL('../../../', import.meta.url).pathname
+const ACCOUNTS_PATH = `${REPO_ROOT}../ops/alpha-users.json`
+const DID_DOC_PORT = 3500
+const SPACE_TYPE = 'zone.stratos.space.feed'
+const SPACE_SKEY = 'spike'
+const COLLECTION = 'zone.stratos.feed.post'
+
+/**
+ * The boundary Stratos has assigned this member. In production this comes from
+ * the enrollment/boundary store, which is the ONLY authority for it.
+ */
+const STRATOS_ASSIGNED_BOUNDARY = 'did:web:stratos.test/engineering'
+
+loadEnv({ path: `${REPO_ROOT}.env` })
+
+const log = (step: string, detail: unknown) =>
+  console.log(`\n── ${step}\n`, detail)
+
+interface AlphaAccounts {
+  pds: string
+  accounts: { username: string; password: string }[]
+}
+
+async function main() {
+  const cfg = JSON.parse(readFileSync(ACCOUNTS_PATH, 'utf8')) as AlphaAccounts
+  const pdsUrl = `https://${cfg.pds}`
+  const account = cfg.accounts[0]
+  if (!account) throw new Error('no accounts in alpha-users.json')
+
+  const authorityKey = await Secp256k1Keypair.create({ exportable: true })
+  const publicKeyMultibase = authorityKey.did().slice('did:key:'.length)
+
+  let didDoc: unknown
+  const server = createServer((req, res) => {
+    if (req.url === '/.well-known/did.json') {
+      res.setHeader('content-type', 'application/did+ld+json')
+      res.end(JSON.stringify(didDoc))
+      return
+    }
+    res.statusCode = 404
+    res.end('not found')
+  })
+  await new Promise<void>((resolve) =>
+    server.listen(DID_DOC_PORT, '127.0.0.1', resolve),
+  )
+  const listener = await ngrok.forward({
+    addr: DID_DOC_PORT,
+    authtoken: process.env.NGROK_AUTHTOKEN,
+    domain: process.env.NGROK_SERVICE_DOMAIN,
+  })
+  const tunnelUrl = listener.url()
+  if (!tunnelUrl) throw new Error('ngrok gave no URL')
+  const AUTHORITY_DID = `did:web:${new URL(tunnelUrl).host}`
+  didDoc = {
+    '@context': [
+      'https://www.w3.org/ns/did/v1',
+      'https://w3id.org/security/multikey/v1',
+    ],
+    id: AUTHORITY_DID,
+    verificationMethod: [
+      {
+        id: `${AUTHORITY_DID}#atproto`,
+        type: 'Multikey',
+        controller: AUTHORITY_DID,
+        publicKeyMultibase,
+      },
+    ],
+    service: [
+      { id: '#stratos', type: 'StratosService', serviceEndpoint: tunnelUrl },
+    ],
+  }
+  const spaceUri = `at://${AUTHORITY_DID}/space/${SPACE_TYPE}/${SPACE_SKEY}`
+  log('authority exposed', { AUTHORITY_DID })
+
+  const dir = mkdtempSync(join(tmpdir(), 'feedgen-spike-'))
+  const db = createSqliteDb(join(dir, 'feedgen.sqlite'))
+  await migrateSqliteDb(db)
+  const store = new SqliteFeedgenStore(db)
+
+  try {
+    // 1. A spaces user writes into their OWN PDS, claiming a boundary they were
+    //    never granted. The host accepts it — see spike A6.
+    const sessionRes = await fetch(
+      `${pdsUrl}/xrpc/com.atproto.server.createSession`,
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          identifier: account.username,
+          password: account.password,
+        }),
+      },
+    )
+    const session = (await sessionRes.json()) as {
+      did?: string
+      accessJwt?: string
+    }
+    if (!session.accessJwt || !session.did) {
+      throw new Error('could not authenticate to the alpha PDS')
+    }
+    const memberDid = session.did
+
+    const rkey = `b3spike${Date.now()}`
+    const writeRes = await fetch(
+      `${pdsUrl}/xrpc/com.atproto.space.createRecord`,
+      {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          authorization: `Bearer ${session.accessJwt}`,
+        },
+        body: JSON.stringify({
+          space: spaceUri,
+          repo: memberDid,
+          collection: COLLECTION,
+          rkey,
+          validate: false,
+          record: {
+            $type: COLLECTION,
+            text: 'posted from a spaces PDS',
+            createdAt: new Date().toISOString(),
+            // A boundary the member is NOT entitled to. The ingest must drop it.
+            boundaries: ['did:web:stratos.test/leadership'],
+          },
+        }),
+      },
+    )
+    if (!writeRes.ok) {
+      log('write failed', await writeRes.json())
+      throw new Error('spaces write failed')
+    }
+    log('spaces user wrote to their own PDS', {
+      memberDid,
+      claimedBoundary: 'did:web:stratos.test/leadership',
+    })
+
+    // 2. The feedgen, as syncer, pulls that repo with an authority credential.
+    const dpopKey = await generateDpopKey()
+    const jkt = dpopThumbprint(dpopKey)
+    const credential = await mintCredential(
+      authorityKey,
+      AUTHORITY_DID,
+      spaceUri,
+      jkt,
+    )
+
+    const opsUrl = new URL(`${pdsUrl}/xrpc/com.atproto.space.listRepoOps`)
+    opsUrl.searchParams.set('space', spaceUri)
+    opsUrl.searchParams.set('repo', memberDid)
+    const opsRes = await fetch(opsUrl, {
+      headers: {
+        authorization: `DPoP ${credential}`,
+        dpop: await createDpopProof(dpopKey, {
+          htm: 'GET',
+          htu: opsUrl.toString(),
+          credential,
+        }),
+      },
+    })
+    // The op shape is {rev, collection, rkey, cid, prev, value?}. `cid` is null
+    // for a delete. `value` carries the record inline for creates and updates,
+    // so a separate getRecord call is only needed when it is absent.
+    const opsBody = (await opsRes.json()) as {
+      ops?: {
+        rev: string
+        collection: string
+        rkey: string
+        cid: string | null
+        prev: string | null
+        value?: Record<string, unknown>
+      }[]
+      commit?: { rev?: string }
+    }
+    log('listRepoOps', {
+      status: opsRes.status,
+      opCount: opsBody.ops?.length,
+      rev: opsBody.commit?.rev,
+      inlineValues: opsBody.ops?.filter((o) => o.value !== undefined).length,
+    })
+
+    // 3. Index. Boundary comes from Stratos state, not the record.
+    let ingested = 0
+    let hydrated = 0
+    for (const op of opsBody.ops ?? []) {
+      if (op.collection !== COLLECTION) continue
+      if (op.cid === null) continue // delete
+
+      let value = op.value
+      if (!value) {
+        const getUrl = new URL(`${pdsUrl}/xrpc/com.atproto.space.getRecord`)
+        getUrl.searchParams.set('space', spaceUri)
+        getUrl.searchParams.set('repo', memberDid)
+        getUrl.searchParams.set('collection', op.collection)
+        getUrl.searchParams.set('rkey', op.rkey)
+        const recRes = await fetch(getUrl, {
+          headers: {
+            authorization: `DPoP ${credential}`,
+            dpop: await createDpopProof(dpopKey, {
+              htm: 'GET',
+              htu: getUrl.toString(),
+              credential,
+            }),
+          },
+        })
+        if (!recRes.ok) continue
+        value = ((await recRes.json()) as { value: Record<string, unknown> })
+          .value
+        hydrated += 1
+      }
+
+      const createdAt =
+        typeof value.createdAt === 'string'
+          ? value.createdAt
+          : new Date().toISOString()
+
+      await store.upsertPost({
+        uri: `${spaceUri}/${memberDid}/${op.collection}/${op.rkey}`,
+        did: memberDid,
+        cid: op.cid,
+        sortAt: createdAt,
+        indexedAt: new Date().toISOString(),
+        record: value,
+        blobRefs: [],
+        // THE RULE: Stratos decides the boundary. The record does not.
+        boundaries: [STRATOS_ASSIGNED_BOUNDARY],
+      })
+      ingested += 1
+    }
+    log('ingested from the foreign host', { ingested, hydratedSeparately: hydrated })
+
+    // 4. A Stratos-custody post, indexed the way the feedgen does today.
+    const custodyUri = `at://did:plc:stratoscustodyuser/${COLLECTION}/local1`
+    await store.upsertPost({
+      uri: custodyUri,
+      did: 'did:plc:stratoscustodyuser',
+      cid: 'bafyreiacustodyplaceholdercidvalueforspikeonlyxxxxxxxxxxxxx',
+      sortAt: new Date(Date.now() - 60_000).toISOString(),
+      indexedAt: new Date().toISOString(),
+      record: {
+        $type: COLLECTION,
+        text: 'posted from Stratos custody',
+        createdAt: new Date(Date.now() - 60_000).toISOString(),
+      },
+      blobRefs: [],
+      boundaries: [STRATOS_ASSIGNED_BOUNDARY],
+    })
+
+    // 5. One boundary feed, both custody classes.
+    const feed = await store.listPostsByBoundary({
+      boundary: STRATOS_ASSIGNED_BOUNDARY,
+      limit: 20,
+    })
+    log('boundary feed', {
+      boundary: STRATOS_ASSIGNED_BOUNDARY,
+      posts: feed.posts.map((p) => ({
+        did: p.did,
+        text: (p.record as { text?: string }).text,
+      })),
+    })
+
+    // The claimed boundary must not have been honoured.
+    const leaked = await store.listPostsByBoundary({
+      boundary: 'did:web:stratos.test/leadership',
+      limit: 20,
+    })
+
+    // The member repo persists on the public PDS between runs, so assert on
+    // custody classes present rather than on an exact count.
+    const spacesPosts = feed.posts.filter((p) => p.did === memberDid).length
+    const custodyPosts = feed.posts.filter(
+      (p) => p.did === 'did:plc:stratoscustodyuser',
+    ).length
+    const bothPresent = spacesPosts > 0 && custodyPosts > 0
+    const noLeak = leaked.posts.length === 0
+    console.log(`\n${'='.repeat(60)}`)
+    console.log(
+      `mixed feed: ${spacesPosts} spaces-PDS post(s), ${custodyPosts} Stratos-custody post(s)`,
+    )
+    console.log(`claimed-but-ungranted boundary was dropped: ${noLeak}`)
+    console.log(
+      bothPresent && noLeak
+        ? 'RESULT: PASS — foreign ingest works and the boundary claim was ignored.'
+        : 'RESULT: FAIL — see above.',
+    )
+    console.log('='.repeat(60))
+    if (!bothPresent || !noLeak) process.exitCode = 1
+  } finally {
+    await listener.close().catch(() => {})
+    server.close()
+  }
+}
+
+async function mintCredential(
+  key: Secp256k1Keypair,
+  iss: string,
+  sub: string,
+  jkt: string,
+): Promise<string> {
+  const b64 = (v: unknown) =>
+    Buffer.from(JSON.stringify(v)).toString('base64url')
+  const iat = Math.floor(Date.now() / 1000)
+  const header = {
+    typ: 'atproto-space-credential+jwt',
+    alg: key.jwtAlg,
+    kid: '#atproto',
+  }
+  const payload = {
+    iss,
+    sub,
+    iat,
+    exp: iat + 300,
+    jti: randomBytes(16).toString('hex'),
+    cnf: { jkt },
+  }
+  const signingInput = `${b64(header)}.${b64(payload)}`
+  const sig = await key.sign(new TextEncoder().encode(signingInput))
+  return `${signingInput}.${Buffer.from(sig).toString('base64url')}`
+}
+
+/** An ES256 DPoP key made with webcrypto, so the feedgen needs no JOSE dep. */
+interface DpopKey {
+  privateKey: webcrypto.CryptoKey
+  jwk: { crv: string; kty: string; x: string; y: string }
+}
+
+async function generateDpopKey(): Promise<DpopKey> {
+  const pair = await webcrypto.subtle.generateKey(
+    { name: 'ECDSA', namedCurve: 'P-256' },
+    true,
+    ['sign', 'verify'],
+  )
+  const pub = (await webcrypto.subtle.exportKey('jwk', pair.publicKey)) as {
+    crv: string
+    kty: string
+    x: string
+    y: string
+  }
+  return {
+    privateKey: pair.privateKey,
+    jwk: { crv: pub.crv, kty: pub.kty, x: pub.x, y: pub.y },
+  }
+}
+
+/** RFC 7638 thumbprint. Member order is canonical for an EC key. */
+function dpopThumbprint(key: DpopKey): string {
+  const canonical = JSON.stringify({
+    crv: key.jwk.crv,
+    kty: key.jwk.kty,
+    x: key.jwk.x,
+    y: key.jwk.y,
+  })
+  return createHash('sha256').update(canonical).digest('base64url')
+}
+
+async function createDpopProof(
+  key: DpopKey,
+  opts: { htm: string; htu: string; credential?: string },
+): Promise<string> {
+  const b64 = (v: unknown) =>
+    Buffer.from(JSON.stringify(v)).toString('base64url')
+  const parsed = new URL(opts.htu)
+  const claims: Record<string, unknown> = {
+    jti: randomBytes(16).toString('hex'),
+    htm: opts.htm,
+    htu: parsed.origin + parsed.pathname,
+    iat: Math.floor(Date.now() / 1000),
+  }
+  if (opts.credential !== undefined) {
+    claims.ath = createHash('sha256')
+      .update(opts.credential)
+      .digest('base64url')
+  }
+  const signingInput = `${b64({ alg: 'ES256', typ: 'dpop+jwt', jwk: key.jwk })}.${b64(claims)}`
+  const sig = await webcrypto.subtle.sign(
+    { name: 'ECDSA', hash: 'SHA-256' },
+    key.privateKey,
+    new TextEncoder().encode(signingInput),
+  )
+  return `${signingInput}.${Buffer.from(sig).toString('base64url')}`
+}
+
+main().catch((err) => {
+  console.error('spike failed:', err)
+  process.exitCode = 1
+})

--- a/test/spike/spaces/b3-feedgen-foreign-ingest.ts
+++ b/test/spike/spaces/b3-feedgen-foreign-ingest.ts
@@ -258,7 +258,10 @@ async function main() {
       })
       ingested += 1
     }
-    log('ingested from the foreign host', { ingested, hydratedSeparately: hydrated })
+    log('ingested from the foreign host', {
+      ingested,
+      hydratedSeparately: hydrated,
+    })
 
     // 4. A Stratos-custody post, indexed the way the feedgen does today.
     const custodyUri = `at://did:plc:stratoscustodyuser/${COLLECTION}/local1`

--- a/test/spike/spaces/b3-feedgen-foreign-ingest.ts
+++ b/test/spike/spaces/b3-feedgen-foreign-ingest.ts
@@ -305,12 +305,14 @@ async function main() {
     const custodyPosts = feed.posts.filter(
       (p) => p.did === 'did:plc:stratoscustodyuser',
     ).length
-    const bothPresent = spacesPosts > 0 && custodyPosts > 0
+    const ownRecordIndexed = feed.posts.some((p) => p.uri.endsWith(`/${rkey}`))
+    const bothPresent = spacesPosts > 0 && custodyPosts > 0 && ownRecordIndexed
     const noLeak = leaked.posts.length === 0
     console.log(`\n${'='.repeat(60)}`)
     console.log(
       `mixed feed: ${spacesPosts} spaces-PDS post(s), ${custodyPosts} Stratos-custody post(s)`,
     )
+    console.log(`this run's own record indexed: ${ownRecordIndexed}`)
     console.log(`claimed-but-ungranted boundary was dropped: ${noLeak}`)
     console.log(
       bothPresent && noLeak

--- a/test/spike/spaces/b4-uri-shape.ts
+++ b/test/spike/spaces/b4-uri-shape.ts
@@ -1,0 +1,77 @@
+/**
+ * Spike B4 — does the existing read path survive a spaces record URI?
+ *
+ * A Stratos-custody record has the familiar three-part URI:
+ *   at://{authorDid}/{collection}/{rkey}
+ *
+ * A spaces record, as the alpha PDS returns it, is seven parts and starts with
+ * the space AUTHORITY, not the author:
+ *   at://{authorityDid}/space/{type}/{skey}/{authorDid}/{collection}/{rkey}
+ *
+ * `webapp/src/lib/feed.ts:133` derives the author by taking the first segment.
+ * That is correct for a custody record and wrong for a spaces record, where it
+ * yields the authority. This script demonstrates the failure against the real
+ * URI observed in spike A5, and checks the proposed fix.
+ *
+ * Run: pnpm exec tsx test/spike/spaces/b4-uri-shape.ts
+ */
+
+/** Copy of webapp/src/lib/feed.ts:133 as it stands today. */
+function authorFromUri(uri: string): string {
+  return uri.replace('at://', '').split('/')[0]
+}
+
+/**
+ * Proposed replacement. A space record URI carries the literal `space` segment
+ * in second position, and the author is the fifth segment.
+ */
+function authorFromUriFixed(uri: string): string {
+  const parts = uri.replace('at://', '').split('/')
+  if (parts[1] === 'space' && parts.length >= 7) return parts[4]
+  return parts[0]
+}
+
+// Observed verbatim in spike A5 against spaces-alpha.host.bsky.network.
+const SPACES_URI =
+  'at://did:web:melioristic-outspokenly-roselyn.ngrok-free.dev' +
+  '/space/zone.stratos.space.feed/spike' +
+  '/did:plc:atbnxlrciwofkeceaup75ty7/zone.stratos.feed.post/spike1787732940930'
+const CUSTODY_URI =
+  'at://did:plc:stratoscustodyuser/zone.stratos.feed.post/local1'
+
+const EXPECTED_SPACES_AUTHOR = 'did:plc:atbnxlrciwofkeceaup75ty7'
+const EXPECTED_CUSTODY_AUTHOR = 'did:plc:stratoscustodyuser'
+
+const cases = [
+  { name: 'spaces record', uri: SPACES_URI, expect: EXPECTED_SPACES_AUTHOR },
+  { name: 'custody record', uri: CUSTODY_URI, expect: EXPECTED_CUSTODY_AUTHOR },
+]
+
+console.log('current authorFromUri (webapp/src/lib/feed.ts:133)')
+let currentOk = true
+for (const c of cases) {
+  const got = authorFromUri(c.uri)
+  const ok = got === c.expect
+  if (!ok) currentOk = false
+  console.log(`  ${ok ? 'ok  ' : 'WRONG'} ${c.name}: ${got}`)
+}
+
+console.log('\nproposed authorFromUriFixed')
+let fixedOk = true
+for (const c of cases) {
+  const got = authorFromUriFixed(c.uri)
+  const ok = got === c.expect
+  if (!ok) fixedOk = false
+  console.log(`  ${ok ? 'ok  ' : 'WRONG'} ${c.name}: ${got}`)
+}
+
+console.log(`\n${'='.repeat(62)}`)
+console.log(`current helper handles both shapes: ${currentOk}`)
+console.log(`proposed helper handles both shapes: ${fixedOk}`)
+console.log(
+  !currentOk && fixedOk
+    ? 'RESULT: confirmed defect, and the proposed fix resolves it.'
+    : 'RESULT: unexpected — re-check the assumptions above.',
+)
+console.log('='.repeat(62))
+if (currentOk || !fixedOk) process.exitCode = 1

--- a/test/spike/spaces/node_modules
+++ b/test/spike/spaces/node_modules
@@ -1,0 +1,1 @@
+../../../stratos-feedgen/node_modules

--- a/test/spike/spaces/node_modules
+++ b/test/spike/spaces/node_modules
@@ -1,1 +1,0 @@
-../../../stratos-feedgen/node_modules


### PR DESCRIPTION
First of five stacked PRs adding **mixed-mode spaces support**: some users keep their records with Stratos as today, while users on a spaces-capable PDS host their own repo with Stratos acting only as the space authority.

## Why

We want Stratos to be the space authority while a member's own PDS hosts the repo. The upstream alpha PDS accepts that. This proves it and fixes the one thing that blocked it.

A foreign host verifies a space credential against our DID document, and it accepts only the `#atproto` or `#atproto_space` key fragment. We published `#atproto_pns`, so no host could verify us. The document now carries both, same key.

## What is proven

Each spike ran against the real alpha PDS, most of it against the public `spaces-alpha.host.bsky.network`.

| Spike | Result |
| --- | --- |
| A2 foreign host accepts a Stratos credential | valid → `400 RepoNotFound`, tampered → `401 BadJwtSignature` |
| A3 a PDS-less `did:web` self-mints a delegation token | accepted by the real verifier, unmodified |
| A4 repo-host discovery | both arms resolve, unresolvable member yields undefined |
| A5 write and read a foreign repo | `listRepoOps` and `getRecord` both 200 |
| A6 a host does not authorize writes | an unrelated account wrote into a space owned by an unresolvable DID |
| B3 the feedgen syncs a foreign repo | 3 ops ingested, boundary claim dropped |
| B4 record URI shape | the webapp credits every spaces post to Stratos |

A6 is the one that shapes the rest of the stack. A boundary on a record from a user's own PDS is a claim, not a fact.

## Scope

The spike scripts are throwaway. They stay because they record the exact request and response shapes the implementation must match, and they are the interop regression check.

`AGENTS.md` gains the mixed-mode concepts and the three load-bearing rules.

## Test plan

- [x] Lint, build, typecheck, and the unit suite pass
- [x] E2E 16/16 phases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance explaining custody models, space records, repository hosting, synchronization, authorization, and credential requirements.
  - Added contribution guidelines for commit messages and pull requests.

- **Interoperability**
  - Improved DID metadata so external hosts can verify space credentials issued by Stratos.
  - Added support coverage for mixed custody, foreign repositories, space scopes, authorization, host discovery, and seven-segment record URIs.

- **Testing**
  - Added end-to-end interoperability checks using an upstream Spaces PDS, including positive and negative credential, delegation, synchronization, and write-authorization scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
