### PR TITLE
MM-07: Add the webapp mixed-custody flow

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -605,6 +605,9 @@ importers:
       '@atproto/syntax':
         specifier: ^0.7.4
         version: 0.7.4
+      '@northskysocial/stratos-core':
+        specifier: workspace:*
+        version: link:../stratos-core
     devDependencies:
       '@eslint/js':
         specifier: ^10.0.1

--- a/scripts/dev-local.ts
+++ b/scripts/dev-local.ts
@@ -184,7 +184,10 @@ async function start() {
     if (fs.existsSync(clientMetadataTemplatePath)) {
       let content = fs.readFileSync(clientMetadataTemplatePath, 'utf8')
       content = content.replace(/VITE_WEBAPP_URL/g, webappUrl)
-      content = content.replace(/VITE_STRATOS_SERVICE_DID/g, derivedServiceDid)
+      content = content.replace(
+        /VITE_STRATOS_SERVICE_DID_ENCODED/g,
+        encodeURIComponent(derivedServiceDid),
+      )
       fs.writeFileSync(clientMetadataPath, content)
       console.log(`Updated ${clientMetadataPath} with ${webappUrl}`)
     }

--- a/scripts/dev-local.ts
+++ b/scripts/dev-local.ts
@@ -184,6 +184,7 @@ async function start() {
     if (fs.existsSync(clientMetadataTemplatePath)) {
       let content = fs.readFileSync(clientMetadataTemplatePath, 'utf8')
       content = content.replace(/VITE_WEBAPP_URL/g, webappUrl)
+      content = content.replace(/VITE_STRATOS_SERVICE_DID/g, derivedServiceDid)
       fs.writeFileSync(clientMetadataPath, content)
       console.log(`Updated ${clientMetadataPath} with ${webappUrl}`)
     }

--- a/stratos-client/scripts/gen-lexicons.mjs
+++ b/stratos-client/scripts/gen-lexicons.mjs
@@ -1,5 +1,5 @@
-// Generates src/lexicons.gen.ts by inlining the canonical Stratos lexicon JSON
-// documents (lexicons/zone/stratos/**) into a browser-safe TypeScript module.
+// Generates src/lexicons.gen.ts by inlining the Stratos lexicon JSON documents
+// into a browser-safe TypeScript module.
 //
 // The bundle is inlined (rather than importing JSON at runtime) so the published
 // package works from its compiled dist/ output without shipping JSON assets.
@@ -11,7 +11,10 @@ import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const scriptDir = dirname(fileURLToPath(import.meta.url))
-const lexiconsDir = resolve(scriptDir, '../../lexicons/zone/stratos')
+const lexiconDirs = [
+  resolve(scriptDir, '../../lexicons/zone/stratos'),
+  resolve(scriptDir, '../../lexicons-spaces/zone/stratos'),
+]
 const outFile = resolve(scriptDir, '../src/lexicons.gen.ts')
 
 function collectJsonFiles(dir) {
@@ -27,7 +30,8 @@ function collectJsonFiles(dir) {
   return found
 }
 
-const docs = collectJsonFiles(lexiconsDir)
+const docs = lexiconDirs
+  .flatMap(collectJsonFiles)
   .map((file) => {
     const raw = readFileSync(file, 'utf-8').trim()
     const id = JSON.parse(raw).id
@@ -41,7 +45,7 @@ const docs = collectJsonFiles(lexiconsDir)
 const banner = `/* eslint-disable */
 // AUTO-GENERATED FILE — DO NOT EDIT.
 // Regenerate with: pnpm --filter @northskysocial/stratos-client lexgen
-// Source: lexicons/zone/stratos/**/*.json
+// Source: lexicons*/zone/stratos/**/*.json
 `
 
 const body = `import type { LexiconDoc } from '@atproto/lexicon'

--- a/stratos-client/src/lexicons.gen.ts
+++ b/stratos-client/src/lexicons.gen.ts
@@ -1,7 +1,7 @@
 /* eslint-disable */
 // AUTO-GENERATED FILE — DO NOT EDIT.
 // Regenerate with: pnpm --filter @northskysocial/stratos-client lexgen
-// Source: lexicons/zone/stratos/**/*.json
+// Source: lexicons*/zone/stratos/**/*.json
 
 import type { LexiconDoc } from '@atproto/lexicon'
 
@@ -1153,6 +1153,19 @@ export const stratosLexicons: LexiconDoc[] = [
           }
         }
       }
+    }
+  }
+},
+{
+  "lexicon": 1,
+  "id": "zone.stratos.space.feed",
+  "defs": {
+    "main": {
+      "type": "space",
+      "description": "A members-only Stratos post feed",
+      "key": "any",
+      "name": "Stratos Feed",
+      "collections": ["zone.stratos.feed.post"]
     }
   }
 },

--- a/stratos-service/src/features/enrollment/internal/pds-enrollment-sync.ts
+++ b/stratos-service/src/features/enrollment/internal/pds-enrollment-sync.ts
@@ -73,6 +73,10 @@ export async function syncEnrollmentRecordToPds(
           signingKey: attestation.signingKey,
         },
         createdAt: new Date().toISOString(),
+        custody: enrollment.custody ?? 'stratos',
+        ...(enrollment.custody === 'pds' && enrollment.repoHost
+          ? { repoHost: enrollment.repoHost }
+          : {}),
       },
     },
     { signal },

--- a/stratos-service/tests/admin-boundaries.test.ts
+++ b/stratos-service/tests/admin-boundaries.test.ts
@@ -13,6 +13,10 @@ import {
   type PdsSyncQueueStore,
 } from '../src/features'
 
+const { putRecord } = vi.hoisted(() => ({
+  putRecord: vi.fn(async () => ({})),
+}))
+
 // The boundary handlers write the user's PDS enrollment record through an
 // `Agent` constructed inside `syncEnrollmentRecordToPds`. Stub it so the PDS
 // write is deterministic: by default it succeeds (pdsSync: 'ok'); a failure is
@@ -24,7 +28,7 @@ vi.mock('@atproto/api', () => ({
     com = {
       atproto: {
         repo: {
-          putRecord: async () => ({}),
+          putRecord,
         },
       },
     }
@@ -530,6 +534,41 @@ describe('admin boundary endpoints', () => {
   })
 
   describe('POST /xrpc/zone.stratos.admin.setBoundaries', () => {
+    it('preserves PDS custody metadata in the profile record', async () => {
+      putRecord.mockClear()
+      const { app } = createCtx({
+        enrollmentStore: {
+          getEnrollment: vi.fn(async () => ({
+            did: 'did:plc:usagi',
+            enrolledAt: '2026-01-01T00:00:00.000Z',
+            pdsEndpoint: 'https://pds.example.com',
+            signingKeyDid: 'did:key:zSailorMoon',
+            active: true,
+            enrollmentRkey: 'rkey123',
+            custody: 'pds' as const,
+            repoHost: 'https://pds.example.com',
+          })),
+        },
+      })
+
+      const res = await invokePostRoute(
+        app,
+        '/xrpc/zone.stratos.admin.setBoundaries',
+        { did: 'did:plc:usagi', boundaries: ['did:web:nerv.tokyo.jp/bees'] },
+      )
+
+      expect(res.statusCode).toBe(200)
+      expect(putRecord).toHaveBeenCalledWith(
+        expect.objectContaining({
+          record: expect.objectContaining({
+            custody: 'pds',
+            repoHost: 'https://pds.example.com',
+          }),
+        }),
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      )
+    })
+
     it('sets boundaries for an enrolled user', async () => {
       const { app, enrollmentStore } = createCtx({})
       const res = await invokePostRoute(

--- a/stratos-service/tests/pds-sync.integration.test.ts
+++ b/stratos-service/tests/pds-sync.integration.test.ts
@@ -122,6 +122,8 @@ describe('PDS enrollment sync (sqlite integration)', () => {
       signingKeyDid: 'did:key:zSailorMoon',
       active: true,
       boundaries: [ENGINEERING],
+      custody: 'pds',
+      repoHost: 'https://pds.juban.tokyo.jp',
     })
   })
 
@@ -161,6 +163,8 @@ describe('PDS enrollment sync (sqlite integration)', () => {
       boundaries: Array<{ value: string }>
       signingKey: string
       service: string
+      custody: 'pds'
+      repoHost: string
       attestation: { sig: Uint8Array; signingKey: string }
     }
     const values = record.boundaries.map((b) => b.value)
@@ -170,6 +174,8 @@ describe('PDS enrollment sync (sqlite integration)', () => {
     expect(values).toContain(RESERVED)
     expect(record.signingKey).toBe('did:key:zSailorMoon')
     expect(record.service).toBe('https://stratos.example.com')
+    expect(record.custody).toBe('pds')
+    expect(record.repoHost).toBe('https://pds.juban.tokyo.jp')
     expect(record.attestation.signingKey).toBe('did:key:zServiceKey')
     expect(Array.from(record.attestation.sig)).toEqual([1, 2, 3])
   })

--- a/webapp/Dockerfile
+++ b/webapp/Dockerfile
@@ -52,8 +52,8 @@ RUN pnpm build
 # Generate client-metadata.json for OAuth discovery.
 # The scope MUST match the authorization request in webapp/src/lib/auth.ts
 # (OAUTH_SCOPE) or the authorization server rejects sign-in with invalid_scope.
-RUN printf '{"client_id":"%s/client-metadata.json","client_name":"Stratos","client_uri":"%s","redirect_uris":["%s/"],"scope":"atproto repo:zone.stratos.actor.enrollment repo:zone.stratos.feed.post?action=create&action=delete rpc:zone.stratos.feedgen.getFeed?aud=* repo:app.bsky.feed.post?action=create","grant_types":["authorization_code","refresh_token"],"response_types":["code"],"token_endpoint_auth_method":"none","application_type":"web","dpop_bound_access_tokens":true}\n' \
-  "$VITE_WEBAPP_URL" "$VITE_WEBAPP_URL" "$VITE_WEBAPP_URL" > dist/client-metadata.json
+RUN printf '{"client_id":"%s/client-metadata.json","client_name":"Stratos","client_uri":"%s","redirect_uris":["%s/"],"scope":"atproto repo:zone.stratos.actor.enrollment repo:zone.stratos.feed.post?action=create&action=delete rpc:zone.stratos.feedgen.getFeed?aud=* repo:app.bsky.feed.post?action=create space:zone.stratos.space.feed?authority=%s&collection=zone.stratos.feed.post&action=create&action=read","grant_types":["authorization_code","refresh_token"],"response_types":["code"],"token_endpoint_auth_method":"none","application_type":"web","dpop_bound_access_tokens":true}\n' \
+  "$VITE_WEBAPP_URL" "$VITE_WEBAPP_URL" "$VITE_WEBAPP_URL" "$VITE_STRATOS_SERVICE_DID" > dist/client-metadata.json
 
 # Production stage
 FROM nginx:alpine

--- a/webapp/Dockerfile
+++ b/webapp/Dockerfile
@@ -52,8 +52,9 @@ RUN pnpm build
 # Generate client-metadata.json for OAuth discovery.
 # The scope MUST match the authorization request in webapp/src/lib/auth.ts
 # (OAUTH_SCOPE) or the authorization server rejects sign-in with invalid_scope.
-RUN printf '{"client_id":"%s/client-metadata.json","client_name":"Stratos","client_uri":"%s","redirect_uris":["%s/"],"scope":"atproto repo:zone.stratos.actor.enrollment repo:zone.stratos.feed.post?action=create&action=delete rpc:zone.stratos.feedgen.getFeed?aud=* repo:app.bsky.feed.post?action=create space:zone.stratos.space.feed?authority=%s&collection=zone.stratos.feed.post&action=create&action=read","grant_types":["authorization_code","refresh_token"],"response_types":["code"],"token_endpoint_auth_method":"none","application_type":"web","dpop_bound_access_tokens":true}\n' \
-  "$VITE_WEBAPP_URL" "$VITE_WEBAPP_URL" "$VITE_WEBAPP_URL" "$VITE_STRATOS_SERVICE_DID" > dist/client-metadata.json
+RUN SERVICE_DID_AUTHORITY="$(node -p 'encodeURIComponent(process.env.VITE_STRATOS_SERVICE_DID ?? "")')" && \
+  printf '{"client_id":"%s/client-metadata.json","client_name":"Stratos","client_uri":"%s","redirect_uris":["%s/"],"scope":"atproto repo:zone.stratos.actor.enrollment repo:zone.stratos.feed.post?action=create&action=delete rpc:zone.stratos.feedgen.getFeed?aud=* repo:app.bsky.feed.post?action=create space:zone.stratos.space.feed?authority=%s&collection=zone.stratos.feed.post&action=read&action=create","grant_types":["authorization_code","refresh_token"],"response_types":["code"],"token_endpoint_auth_method":"none","application_type":"web","dpop_bound_access_tokens":true}\n' \
+  "$VITE_WEBAPP_URL" "$VITE_WEBAPP_URL" "$VITE_WEBAPP_URL" "$SERVICE_DID_AUTHORITY" > dist/client-metadata.json
 
 # Production stage
 FROM nginx:alpine

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -22,7 +22,8 @@
     "@atproto/lexicon": "^0.7.11",
     "@atproto/oauth-client-browser": "^0.5.3",
     "@atproto/oauth-types": "^0.7.5",
-    "@atproto/syntax": "^0.7.4"
+    "@atproto/syntax": "^0.7.4",
+    "@northskysocial/stratos-core": "workspace:*"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/webapp/public/client-metadata.json.template
+++ b/webapp/public/client-metadata.json.template
@@ -3,7 +3,7 @@
   "client_name": "Stratos",
   "client_uri": "VITE_WEBAPP_URL",
   "redirect_uris": ["VITE_WEBAPP_URL/"],
-  "scope": "atproto repo:zone.stratos.actor.enrollment repo:zone.stratos.feed.post?action=create&action=delete rpc:zone.stratos.feedgen.getFeed?aud=* repo:app.bsky.feed.post?action=create",
+  "scope": "atproto repo:zone.stratos.actor.enrollment repo:zone.stratos.feed.post?action=create&action=delete rpc:zone.stratos.feedgen.getFeed?aud=* repo:app.bsky.feed.post?action=create space:zone.stratos.space.feed?authority=VITE_STRATOS_SERVICE_DID&collection=zone.stratos.feed.post&action=create&action=read",
   "grant_types": ["authorization_code", "refresh_token"],
   "response_types": ["code"],
   "token_endpoint_auth_method": "none",

--- a/webapp/public/client-metadata.json.template
+++ b/webapp/public/client-metadata.json.template
@@ -3,7 +3,7 @@
   "client_name": "Stratos",
   "client_uri": "VITE_WEBAPP_URL",
   "redirect_uris": ["VITE_WEBAPP_URL/"],
-  "scope": "atproto repo:zone.stratos.actor.enrollment repo:zone.stratos.feed.post?action=create&action=delete rpc:zone.stratos.feedgen.getFeed?aud=* repo:app.bsky.feed.post?action=create space:zone.stratos.space.feed?authority=VITE_STRATOS_SERVICE_DID&collection=zone.stratos.feed.post&action=create&action=read",
+  "scope": "atproto repo:zone.stratos.actor.enrollment repo:zone.stratos.feed.post?action=create&action=delete rpc:zone.stratos.feedgen.getFeed?aud=* repo:app.bsky.feed.post?action=create space:zone.stratos.space.feed?authority=VITE_STRATOS_SERVICE_DID_ENCODED&collection=zone.stratos.feed.post&action=read&action=create",
   "grant_types": ["authorization_code", "refresh_token"],
   "response_types": ["code"],
   "token_endpoint_auth_method": "none",

--- a/webapp/src/App.svelte
+++ b/webapp/src/App.svelte
@@ -197,34 +197,58 @@
    * and optionally Stratos posts if the Stratos agent is available.
    */
   async function refreshFeed() {
-    if (!session) {
+    const refreshSession = session
+    const epoch = discoveryEpoch
+    if (!refreshSession) {
+      return
+    }
+    const isCurrent = () =>
+      session === refreshSession && discoveryEpoch === epoch
+
+    if (!isCurrent()) {
       return
     }
     loading = true
     loadingStatus = 'Loading feed...'
     try {
       const publicPosts = appviewAgent
-        ? await fetchPublicPosts(appviewAgent, session.sub)
-        : await fetchRepoPublicPosts(configureAgent(new Agent(session)), session.sub)
+        ? await fetchPublicPosts(appviewAgent, refreshSession.sub)
+        : await fetchRepoPublicPosts(
+            configureAgent(new Agent(refreshSession)),
+            refreshSession.sub,
+          )
+
+      if (!isCurrent()) {
+        return
+      }
 
       let stratosPosts: FeedPost[] = []
       if (FEEDGEN_DID) {
-        const res = await fetchFeedgenPosts(session, FEEDGEN_DID, FEEDGEN_FEED)
+        const res = await fetchFeedgenPosts(
+          refreshSession,
+          FEEDGEN_DID,
+          FEEDGEN_FEED,
+        )
         stratosPosts = res.posts
       } else if (APPVIEW_URL) {
         const res = await fetchAppviewStratosPosts(
-          session,
+          refreshSession,
           APPVIEW_URL,
         )
         stratosPosts = res.posts
       } else if (stratosAgent) {
-        stratosPosts = await fetchStratosPosts(stratosAgent, session.sub)
+        stratosPosts = await fetchStratosPosts(stratosAgent, refreshSession.sub)
       }
 
+      if (!isCurrent()) {
+        return
+      }
       const unified = buildUnifiedFeed(publicPosts, stratosPosts)
       allPosts = resolveHandles(unified, did, handle)
     } finally {
-      loading = false
+      if (isCurrent()) {
+        loading = false
+      }
     }
   }
 
@@ -263,36 +287,31 @@
   /**
    * Handles signing out the user.
    */
+  function clearSession() {
+    discoveryEpoch += 1
+    session = null
+    enrollment = null
+    stratosStatus = null
+    attestationVerified = null
+    appviewAgent = null
+    stratosAgent = null
+    allPosts = []
+    handle = ''
+    did = ''
+    activeFeed = null
+    loading = false
+  }
+
   async function handleSignOut() {
     if (confirm('Are you sure you want to log out?')) {
+      clearSession()
       await signOut()
-      discoveryEpoch += 1
-      session = null
-      enrollment = null
-      stratosStatus = null
-      attestationVerified = null
-      appviewAgent = null
-      stratosAgent = null
-      allPosts = []
-      handle = ''
-      did = ''
-      activeFeed = null
     }
   }
 
   onMount(async () => {
     onSessionDeleted(() => {
-      discoveryEpoch += 1
-      session = null
-      enrollment = null
-      stratosStatus = null
-      attestationVerified = null
-      appviewAgent = null
-      stratosAgent = null
-      allPosts = []
-      handle = ''
-      did = ''
-      activeFeed = null
+      clearSession()
     })
 
     if (import.meta.env.DEV && initialStartupDone && session && (window as unknown as CustomWindow).__MOCK_SESSION__) {

--- a/webapp/src/App.svelte
+++ b/webapp/src/App.svelte
@@ -45,6 +45,7 @@
   let loading = $state(true)
   let loadingStatus = $state('Initializing session...')
   let initialStartupDone = false
+  let discoveryEpoch = 0
   let did = $state('')
   let handle = $state('')
 
@@ -149,38 +150,45 @@
     }
     loading = true
     loadingStatus = 'Discovering service...'
+    const epoch = ++discoveryEpoch
     try {
-      if (APPVIEW_URL) {
-        appviewAgent = createServiceAgent(session, APPVIEW_URL)
-      }
-
-      enrollment = await discoverStratosEnrollment(session)
-
-      const url = enrollment?.service ?? serviceUrl
+      const nextAppviewAgent = APPVIEW_URL
+        ? createServiceAgent(session, APPVIEW_URL)
+        : null
+      const nextEnrollment = await discoverStratosEnrollment(session)
+      const nextAttestationVerified = nextEnrollment
+        ? await verifyAttestation(session.sub, nextEnrollment)
+        : null
+      const url = nextEnrollment?.service ?? serviceUrl
+      let nextStratosStatus: StratosServiceStatus = {enrolled: false}
+      let nextServerDomains: string[] = []
+      let nextStratosAgent: Agent | null = null
       if (url) {
-        serviceUrl = url
-        stratosAgent = createStratosAgent(session, url)
+        nextStratosAgent = createStratosAgent(session, url)
 
         try {
-          stratosStatus = await checkStratosServiceStatus(url, session.sub)
-          serverDomains = await fetchServerDomains(url)
+          nextStratosStatus = await checkStratosServiceStatus(url, session.sub)
+          nextServerDomains = await fetchServerDomains(url)
         } catch (err) {
           console.error('Failed to check service status:', err)
-          stratosStatus = {enrolled: false}
+          nextStratosStatus = {enrolled: false}
         }
-      } else {
-        stratosStatus = {enrolled: false}
       }
 
-      if (enrollment) {
-        attestationVerified = await verifyAttestation(session.sub, enrollment)
-      } else {
-        attestationVerified = null
-      }
+      if (epoch !== discoveryEpoch) return
+      serviceUrl = url
+      appviewAgent = nextAppviewAgent
+      enrollment = nextEnrollment
+      attestationVerified = nextAttestationVerified
+      stratosAgent = nextStratosAgent
+      stratosStatus = nextStratosStatus
+      serverDomains = nextServerDomains
 
       await refreshFeed()
     } finally {
-      loading = false
+      if (epoch === discoveryEpoch) {
+        loading = false
+      }
     }
   }
 
@@ -234,7 +242,7 @@
    */
   function handleSetServiceUrl(url: string) {
     serviceUrl = url
-    discoverAndLoad()
+    void discoverAndLoad()
   }
 
   /**
@@ -258,6 +266,7 @@
   async function handleSignOut() {
     if (confirm('Are you sure you want to log out?')) {
       await signOut()
+      discoveryEpoch += 1
       session = null
       enrollment = null
       stratosStatus = null
@@ -273,6 +282,7 @@
 
   onMount(async () => {
     onSessionDeleted(() => {
+      discoveryEpoch += 1
       session = null
       enrollment = null
       stratosStatus = null
@@ -328,7 +338,7 @@
                 <button class="sign-out" onclick={handleSignOut}>Log Out</button>
             </header>
 
-            <Composer {session} {enrollment} {stratosAgent} {replyingTo} onpost={refreshFeed}
+            <Composer {session} {enrollment} {attestationVerified} {stratosAgent} {replyingTo} onpost={refreshFeed}
                       oncancelreply={cancelReply}/>
 
             <div class="feed-tabs">
@@ -339,7 +349,7 @@
                 >
                     All
                 </button>
-                {#each enrolledDomains as domain}
+                    {#each enrolledDomains as domain (domain)}
                     <button
                             class="tab"
                             class:active={activeFeed === domain}

--- a/webapp/src/App.svelte
+++ b/webapp/src/App.svelte
@@ -305,6 +305,7 @@
     appviewAgent = null
     stratosAgent = null
     allPosts = []
+    replyingTo = null
     handle = ''
     did = ''
     activeFeed = null

--- a/webapp/src/App.svelte
+++ b/webapp/src/App.svelte
@@ -46,6 +46,7 @@
   let loadingStatus = $state('Initializing session...')
   let initialStartupDone = false
   let discoveryEpoch = 0
+  let feedRefreshEpoch = 0
   let did = $state('')
   let handle = $state('')
 
@@ -151,6 +152,7 @@
     loading = true
     loadingStatus = 'Discovering service...'
     const epoch = ++discoveryEpoch
+    const startingFeedRefreshEpoch = feedRefreshEpoch
     try {
       const nextAppviewAgent = APPVIEW_URL
         ? createServiceAgent(session, APPVIEW_URL)
@@ -186,7 +188,10 @@
 
       await refreshFeed()
     } finally {
-      if (epoch === discoveryEpoch) {
+      if (
+        epoch === discoveryEpoch &&
+        feedRefreshEpoch === startingFeedRefreshEpoch
+      ) {
         loading = false
       }
     }
@@ -198,12 +203,15 @@
    */
   async function refreshFeed() {
     const refreshSession = session
-    const epoch = discoveryEpoch
     if (!refreshSession) {
       return
     }
+    const discovery = discoveryEpoch
+    const refresh = ++feedRefreshEpoch
     const isCurrent = () =>
-      session === refreshSession && discoveryEpoch === epoch
+      session === refreshSession &&
+      discoveryEpoch === discovery &&
+      feedRefreshEpoch === refresh
 
     if (!isCurrent()) {
       return
@@ -289,6 +297,7 @@
    */
   function clearSession() {
     discoveryEpoch += 1
+    feedRefreshEpoch += 1
     session = null
     enrollment = null
     stratosStatus = null

--- a/webapp/src/lib/Composer.svelte
+++ b/webapp/src/lib/Composer.svelte
@@ -378,7 +378,7 @@
             {spaceWriteScope === 'granted'
               ? 'Your PDS will hold your private posts after enrollment.'
               : spaceWriteScope === 'missing'
-                ? 'Private posting needs a new space permission after enrollment.'
+                ? 'Stratos will hold your private posts after enrollment.'
                 : 'Private posting permission could not be verified.'}
         </p>
     {/if}

--- a/webapp/src/lib/Composer.svelte
+++ b/webapp/src/lib/Composer.svelte
@@ -35,15 +35,7 @@
   let error = $state('')
 
   let privatePostingDisabled = $derived(!enrollment || attestationVerified !== true)
-  let pdsScopeUnavailable = $derived(
-    enrollment?.custody === 'pds' &&
-      (spaceWriteScope === 'missing' || spaceWriteScope === 'unavailable'),
-  )
-  let privateModeUnavailable = $derived(privatePostingDisabled || pdsScopeUnavailable)
-  let privateModeDisabled = $derived(
-    privateModeUnavailable ||
-      (enrollment?.custody === 'pds' && spaceWriteScope === 'checking'),
-  )
+  let privateModeUnavailable = $derived(privatePostingDisabled)
   let pdsPrivatePost = $derived(
     isPrivate && enrollment?.custody === 'pds',
   )
@@ -59,6 +51,10 @@
   })
 
   $effect(() => {
+    if (enrollment !== null) {
+      spaceWriteScope = 'checking'
+      return
+    }
     let cancelled = false
     spaceWriteScope = 'checking'
     getSpaceWriteScopeStatus(session).then((status) => {
@@ -133,12 +129,6 @@
     }
     if (isPrivate && !selectedDomain) {
       error = 'Select an enrolled private space before posting.'
-      return
-    }
-    if (isPrivate && enrollment?.custody === 'pds' && spaceWriteScope !== 'granted') {
-      error = spaceWriteScope === 'missing'
-        ? 'Private posting requires a new space permission. Sign out and authorize the app again.'
-        : 'Private posting is unavailable because the space permission could not be verified.'
       return
     }
     if (isPrivate && enrollment?.custody === 'stratos' && !stratosAgent) {
@@ -267,7 +257,7 @@
     } catch (err) {
       console.error('Post failed:', err)
       const message = err instanceof Error ? err.message : 'Failed to create post'
-      if (pdsPrivatePost && message.includes('scope')) {
+      if (pdsPrivatePost && message.toLowerCase().includes('scope')) {
         error = 'Private posting requires a new space permission. Sign out and authorize the app again.'
       } else if (!isPrivate && message.includes('Missing required scope')) {
         error = 'Public posting is not available — this demo is for private data only.'
@@ -327,23 +317,17 @@
                 <span class="posting-note">Images are not available for PDS-hosted private posts yet.</span>
             {/if}
 
-            <label class="private-toggle" class:disabled={privateModeDisabled}>
+            <label class="private-toggle" class:disabled={privateModeUnavailable}>
                 <input
                         type="checkbox"
                         bind:checked={isPrivate}
-                        disabled={privateModeDisabled || posting}
+                        disabled={privateModeUnavailable || posting}
                 />
                 <span>Private</span>
                 {#if !enrollment}
                     <span class="tooltip">Enroll in Stratos to post privately</span>
                 {:else if privatePostingDisabled}
                     <span class="tooltip">Private posting requires a valid enrollment attestation</span>
-                {:else if enrollment?.custody === 'pds' && spaceWriteScope === 'checking'}
-                    <span class="tooltip">Checking the required space permission</span>
-                {:else if enrollment?.custody === 'pds' && spaceWriteScope === 'missing'}
-                    <span class="tooltip">Private posting requires a new space permission</span>
-                {:else if enrollment?.custody === 'pds' && spaceWriteScope === 'unavailable'}
-                    <span class="tooltip">The space permission could not be verified</span>
                 {/if}
             </label>
 

--- a/webapp/src/lib/Composer.svelte
+++ b/webapp/src/lib/Composer.svelte
@@ -5,17 +5,20 @@
   import type {FeedPost, ReplyRef} from './feed'
   import {displayBoundary} from './boundary-display'
   import {configureAgent} from './stratos-agent'
+  import {boundaryToSpaceUri} from '@northskysocial/stratos-core'
+  import {getSpaceWriteScopeStatus, type SpaceWriteScopeStatus} from './auth'
 
   interface Props {
     session: OAuthSession
     enrollment: StratosEnrollment | null
+    attestationVerified: boolean | null
     stratosAgent: Agent | null
     replyingTo: FeedPost | null
     onpost: () => void
     oncancelreply: () => void
   }
 
-  let {session, enrollment, stratosAgent, replyingTo, onpost, oncancelreply}: Props = $props()
+  let {session, enrollment, attestationVerified, stratosAgent, replyingTo, onpost, oncancelreply}: Props = $props()
 
   let text = $state('')
   const CHAR_LIMIT = 300
@@ -27,8 +30,23 @@
   let selectedFile: File | null = $state(null)
   let imagePreview: string | null = $state(null)
   let altText = $state('')
+  let spaceWriteScope = $state<SpaceWriteScopeStatus | 'checking'>('checking')
 
   let error = $state('')
+
+  let privatePostingDisabled = $derived(!enrollment || attestationVerified !== true)
+  let pdsScopeUnavailable = $derived(
+    enrollment?.custody === 'pds' &&
+      (spaceWriteScope === 'missing' || spaceWriteScope === 'unavailable'),
+  )
+  let privateModeUnavailable = $derived(privatePostingDisabled || pdsScopeUnavailable)
+  let privateModeDisabled = $derived(
+    privateModeUnavailable ||
+      (enrollment?.custody === 'pds' && spaceWriteScope === 'checking'),
+  )
+  let pdsPrivatePost = $derived(
+    isPrivate && enrollment?.custody === 'pds',
+  )
 
   let domains = $derived(
     enrollment?.boundaries.map((b) => b.value).filter(Boolean) ?? [],
@@ -41,7 +59,26 @@
   })
 
   $effect(() => {
-    if (replyingTo?.isPrivate) {
+    let cancelled = false
+    spaceWriteScope = 'checking'
+    getSpaceWriteScopeStatus(session).then((status) => {
+      if (!cancelled) {
+        spaceWriteScope = status
+      }
+    })
+    return () => {
+      cancelled = true
+    }
+  })
+
+  $effect(() => {
+    if (privateModeUnavailable) {
+      isPrivate = false
+    }
+  })
+
+  $effect(() => {
+    if (replyingTo?.isPrivate && !privateModeUnavailable) {
       isPrivate = true
     }
   })
@@ -71,6 +108,14 @@
     return {root: rootRef, parent: parentRef}
   }
 
+  function spaceUriFromBoundary(boundary: string): string {
+    const result = boundaryToSpaceUri(boundary, 'zone.stratos.space.feed')
+    if (!result.ok) {
+      throw new Error(`The selected private space is invalid: ${result.error.message}`)
+    }
+    return result.value
+  }
+
   function shortDid(did: string): string {
     if (did.length <= 24) {
       return did
@@ -82,6 +127,24 @@
     if (!text.trim() && !selectedFile) {
       return
     }
+    if (isPrivate && privatePostingDisabled) {
+      error = 'Private posting is disabled because the enrollment attestation is not valid.'
+      return
+    }
+    if (isPrivate && !selectedDomain) {
+      error = 'Select an enrolled private space before posting.'
+      return
+    }
+    if (isPrivate && enrollment?.custody === 'pds' && spaceWriteScope !== 'granted') {
+      error = spaceWriteScope === 'missing'
+        ? 'Private posting requires a new space permission. Sign out and authorize the app again.'
+        : 'Private posting is unavailable because the space permission could not be verified.'
+      return
+    }
+    if (isPrivate && enrollment?.custody === 'stratos' && !stratosAgent) {
+      error = 'Private posting is unavailable because the Stratos service is not connected.'
+      return
+    }
     posting = true
     error = ''
 
@@ -91,6 +154,9 @@
       let embed: FeedPost['embed'] | undefined
 
       if (selectedFile) {
+        if (pdsPrivatePost) {
+          throw new Error('Images are not available for PDS-hosted private posts yet.')
+        }
         uploading = true
         try {
           if (isPrivate && stratosAgent) {
@@ -138,7 +204,31 @@
         }
       }
 
-      if (isPrivate && stratosAgent && selectedDomain) {
+      if (isPrivate && enrollment?.custody === 'pds') {
+        const response = await session.fetchHandler(
+          '/xrpc/com.atproto.space.createRecord',
+          {
+            method: 'POST',
+            headers: {'content-type': 'application/json'},
+            body: JSON.stringify({
+              space: spaceUriFromBoundary(selectedDomain),
+              repo: session.sub,
+              collection: 'zone.stratos.feed.post',
+              validate: false,
+              record: {
+                $type: 'zone.stratos.feed.post',
+                text: text.trim(),
+                ...(replyRef ? {reply: replyRef} : {}),
+                createdAt: now,
+              },
+            }),
+          },
+        )
+        if (!response.ok) {
+          const responseText = await response.text().catch(() => '')
+          throw new Error(responseText || `PDS write failed (${response.status})`)
+        }
+      } else if (isPrivate && enrollment?.custody === 'stratos' && stratosAgent) {
         await stratosAgent.com.atproto.repo.createRecord({
           repo: session.sub,
           collection: 'zone.stratos.feed.post',
@@ -154,7 +244,7 @@
             createdAt: now,
           },
         })
-      } else {
+      } else if (!isPrivate) {
         console.log('Creating public post with Atproto')
         const agent = configureAgent(new Agent(session))
         await agent.com.atproto.repo.createRecord({
@@ -177,7 +267,9 @@
     } catch (err) {
       console.error('Post failed:', err)
       const message = err instanceof Error ? err.message : 'Failed to create post'
-      if (!isPrivate && message.includes('Missing required scope')) {
+      if (pdsPrivatePost && message.includes('scope')) {
+        error = 'Private posting requires a new space permission. Sign out and authorize the app again.'
+      } else if (!isPrivate && message.includes('Missing required scope')) {
         error = 'Public posting is not available — this demo is for private data only.'
       } else {
         error = message
@@ -221,26 +313,37 @@
 
     <div class="composer-actions">
         <div class="left-actions">
-            <label class="image-upload" class:disabled={posting}>
+            <label class="image-upload" class:disabled={posting || pdsPrivatePost}>
                 <input
                         type="file"
                         accept="image/*"
                         onchange={handleFileChange}
-                        disabled={posting}
+                        disabled={posting || pdsPrivatePost}
                         style="display: none;"
                 />
                 <span class="icon">🖼️</span>
             </label>
+            {#if pdsPrivatePost}
+                <span class="posting-note">Images are not available for PDS-hosted private posts yet.</span>
+            {/if}
 
-            <label class="private-toggle" class:disabled={!enrollment}>
+            <label class="private-toggle" class:disabled={privateModeDisabled}>
                 <input
                         type="checkbox"
                         bind:checked={isPrivate}
-                        disabled={!enrollment || posting}
+                        disabled={privateModeDisabled || posting}
                 />
                 <span>Private</span>
                 {#if !enrollment}
                     <span class="tooltip">Enroll in Stratos to post privately</span>
+                {:else if privatePostingDisabled}
+                    <span class="tooltip">Private posting requires a valid enrollment attestation</span>
+                {:else if enrollment?.custody === 'pds' && spaceWriteScope === 'checking'}
+                    <span class="tooltip">Checking the required space permission</span>
+                {:else if enrollment?.custody === 'pds' && spaceWriteScope === 'missing'}
+                    <span class="tooltip">Private posting requires a new space permission</span>
+                {:else if enrollment?.custody === 'pds' && spaceWriteScope === 'unavailable'}
+                    <span class="tooltip">The space permission could not be verified</span>
                 {/if}
             </label>
 
@@ -250,7 +353,7 @@
                         bind:value={selectedDomain}
                         disabled={posting}
                 >
-                    {#each domains as domain}
+                    {#each domains as domain (domain)}
                         <option value={domain}>{displayBoundary(domain)}</option>
                     {/each}
                 </select>
@@ -269,6 +372,15 @@
 
     {#if error}
         <p class="error">{error}</p>
+    {/if}
+    {#if !enrollment && spaceWriteScope !== 'checking'}
+        <p class="posting-note">
+            {spaceWriteScope === 'granted'
+              ? 'Your PDS will hold your private posts after enrollment.'
+              : spaceWriteScope === 'missing'
+                ? 'Private posting needs a new space permission after enrollment.'
+                : 'Private posting permission could not be verified.'}
+        </p>
     {/if}
 </div>
 

--- a/webapp/src/lib/PostCard.svelte
+++ b/webapp/src/lib/PostCard.svelte
@@ -52,7 +52,6 @@
     if (cid && imageUrls[cid]) {
       return safeHttpOrBlobUrl(imageUrls[cid])
     }
-    // If hydrated fields are available, use them
     if (img.thumb) {
       return safeHttpUrl(img.thumb)
     }

--- a/webapp/src/lib/PostCard.svelte
+++ b/webapp/src/lib/PostCard.svelte
@@ -17,6 +17,18 @@
   let inspectorOpen = $state(false)
   let imageUrls = $state<Record<string, string>>({})
 
+  function safeUrl(value: string | undefined, allowBlob = false): string {
+    if (!value) return ''
+    try {
+      const url = new URL(value)
+      if (url.protocol === 'https:' || url.protocol === 'http:') return value
+      if (allowBlob && url.protocol === 'blob:') return value
+    } catch {
+      return ''
+    }
+    return ''
+  }
+
   /**
    * Get the URL for an image.
    * @param img - The image object.
@@ -25,17 +37,17 @@
   function getImageUrl(img: StratosImage): string {
     const cid = getCid(img.image)
     if (cid && imageUrls[cid]) {
-      return imageUrls[cid]
+      return safeUrl(imageUrls[cid], true)
     }
     // If hydrated fields are available, use them
     if (img.thumb) {
-      return img.thumb
+      return safeUrl(img.thumb)
     }
     if (img.fullsize) {
-      return img.fullsize
+      return safeUrl(img.fullsize)
     }
     if (typeof img.image === 'object' && img.image.url) {
-      return img.image.url
+      return safeUrl(img.image.url)
     }
     return ''
   }
@@ -263,7 +275,7 @@
                 <img src={getImageUrl(embed)} alt={embed.alt} class="post-image"/>
             </div>
         {:else if embed.$type === 'app.bsky.embed.external' && embed.external}
-            <a href={embed.external.uri} target="_blank" rel="noopener noreferrer"
+            <a href={safeUrl(embed.external.uri) || undefined} target="_blank" rel="noopener noreferrer"
                class="external-embed">
                 {#if embed.external.thumb}
                     {@const cid = getCid(embed.external.thumb)}

--- a/webapp/src/lib/PostCard.svelte
+++ b/webapp/src/lib/PostCard.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import {Agent} from '@atproto/api'
-  import type {FeedPost} from './feed'
+  import {authorFromUri, type FeedPost} from './feed'
   import {displayBoundary} from './boundary-display'
   import RecordInspector from './RecordInspector.svelte'
   import {getCid, type StratosImage} from './utils/cid'
@@ -215,15 +215,6 @@
   }
 
   /**
-   * Extract the parent author from a URI.
-   * @param uriStr - The URI to extract the parent author from.
-   * @returns The parent author.
-   */
-  function parentAuthor(uriStr: string): string {
-    return (uriStr || '').replace('at://', '').split('/')[0]
-  }
-
-  /**
    * Get the author handle for a post.
    * @returns The author handle for the post.
    */
@@ -237,7 +228,7 @@
 <article class="post-card" class:private={post.isPrivate}>
     {#if post.reply}
         <div class="reply-context">
-            ↩ replying to {shortDid(parentAuthor(post.reply.parent.uri))}
+            ↩ replying to {shortDid(authorFromUri(post.reply.parent.uri))}
         </div>
     {/if}
 

--- a/webapp/src/lib/PostCard.svelte
+++ b/webapp/src/lib/PostCard.svelte
@@ -17,12 +17,25 @@
   let inspectorOpen = $state(false)
   let imageUrls = $state<Record<string, string>>({})
 
-  function safeUrl(value: string | undefined, allowBlob = false): string {
+  const HTTP_PROTOCOLS = ['https:', 'http:'] as const
+  const HTTP_OR_BLOB_PROTOCOLS = [...HTTP_PROTOCOLS, 'blob:'] as const
+
+  function safeHttpUrl(value: string | undefined): string {
+    return safeUrlForProtocols(value, HTTP_PROTOCOLS)
+  }
+
+  function safeHttpOrBlobUrl(value: string | undefined): string {
+    return safeUrlForProtocols(value, HTTP_OR_BLOB_PROTOCOLS)
+  }
+
+  function safeUrlForProtocols(
+    value: string | undefined,
+    allowedProtocols: readonly string[],
+  ): string {
     if (!value) return ''
     try {
       const url = new URL(value)
-      if (url.protocol === 'https:' || url.protocol === 'http:') return value
-      if (allowBlob && url.protocol === 'blob:') return value
+      if (allowedProtocols.includes(url.protocol)) return value
     } catch {
       return ''
     }
@@ -37,17 +50,17 @@
   function getImageUrl(img: StratosImage): string {
     const cid = getCid(img.image)
     if (cid && imageUrls[cid]) {
-      return safeUrl(imageUrls[cid], true)
+      return safeHttpOrBlobUrl(imageUrls[cid])
     }
     // If hydrated fields are available, use them
     if (img.thumb) {
-      return safeUrl(img.thumb)
+      return safeHttpUrl(img.thumb)
     }
     if (img.fullsize) {
-      return safeUrl(img.fullsize)
+      return safeHttpUrl(img.fullsize)
     }
     if (typeof img.image === 'object' && img.image.url) {
-      return safeUrl(img.image.url)
+      return safeHttpUrl(img.image.url)
     }
     return ''
   }
@@ -266,7 +279,7 @@
                 <img src={getImageUrl(embed)} alt={embed.alt} class="post-image"/>
             </div>
         {:else if embed.$type === 'app.bsky.embed.external' && embed.external}
-            <a href={safeUrl(embed.external.uri) || undefined} target="_blank" rel="noopener noreferrer"
+            <a href={safeHttpUrl(embed.external.uri) || undefined} target="_blank" rel="noopener noreferrer"
                class="external-embed">
                 {#if embed.external.thumb}
                     {@const cid = getCid(embed.external.thumb)}

--- a/webapp/src/lib/Sidebar.svelte
+++ b/webapp/src/lib/Sidebar.svelte
@@ -33,7 +33,7 @@
     onSetServiceUrl,
   }: Props = $props()
 
-  let inputUrl = $state(serviceUrl)
+  let inputUrl = $derived(serviceUrl)
 </script>
 
 <nav class="sidebar-nav">
@@ -52,6 +52,16 @@
             <span class="badge unverified" title="Attestation could not be verified">⚠</span>
           {/if}
         </div>
+        <div class="custody-status">
+          <span class="enrollment-label">Record custody</span>
+          <span>{enrollment.custody === 'pds' ? 'PDS' : 'Stratos service'}</span>
+        </div>
+        <!-- Custody is not covered by the enrollment attestation. -->
+        {#if attestationVerified === false}
+          <p class="attestation-failure" role="alert">
+            The enrollment attestation could not be verified. Private posting is disabled.
+          </p>
+        {/if}
       {:else}
         <div class="status not-enrolled">
           <span class="dot"></span>
@@ -93,13 +103,13 @@
           <input
             type="text"
             placeholder="Stratos Service URL"
-            bind:value={inputUrl.value}
+            bind:value={inputUrl}
             class="url-input"
           />
           <button
             class="set-url-btn"
-            disabled={!inputUrl.value}
-            onclick={() => onSetServiceUrl?.(inputUrl.value)}
+            disabled={!inputUrl}
+            onclick={() => onSetServiceUrl?.(inputUrl)}
           >
             Set URL
           </button>
@@ -123,7 +133,7 @@
     >
       All domains
     </button>
-    {#each enrolledDomains as domain}
+    {#each enrolledDomains as domain (domain)}
       <button
         class="feed-btn"
         class:active={activeFeed === domain}
@@ -152,7 +162,7 @@
       <p class="muted">No domains discovered</p>
     {:else}
       <div class="domain-list">
-        {#each allDomains as domain}
+        {#each allDomains as domain (domain)}
           <span
             class="domain-tag"
             class:enrolled-tag={enrolledDomains.includes(domain)}
@@ -171,7 +181,7 @@
     <div class="section">
       <h3 class="section-title">Your Domains</h3>
       <div class="domain-list">
-        {#each enrolledDomains as domain}
+        {#each enrolledDomains as domain (domain)}
           <span class="domain-tag enrolled-tag">{displayBoundary(domain)}</span>
         {/each}
       </div>
@@ -260,6 +270,26 @@
     border-radius: 6px;
     margin-top: 0.4rem;
     line-height: 1.3;
+  }
+
+  .custody-status {
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+    color: #444;
+    font-size: 0.82rem;
+    margin-bottom: 0.4rem;
+  }
+
+  .attestation-failure {
+    background: #fef2f2;
+    border: 1px solid #fecaca;
+    border-radius: 6px;
+    color: #b91c1c;
+    font-size: 0.78rem;
+    line-height: 1.35;
+    margin: 0.35rem 0 0;
+    padding: 0.4rem 0.5rem;
   }
 
   .enroll-btn {

--- a/webapp/src/lib/auth.ts
+++ b/webapp/src/lib/auth.ts
@@ -9,6 +9,10 @@ let client: BrowserOAuthClient | null = null
 let currentSession: OAuthSession | null = null
 let sessionDeletedCallback: (() => void) | null = null
 
+export const SPACE_WRITE_SCOPE = `space:zone.stratos.space.feed?authority=${import.meta.env.VITE_STRATOS_SERVICE_DID}&collection=zone.stratos.feed.post&action=create&action=read`
+
+export type SpaceWriteScopeStatus = 'granted' | 'missing' | 'unavailable'
+
 const HANDLE_RESOLVER =
   import.meta.env.VITE_ATPROTO_HANDLE_RESOLVER ?? 'https://bsky.social'
 
@@ -21,7 +25,26 @@ const HANDLE_RESOLVER =
 const OAUTH_SCOPE = [
   ...buildStratosScopes(),
   'repo:app.bsky.feed.post?action=create',
+  // Keep this scope as one string during OAuth scope reserialization.
+  SPACE_WRITE_SCOPE,
 ].join(' ')
+
+export async function hasSpaceWriteScope(
+  session: OAuthSession,
+): Promise<boolean> {
+  const tokenInfo = await session.getTokenInfo(false)
+  return tokenInfo.scope.split(' ').includes(SPACE_WRITE_SCOPE)
+}
+
+export async function getSpaceWriteScopeStatus(
+  session: OAuthSession,
+): Promise<SpaceWriteScopeStatus> {
+  try {
+    return (await hasSpaceWriteScope(session)) ? 'granted' : 'missing'
+  } catch {
+    return 'unavailable'
+  }
+}
 
 function isLoopback(): boolean {
   const h = window.location.hostname

--- a/webapp/src/lib/auth.ts
+++ b/webapp/src/lib/auth.ts
@@ -9,7 +9,13 @@ let client: BrowserOAuthClient | null = null
 let currentSession: OAuthSession | null = null
 let sessionDeletedCallback: (() => void) | null = null
 
-export const SPACE_WRITE_SCOPE = `space:zone.stratos.space.feed?authority=${import.meta.env.VITE_STRATOS_SERVICE_DID}&collection=zone.stratos.feed.post&action=create&action=read`
+export function buildSpaceWriteScope(
+  serviceDid = import.meta.env.VITE_STRATOS_SERVICE_DID,
+): string {
+  return `space:zone.stratos.space.feed?authority=${encodeURIComponent(serviceDid ?? '')}&collection=zone.stratos.feed.post&action=read&action=create`
+}
+
+export const SPACE_WRITE_SCOPE = buildSpaceWriteScope()
 
 export type SpaceWriteScopeStatus = 'granted' | 'missing' | 'unavailable'
 

--- a/webapp/src/lib/feed.ts
+++ b/webapp/src/lib/feed.ts
@@ -130,8 +130,10 @@ export interface ThreadNode {
  * @param uri - The At Protocol URI.
  * @returns The author DID.
  */
-function authorFromUri(uri: string): string {
-  return uri.replace('at://', '').split('/')[0]
+export function authorFromUri(uri: string): string {
+  const parts = uri.replace('at://', '').split('/')
+  if (parts[1] === 'space' && parts.length >= 7) return parts[4]
+  return parts[0]
 }
 
 /**

--- a/webapp/src/lib/feed.ts
+++ b/webapp/src/lib/feed.ts
@@ -8,6 +8,7 @@ interface FeedViewPost {
     record?: Record<string, unknown>
     indexedAt?: string
     author?: { did: string; handle: string }
+    boundaries?: unknown
   }
   reason?: unknown
 }
@@ -193,6 +194,12 @@ function mapFeedViewPosts(
     const val = item.post.record ?? {}
     const did = item.post.author?.did ?? authorFromUri(item.post.uri)
     const handle = item.post.author?.handle ?? ''
+    const responseBoundaries = item.post.boundaries
+    const boundaries = Array.isArray(responseBoundaries)
+      ? responseBoundaries.filter(
+          (boundary): boundary is string => typeof boundary === 'string',
+        )
+      : boundariesFromRecord(val)
 
     return [
       {
@@ -205,7 +212,7 @@ function mapFeedViewPosts(
         embed: val.embed as FeedPost['embed'],
         author: did,
         authorHandle: handle !== did ? handle : '',
-        boundaries: boundariesFromRecord(val),
+        boundaries,
       },
     ]
   })

--- a/webapp/src/lib/stratos.ts
+++ b/webapp/src/lib/stratos.ts
@@ -39,6 +39,8 @@ export interface ServiceAttestation {
 
 export interface StratosEnrollment {
   service: string
+  custody: 'stratos' | 'pds'
+  repoHost?: string
   boundaries: Array<{ value: string }>
   signingKey: string
   attestation: ServiceAttestation | null
@@ -106,6 +108,8 @@ function parseEnrollmentRecord(
   if (typeof val.service !== 'string') return null
   return {
     service: val.service,
+    custody: val.custody === 'pds' ? 'pds' : 'stratos',
+    repoHost: typeof val.repoHost === 'string' ? val.repoHost : undefined,
     boundaries: Array.isArray(val.boundaries) ? val.boundaries : [],
     signingKey: (val.signingKey as string) ?? '',
     attestation: parseAttestation(val.attestation),

--- a/webapp/tests/app.test.ts
+++ b/webapp/tests/app.test.ts
@@ -1,23 +1,45 @@
-import { render, screen, waitFor } from '@testing-library/svelte'
-import { describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/svelte'
+import { tick } from 'svelte'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import App from '../src/App.svelte'
 
 const appState = vi.hoisted(() => {
   let onSessionDeleted: (() => void) | undefined
-  let resolvePublicPosts: (posts: unknown[]) => void
-  const publicPosts = new Promise<unknown[]>((resolve) => {
-    resolvePublicPosts = resolve
+  const publicPostRequests: Array<{
+    promise: Promise<unknown[]>
+    resolve: (posts: unknown[]) => void
+  }> = []
+  const fetchRepoPublicPosts = vi.fn(() => {
+    let resolveRequest!: (posts: unknown[]) => void
+    const promise = new Promise<unknown[]>((resolve) => {
+      resolveRequest = resolve
+    })
+    publicPostRequests.push({ promise, resolve: resolveRequest })
+    return promise
   })
-  const fetchRepoPublicPosts = vi.fn(() => publicPosts)
+  const createRecord = vi.fn().mockResolvedValue({})
 
   return {
     session: { sub: 'did:plc:motoko' },
+    createRecord,
     fetchRepoPublicPosts,
-    publicPosts,
-    resolvePublicPosts: (posts: unknown[]) => resolvePublicPosts(posts),
+    resolvePublicPosts: async (requestIndex: number, posts: unknown[]) => {
+      const request = publicPostRequests[requestIndex]
+      if (!request) {
+        throw new Error(`Missing public post request ${requestIndex}`)
+      }
+      request.resolve(posts)
+      await request.promise
+    },
     getOnSessionDeleted: () => onSessionDeleted,
     setOnSessionDeleted: (callback: () => void) => {
       onSessionDeleted = callback
+    },
+    reset: () => {
+      onSessionDeleted = undefined
+      publicPostRequests.length = 0
+      fetchRepoPublicPosts.mockClear()
+      createRecord.mockClear()
     },
   }
 })
@@ -30,6 +52,7 @@ vi.mock('@atproto/api', () => ({
           describeRepo: vi.fn().mockResolvedValue({
             data: { handle: 'motoko.example' },
           }),
+          createRecord: appState.createRecord,
         },
       },
     }
@@ -63,6 +86,7 @@ vi.mock('../src/lib/stratos-agent', () => ({
 }))
 
 vi.mock('../src/lib/feed', () => ({
+  authorFromUri: (uri: string) => uri.split('/')[2] ?? '',
   buildUnifiedFeed: (publicPosts: unknown[], stratosPosts: unknown[]) => [
     ...publicPosts,
     ...stratosPosts,
@@ -74,10 +98,30 @@ vi.mock('../src/lib/feed', () => ({
   fetchRepoPublicPosts: appState.fetchRepoPublicPosts,
   fetchStratosPosts: vi.fn(),
   filterByDomain: (posts: unknown[]) => posts,
+  groupIntoThreads: (posts: unknown[]) =>
+    posts.map((post) => ({ post, replies: [], depth: 0 })),
   resolveHandles: (posts: unknown[]) => posts,
 }))
 
+function feedPost(text: string, rkey: string) {
+  return {
+    uri: `at://did:plc:motoko/app.bsky.feed.post/${rkey}`,
+    cid: `motoko-${rkey}`,
+    author: 'did:plc:motoko',
+    authorHandle: 'motoko.example',
+    text,
+    createdAt: '1995-11-18T00:00:00.000Z',
+    boundaries: [],
+    isPrivate: false,
+    reply: null,
+  }
+}
+
 describe('App.svelte', () => {
+  beforeEach(() => {
+    appState.reset()
+  })
+
   it('does not restore a completed feed after its session is deleted', async () => {
     render(App)
 
@@ -85,18 +129,8 @@ describe('App.svelte', () => {
       expect(appState.fetchRepoPublicPosts).toHaveBeenCalledTimes(1),
     )
     appState.getOnSessionDeleted()?.()
-    appState.resolvePublicPosts([
-      {
-        uri: 'at://did:plc:motoko/app.bsky.feed.post/one',
-        cid: 'motoko-cid',
-        author: 'did:plc:motoko',
-        authorHandle: 'motoko.example',
-        text: 'A stale post must not cross the airlock.',
-        createdAt: '1995-11-18T00:00:00.000Z',
-        boundaries: [],
-        isPrivate: false,
-        reply: null,
-      },
+    await appState.resolvePublicPosts(0, [
+      feedPost('A stale post must not cross the airlock.', 'one'),
     ])
 
     await waitFor(() =>
@@ -107,5 +141,64 @@ describe('App.svelte', () => {
     expect(
       screen.queryByText('A stale post must not cross the airlock.'),
     ).not.toBeInTheDocument()
+  })
+
+  it('keeps only the latest same-session feed refresh active', async () => {
+    render(App)
+
+    await waitFor(() =>
+      expect(appState.fetchRepoPublicPosts).toHaveBeenCalledTimes(1),
+    )
+    await appState.resolvePublicPosts(0, [
+      feedPost('The original Section Nine briefing.', 'initial'),
+    ])
+    await screen.findByText('The original Section Nine briefing.')
+
+    const startRefresh = async (text: string, expectedRequestCount: number) => {
+      const composer = screen.getByPlaceholderText('Write a post…')
+      await fireEvent.input(composer, { target: { value: text } })
+      await fireEvent.click(screen.getByRole('button', { name: /Post$/ }))
+      await waitFor(() =>
+        expect(appState.fetchRepoPublicPosts).toHaveBeenCalledTimes(
+          expectedRequestCount,
+        ),
+      )
+      await waitFor(() =>
+        expect(
+          screen.getByPlaceholderText('Write a post…'),
+        ).not.toBeDisabled(),
+      )
+    }
+
+    await fireEvent.input(
+      screen.getByPlaceholderText('Stratos Service URL'),
+      { target: { value: 'https://stratos.example' } },
+    )
+    await fireEvent.click(screen.getByRole('button', { name: 'Set URL' }))
+    await waitFor(() =>
+      expect(appState.fetchRepoPublicPosts).toHaveBeenCalledTimes(2),
+    )
+    await startRefresh('Togusa requests the newer refresh.', 3)
+
+    await appState.resolvePublicPosts(1, [
+      feedPost('An older refresh completed first.', 'older-first'),
+    ])
+    await Promise.resolve()
+    await tick()
+    expect(screen.getByText('Loading posts…')).toBeInTheDocument()
+
+    await startRefresh('The Major requests the final refresh.', 4)
+    await appState.resolvePublicPosts(3, [
+      feedPost('The newest briefing wins.', 'newest'),
+    ])
+    await screen.findByText('The newest briefing wins.')
+
+    await appState.resolvePublicPosts(2, [
+      feedPost('A late stale briefing.', 'late-stale'),
+    ])
+    await tick()
+    expect(screen.getByText('The newest briefing wins.')).toBeInTheDocument()
+    expect(screen.queryByText('A late stale briefing.')).not.toBeInTheDocument()
+    expect(screen.queryByText('Loading posts…')).not.toBeInTheDocument()
   })
 })

--- a/webapp/tests/app.test.ts
+++ b/webapp/tests/app.test.ts
@@ -1,0 +1,111 @@
+import { render, screen, waitFor } from '@testing-library/svelte'
+import { describe, expect, it, vi } from 'vitest'
+import App from '../src/App.svelte'
+
+const appState = vi.hoisted(() => {
+  let onSessionDeleted: (() => void) | undefined
+  let resolvePublicPosts: (posts: unknown[]) => void
+  const publicPosts = new Promise<unknown[]>((resolve) => {
+    resolvePublicPosts = resolve
+  })
+  const fetchRepoPublicPosts = vi.fn(() => publicPosts)
+
+  return {
+    session: { sub: 'did:plc:motoko' },
+    fetchRepoPublicPosts,
+    publicPosts,
+    resolvePublicPosts: (posts: unknown[]) => resolvePublicPosts(posts),
+    getOnSessionDeleted: () => onSessionDeleted,
+    setOnSessionDeleted: (callback: () => void) => {
+      onSessionDeleted = callback
+    },
+  }
+})
+
+vi.mock('@atproto/api', () => ({
+  Agent: class {
+    com = {
+      atproto: {
+        repo: {
+          describeRepo: vi.fn().mockResolvedValue({
+            data: { handle: 'motoko.example' },
+          }),
+        },
+      },
+    }
+  },
+}))
+
+vi.mock('../src/lib/auth', () => ({
+  init: vi.fn().mockResolvedValue(appState.session),
+  onSessionDeleted: vi.fn(appState.setOnSessionDeleted),
+  signIn: vi.fn(),
+  signOut: vi.fn(),
+  getSpaceWriteScopeStatus: vi.fn().mockResolvedValue('unavailable'),
+}))
+
+vi.mock('../src/lib/stratos', () => ({
+  APPVIEW_URL: undefined,
+  FEEDGEN_DID: undefined,
+  FEEDGEN_FEED: 'engineering',
+  STRATOS_URL: undefined,
+  checkStratosServiceStatus: vi.fn().mockResolvedValue({ enrolled: false }),
+  discoverStratosEnrollment: vi.fn().mockResolvedValue(null),
+  fetchServerDomains: vi.fn().mockResolvedValue([]),
+  verifyAttestation: vi.fn().mockResolvedValue(true),
+  enrollInStratos: vi.fn(),
+}))
+
+vi.mock('../src/lib/stratos-agent', () => ({
+  configureAgent: vi.fn((agent) => agent),
+  createServiceAgent: vi.fn(),
+  createStratosAgent: vi.fn(),
+}))
+
+vi.mock('../src/lib/feed', () => ({
+  buildUnifiedFeed: (publicPosts: unknown[], stratosPosts: unknown[]) => [
+    ...publicPosts,
+    ...stratosPosts,
+  ],
+  feedStats: vi.fn(() => ({ postCount: 0, userCount: 0 })),
+  fetchAppviewStratosPosts: vi.fn(),
+  fetchFeedgenPosts: vi.fn(),
+  fetchPublicPosts: vi.fn(),
+  fetchRepoPublicPosts: appState.fetchRepoPublicPosts,
+  fetchStratosPosts: vi.fn(),
+  filterByDomain: (posts: unknown[]) => posts,
+  resolveHandles: (posts: unknown[]) => posts,
+}))
+
+describe('App.svelte', () => {
+  it('does not restore a completed feed after its session is deleted', async () => {
+    render(App)
+
+    await waitFor(() =>
+      expect(appState.fetchRepoPublicPosts).toHaveBeenCalledTimes(1),
+    )
+    appState.getOnSessionDeleted()?.()
+    appState.resolvePublicPosts([
+      {
+        uri: 'at://did:plc:motoko/app.bsky.feed.post/one',
+        cid: 'motoko-cid',
+        author: 'did:plc:motoko',
+        authorHandle: 'motoko.example',
+        text: 'A stale post must not cross the airlock.',
+        createdAt: '1995-11-18T00:00:00.000Z',
+        boundaries: [],
+        isPrivate: false,
+        reply: null,
+      },
+    ])
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', { name: 'Sign In' }),
+      ).toBeInTheDocument(),
+    )
+    expect(
+      screen.queryByText('A stale post must not cross the airlock.'),
+    ).not.toBeInTheDocument()
+  })
+})

--- a/webapp/tests/app.test.ts
+++ b/webapp/tests/app.test.ts
@@ -164,16 +164,13 @@ describe('App.svelte', () => {
         ),
       )
       await waitFor(() =>
-        expect(
-          screen.getByPlaceholderText('Write a post…'),
-        ).not.toBeDisabled(),
+        expect(screen.getByPlaceholderText('Write a post…')).not.toBeDisabled(),
       )
     }
 
-    await fireEvent.input(
-      screen.getByPlaceholderText('Stratos Service URL'),
-      { target: { value: 'https://stratos.example' } },
-    )
+    await fireEvent.input(screen.getByPlaceholderText('Stratos Service URL'), {
+      target: { value: 'https://stratos.example' },
+    })
     await fireEvent.click(screen.getByRole('button', { name: 'Set URL' }))
     await waitFor(() =>
       expect(appState.fetchRepoPublicPosts).toHaveBeenCalledTimes(2),

--- a/webapp/tests/auth.test.ts
+++ b/webapp/tests/auth.test.ts
@@ -109,13 +109,17 @@ describe('auth', () => {
 
   it('distinguishes a missing space scope from a scope lookup failure', async () => {
     const missing = await getSpaceWriteScopeStatus({
-      getTokenInfo: vi.fn().mockResolvedValue({scope: 'atproto transition:generic'}),
+      getTokenInfo: vi
+        .fn()
+        .mockResolvedValue({ scope: 'atproto transition:generic' }),
     } as never)
     const unavailable = await getSpaceWriteScopeStatus({
-      getTokenInfo: vi.fn().mockRejectedValue(new Error('Nadia cannot reach the token endpoint')),
+      getTokenInfo: vi
+        .fn()
+        .mockRejectedValue(new Error('Nadia cannot reach the token endpoint')),
     } as never)
     const granted = await getSpaceWriteScopeStatus({
-      getTokenInfo: vi.fn().mockResolvedValue({scope: SPACE_WRITE_SCOPE}),
+      getTokenInfo: vi.fn().mockResolvedValue({ scope: SPACE_WRITE_SCOPE }),
     } as never)
 
     expect(missing).toBe('missing')

--- a/webapp/tests/auth.test.ts
+++ b/webapp/tests/auth.test.ts
@@ -128,14 +128,14 @@ describe('auth', () => {
   })
 
   it('uses a canonical, encoded scope for a port-bearing service DID', async () => {
-    vi.stubEnv('VITE_STRATOS_SERVICE_DID', 'did:web:localhost%3A3100')
+    vi.stubEnv('VITE_STRATOS_SERVICE_DID', 'did:web:motoko.test%3A3100')
     vi.resetModules()
     const { getSpaceWriteScopeStatus, SPACE_WRITE_SCOPE } =
       await import('../src/lib/auth')
     const getTokenInfo = vi.fn().mockResolvedValue({ scope: SPACE_WRITE_SCOPE })
 
     expect(SPACE_WRITE_SCOPE).toBe(
-      'space:zone.stratos.space.feed?authority=did%3Aweb%3Alocalhost%253A3100&collection=zone.stratos.feed.post&action=read&action=create',
+      'space:zone.stratos.space.feed?authority=did%3Aweb%3Amotoko.test%253A3100&collection=zone.stratos.feed.post&action=read&action=create',
     )
     await expect(
       getSpaceWriteScopeStatus({ getTokenInfo } as never),

--- a/webapp/tests/auth.test.ts
+++ b/webapp/tests/auth.test.ts
@@ -126,4 +126,31 @@ describe('auth', () => {
     expect(unavailable).toBe('unavailable')
     expect(granted).toBe('granted')
   })
+
+  it('uses a canonical, encoded scope for a port-bearing service DID', async () => {
+    vi.stubEnv('VITE_STRATOS_SERVICE_DID', 'did:web:localhost%3A3100')
+    vi.resetModules()
+    const { getSpaceWriteScopeStatus, SPACE_WRITE_SCOPE } =
+      await import('../src/lib/auth')
+    const getTokenInfo = vi.fn().mockResolvedValue({ scope: SPACE_WRITE_SCOPE })
+
+    expect(SPACE_WRITE_SCOPE).toBe(
+      'space:zone.stratos.space.feed?authority=did%3Aweb%3Alocalhost%253A3100&collection=zone.stratos.feed.post&action=read&action=create',
+    )
+    await expect(
+      getSpaceWriteScopeStatus({ getTokenInfo } as never),
+    ).resolves.toBe('granted')
+    expect(getTokenInfo).toHaveBeenCalledWith(false)
+    await expect(
+      getSpaceWriteScopeStatus({
+        getTokenInfo: vi.fn().mockResolvedValue({
+          scope: SPACE_WRITE_SCOPE.replace(
+            'action=read&action=create',
+            'action=create&action=read',
+          ),
+        }),
+      } as never),
+    ).resolves.toBe('missing')
+    vi.unstubAllEnvs()
+  })
 })

--- a/webapp/tests/auth.test.ts
+++ b/webapp/tests/auth.test.ts
@@ -5,7 +5,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 // Import AFTER mocking
 import {
   getSession,
+  getSpaceWriteScopeStatus,
   init,
+  SPACE_WRITE_SCOPE,
   onSessionDeleted,
   signIn,
   signOut,
@@ -103,5 +105,21 @@ describe('auth', () => {
 
     expect(callback).toHaveBeenCalled()
     expect(getSession()).toBeNull()
+  })
+
+  it('distinguishes a missing space scope from a scope lookup failure', async () => {
+    const missing = await getSpaceWriteScopeStatus({
+      getTokenInfo: vi.fn().mockResolvedValue({scope: 'atproto transition:generic'}),
+    } as never)
+    const unavailable = await getSpaceWriteScopeStatus({
+      getTokenInfo: vi.fn().mockRejectedValue(new Error('Nadia cannot reach the token endpoint')),
+    } as never)
+    const granted = await getSpaceWriteScopeStatus({
+      getTokenInfo: vi.fn().mockResolvedValue({scope: SPACE_WRITE_SCOPE}),
+    } as never)
+
+    expect(missing).toBe('missing')
+    expect(unavailable).toBe('unavailable')
+    expect(granted).toBe('granted')
   })
 })

--- a/webapp/tests/composer.test.ts
+++ b/webapp/tests/composer.test.ts
@@ -1,7 +1,7 @@
-import {describe, expect, it, vi} from 'vitest'
-import {fireEvent, render, screen, waitFor} from '@testing-library/svelte'
-import type {StratosEnrollment} from '../src/lib/stratos'
-import {SPACE_WRITE_SCOPE} from '../src/lib/auth'
+import { describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/svelte'
+import type { StratosEnrollment } from '../src/lib/stratos'
+import { SPACE_WRITE_SCOPE } from '../src/lib/auth'
 import Composer from '../src/lib/Composer.svelte'
 
 const stratosCreateRecord = vi.fn().mockResolvedValue({})
@@ -10,7 +10,7 @@ function enrollment(custody: StratosEnrollment['custody']): StratosEnrollment {
   return {
     service: 'https://stratos.example',
     custody,
-    boundaries: [{value: 'did:web:stratos.example/nerve'}],
+    boundaries: [{ value: 'did:web:stratos.example/nerve' }],
     signingKey: 'did:key:zQ3shjRei',
     attestation: null,
     createdAt: '1998-04-03T00:00:00.000Z',
@@ -22,8 +22,8 @@ function session(scope = '') {
   return {
     sub: 'did:plc:faye',
     did: 'did:plc:faye',
-    getTokenInfo: vi.fn().mockResolvedValue({scope}),
-    fetchHandler: vi.fn().mockResolvedValue(new Response('', {status: 200})),
+    getTokenInfo: vi.fn().mockResolvedValue({ scope }),
+    fetchHandler: vi.fn().mockResolvedValue(new Response('', { status: 200 })),
   }
 }
 
@@ -33,7 +33,11 @@ function props(overrides: Record<string, unknown> = {}) {
     enrollment: enrollment('stratos'),
     attestationVerified: true,
     stratosAgent: {
-      com: {atproto: {repo: {uploadBlob: vi.fn(), createRecord: stratosCreateRecord}}},
+      com: {
+        atproto: {
+          repo: { uploadBlob: vi.fn(), createRecord: stratosCreateRecord },
+        },
+      },
     },
     replyingTo: null,
     onpost: vi.fn(),
@@ -44,27 +48,31 @@ function props(overrides: Record<string, unknown> = {}) {
 
 describe('Composer.svelte', () => {
   it('renders a private Stratos composer', () => {
-    render(Composer, {props: props()})
+    render(Composer, { props: props() })
 
     expect(screen.getByPlaceholderText(/Post to nerve…/i)).toBeInTheDocument()
-    expect(screen.getByRole('checkbox', {name: /Private/i})).toBeChecked()
+    expect(screen.getByRole('checkbox', { name: /Private/i })).toBeChecked()
   })
 
   it('unchecks and disables private mode when the attestation fails', async () => {
-    render(Composer, {props: props({attestationVerified: false})})
+    render(Composer, { props: props({ attestationVerified: false }) })
 
-    const toggle = screen.getByRole('checkbox', {name: /Private/i})
+    const toggle = screen.getByRole('checkbox', { name: /Private/i })
     await waitFor(() => expect(toggle).not.toBeChecked())
     expect(toggle).toBeDisabled()
   })
 
   it('does not fall back to a public post when private Stratos routing is unavailable', async () => {
-    render(Composer, {props: props({stratosAgent: null})})
+    render(Composer, { props: props({ stratosAgent: null }) })
 
-    await fireEvent.input(screen.getByRole('textbox'), {target: {value: 'Faye holds the line.'}})
-    await fireEvent.click(screen.getByRole('button', {name: /Post$/}))
+    await fireEvent.input(screen.getByRole('textbox'), {
+      target: { value: 'Faye holds the line.' },
+    })
+    await fireEvent.click(screen.getByRole('button', { name: /Post$/ }))
 
-    expect(screen.getByText(/Stratos service is not connected/i)).toBeInTheDocument()
+    expect(
+      screen.getByText(/Stratos service is not connected/i),
+    ).toBeInTheDocument()
     expect(stratosCreateRecord).not.toHaveBeenCalled()
   })
 
@@ -73,54 +81,78 @@ describe('Composer.svelte', () => {
     const onpost = vi.fn()
     render(Composer, {
       props: props({
-        stratosAgent: {com: {atproto: {repo: {uploadBlob: vi.fn(), createRecord}}}},
+        stratosAgent: {
+          com: { atproto: { repo: { uploadBlob: vi.fn(), createRecord } } },
+        },
         onpost,
       }),
     })
 
-    await fireEvent.input(screen.getByRole('textbox'), {target: {value: 'Motoko checks the perimeter.'}})
-    await fireEvent.click(screen.getByRole('button', {name: /Post$/}))
+    await fireEvent.input(screen.getByRole('textbox'), {
+      target: { value: 'Motoko checks the perimeter.' },
+    })
+    await fireEvent.click(screen.getByRole('button', { name: /Post$/ }))
 
     await waitFor(() => expect(createRecord).toHaveBeenCalledTimes(1))
-    expect(createRecord).toHaveBeenCalledWith(expect.objectContaining({
-      repo: 'did:plc:faye',
-      collection: 'zone.stratos.feed.post',
-      record: expect.objectContaining({
-        text: 'Motoko checks the perimeter.',
-        boundary: {
-          $type: 'zone.stratos.boundary.defs#Domains',
-          values: [{value: 'did:web:stratos.example/nerve'}],
-        },
+    expect(createRecord).toHaveBeenCalledWith(
+      expect.objectContaining({
+        repo: 'did:plc:faye',
+        collection: 'zone.stratos.feed.post',
+        record: expect.objectContaining({
+          text: 'Motoko checks the perimeter.',
+          boundary: {
+            $type: 'zone.stratos.boundary.defs#Domains',
+            values: [{ value: 'did:web:stratos.example/nerve' }],
+          },
+        }),
       }),
-    }))
+    )
     expect(onpost).toHaveBeenCalledTimes(1)
   })
 
   it('writes PDS-custody posts through the space endpoint without a boundary or embed', async () => {
     const pdsSession = session(SPACE_WRITE_SCOPE)
     render(Composer, {
-      props: props({session: pdsSession, enrollment: enrollment('pds'), stratosAgent: null}),
+      props: props({
+        session: pdsSession,
+        enrollment: enrollment('pds'),
+        stratosAgent: null,
+      }),
     })
 
-    await waitFor(() => expect(screen.getByRole('checkbox', {name: /Private/i})).not.toBeDisabled())
-    await fireEvent.input(screen.getByRole('textbox'), {target: {value: 'Rei keeps the record.'}})
-    await fireEvent.click(screen.getByRole('button', {name: /Post$/}))
+    await waitFor(() =>
+      expect(
+        screen.getByRole('checkbox', { name: /Private/i }),
+      ).not.toBeDisabled(),
+    )
+    await fireEvent.input(screen.getByRole('textbox'), {
+      target: { value: 'Rei keeps the record.' },
+    })
+    await fireEvent.click(screen.getByRole('button', { name: /Post$/ }))
 
-    await waitFor(() => expect(pdsSession.fetchHandler).toHaveBeenCalledTimes(1))
+    await waitFor(() =>
+      expect(pdsSession.fetchHandler).toHaveBeenCalledTimes(1),
+    )
     const [path, init] = pdsSession.fetchHandler.mock.calls[0]
     expect(path).toBe('/xrpc/com.atproto.space.createRecord')
-    expect(init).toMatchObject({method: 'POST', headers: {'content-type': 'application/json'}})
-    expect(JSON.parse(init.body)).toEqual(expect.objectContaining({
-      space: 'at://did:web:stratos.example/space/zone.stratos.space.feed/nerve',
-      repo: 'did:plc:faye',
-      collection: 'zone.stratos.feed.post',
-      validate: false,
-      record: {
-        $type: 'zone.stratos.feed.post',
-        text: 'Rei keeps the record.',
-        createdAt: expect.any(String),
-      },
-    }))
+    expect(init).toMatchObject({
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+    })
+    expect(JSON.parse(init.body)).toEqual(
+      expect.objectContaining({
+        space:
+          'at://did:web:stratos.example/space/zone.stratos.space.feed/nerve',
+        repo: 'did:plc:faye',
+        collection: 'zone.stratos.feed.post',
+        validate: false,
+        record: {
+          $type: 'zone.stratos.feed.post',
+          text: 'Rei keeps the record.',
+          createdAt: expect.any(String),
+        },
+      }),
+    )
     const body = JSON.parse(init.body)
     expect(body.record).not.toHaveProperty('boundary')
     expect(body.record).not.toHaveProperty('embed')
@@ -128,34 +160,63 @@ describe('Composer.svelte', () => {
 
   it('shows distinct guidance for a missing and an unavailable PDS space scope', async () => {
     const missing = render(Composer, {
-      props: props({session: session(), enrollment: enrollment('pds'), stratosAgent: null}),
-    })
-    await waitFor(() => expect(screen.getByText(/requires a new space permission/i)).toBeInTheDocument())
-    expect(screen.getByRole('checkbox', {name: /Private/i})).not.toBeChecked()
-    expect(screen.getByRole('checkbox', {name: /Private/i})).toBeDisabled()
-    missing.unmount()
-
-    render(Composer, {
       props: props({
-        session: {...session(), getTokenInfo: vi.fn().mockRejectedValue(new Error('Misato lost the token'))},
+        session: session(),
         enrollment: enrollment('pds'),
         stratosAgent: null,
       }),
     })
-    await waitFor(() => expect(screen.getByText(/could not be verified/i)).toBeInTheDocument())
+    await waitFor(() =>
+      expect(
+        screen.getByText(/requires a new space permission/i),
+      ).toBeInTheDocument(),
+    )
+    expect(screen.getByRole('checkbox', { name: /Private/i })).not.toBeChecked()
+    expect(screen.getByRole('checkbox', { name: /Private/i })).toBeDisabled()
+    missing.unmount()
+
+    render(Composer, {
+      props: props({
+        session: {
+          ...session(),
+          getTokenInfo: vi
+            .fn()
+            .mockRejectedValue(new Error('Misato lost the token')),
+        },
+        enrollment: enrollment('pds'),
+        stratosAgent: null,
+      }),
+    })
+    await waitFor(() =>
+      expect(screen.getByText(/could not be verified/i)).toBeInTheDocument(),
+    )
   })
 
   it('shows an image preview for Stratos custody and blocks image selection for PDS custody', async () => {
-    const {unmount} = render(Composer, {props: props()})
-    const image = new File(['misa'], 'misato.png', {type: 'image/png'})
-    await fireEvent.change(screen.getByLabelText(/🖼️/i), {target: {files: [image]}})
-    await waitFor(() => expect(screen.getByAltText('Preview')).toBeInTheDocument())
+    const { unmount } = render(Composer, { props: props() })
+    const image = new File(['misa'], 'misato.png', { type: 'image/png' })
+    await fireEvent.change(screen.getByLabelText(/🖼️/i), {
+      target: { files: [image] },
+    })
+    await waitFor(() =>
+      expect(screen.getByAltText('Preview')).toBeInTheDocument(),
+    )
     unmount()
 
     render(Composer, {
-      props: props({session: session(SPACE_WRITE_SCOPE), enrollment: enrollment('pds'), stratosAgent: null}),
+      props: props({
+        session: session(SPACE_WRITE_SCOPE),
+        enrollment: enrollment('pds'),
+        stratosAgent: null,
+      }),
     })
-    await waitFor(() => expect(screen.getByText(/Images are not available for PDS-hosted private posts yet/i)).toBeInTheDocument())
+    await waitFor(() =>
+      expect(
+        screen.getByText(
+          /Images are not available for PDS-hosted private posts yet/i,
+        ),
+      ).toBeInTheDocument(),
+    )
     expect(screen.getByLabelText(/🖼️/i)).toBeDisabled()
   })
 })

--- a/webapp/tests/composer.test.ts
+++ b/webapp/tests/composer.test.ts
@@ -192,6 +192,41 @@ describe('Composer.svelte', () => {
     )
   })
 
+  it('previews custody from the granted space scope before enrollment', async () => {
+    const pdsPreview = render(Composer, {
+      props: props({
+        session: session(SPACE_WRITE_SCOPE),
+        enrollment: null,
+        attestationVerified: null,
+        stratosAgent: null,
+      }),
+    })
+    await waitFor(() =>
+      expect(
+        screen.getByText(
+          /Your PDS will hold your private posts after enrollment/i,
+        ),
+      ).toBeInTheDocument(),
+    )
+    pdsPreview.unmount()
+
+    render(Composer, {
+      props: props({
+        session: session(),
+        enrollment: null,
+        attestationVerified: null,
+        stratosAgent: null,
+      }),
+    })
+    await waitFor(() =>
+      expect(
+        screen.getByText(
+          /Stratos will hold your private posts after enrollment/i,
+        ),
+      ).toBeInTheDocument(),
+    )
+  })
+
   it('shows an image preview for Stratos custody and blocks image selection for PDS custody', async () => {
     const { unmount } = render(Composer, { props: props() })
     const image = new File(['misa'], 'misato.png', { type: 'image/png' })

--- a/webapp/tests/composer.test.ts
+++ b/webapp/tests/composer.test.ts
@@ -158,38 +158,77 @@ describe('Composer.svelte', () => {
     expect(body.record).not.toHaveProperty('embed')
   })
 
-  it('shows distinct guidance for a missing and an unavailable PDS space scope', async () => {
+  it('treats the local scope preview as advisory after enrollment', async () => {
+    const missingScopeSession = session()
     const missing = render(Composer, {
       props: props({
-        session: session(),
+        session: missingScopeSession,
         enrollment: enrollment('pds'),
         stratosAgent: null,
       }),
     })
     await waitFor(() =>
       expect(
-        screen.getByText(/requires a new space permission/i),
-      ).toBeInTheDocument(),
+        screen.getByRole('checkbox', { name: /Private/i }),
+      ).not.toBeDisabled(),
     )
-    expect(screen.getByRole('checkbox', { name: /Private/i })).not.toBeChecked()
-    expect(screen.getByRole('checkbox', { name: /Private/i })).toBeDisabled()
+    await fireEvent.input(screen.getByRole('textbox'), {
+      target: { value: 'Rei writes without trusting the preview.' },
+    })
+    await fireEvent.click(screen.getByRole('button', { name: /Post$/ }))
+    await waitFor(() =>
+      expect(missingScopeSession.fetchHandler).toHaveBeenCalledTimes(1),
+    )
+    expect(missingScopeSession.getTokenInfo).not.toHaveBeenCalled()
     missing.unmount()
 
+    const unavailableScopeSession = {
+      ...session(),
+      getTokenInfo: vi
+        .fn()
+        .mockRejectedValue(new Error('Misato lost the token')),
+    }
     render(Composer, {
       props: props({
-        session: {
-          ...session(),
-          getTokenInfo: vi
-            .fn()
-            .mockRejectedValue(new Error('Misato lost the token')),
-        },
+        session: unavailableScopeSession,
         enrollment: enrollment('pds'),
         stratosAgent: null,
       }),
     })
+    await fireEvent.input(screen.getByRole('textbox'), {
+      target: { value: 'Asuka writes while token info is unavailable.' },
+    })
+    await fireEvent.click(screen.getByRole('button', { name: /Post$/ }))
     await waitFor(() =>
-      expect(screen.getByText(/could not be verified/i)).toBeInTheDocument(),
+      expect(unavailableScopeSession.fetchHandler).toHaveBeenCalledTimes(1),
     )
+    expect(unavailableScopeSession.getTokenInfo).not.toHaveBeenCalled()
+  })
+
+  it('shows reauthorization guidance when the PDS rejects the space grant', async () => {
+    const pdsSession = session(SPACE_WRITE_SCOPE)
+    pdsSession.fetchHandler.mockResolvedValue(
+      new Response('Missing required scope', { status: 403 }),
+    )
+    render(Composer, {
+      props: props({
+        session: pdsSession,
+        enrollment: enrollment('pds'),
+        stratosAgent: null,
+      }),
+    })
+
+    await fireEvent.input(screen.getByRole('textbox'), {
+      target: { value: 'Rei needs a renewed grant.' },
+    })
+    await fireEvent.click(screen.getByRole('button', { name: /Post$/ }))
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(/requires a new space permission/i),
+      ).toBeInTheDocument(),
+    )
+    expect(pdsSession.fetchHandler).toHaveBeenCalledTimes(1)
   })
 
   it('previews custody from the granted space scope before enrollment', async () => {

--- a/webapp/tests/composer.test.ts
+++ b/webapp/tests/composer.test.ts
@@ -1,57 +1,161 @@
-import { describe, expect, it, vi } from 'vitest'
-import { fireEvent, render, screen } from '@testing-library/svelte'
-import type { StratosEnrollment } from '../src/lib/stratos'
+import {describe, expect, it, vi} from 'vitest'
+import {fireEvent, render, screen, waitFor} from '@testing-library/svelte'
+import type {StratosEnrollment} from '../src/lib/stratos'
+import {SPACE_WRITE_SCOPE} from '../src/lib/auth'
 import Composer from '../src/lib/Composer.svelte'
 
-describe('Composer.svelte', () => {
-  const mockProps = {
-    session: {
-      sub: 'did:plc:alice',
-      did: 'did:plc:alice',
-      signOut: vi.fn(),
-      getTokenInfo: vi.fn(),
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } as unknown as any,
-    enrollment: {
-      service: 'did:web:stratos.ngrok.dev',
-      boundaries: [{ value: 'did:web:stratos.ngrok.dev/example.com' }],
-      signingKey: 'did:key:zQ3shj...',
-      attestation: null,
-      createdAt: new Date().toISOString(),
-      rkey: 'example.com',
-    } as StratosEnrollment,
+const stratosCreateRecord = vi.fn().mockResolvedValue({})
+
+function enrollment(custody: StratosEnrollment['custody']): StratosEnrollment {
+  return {
+    service: 'https://stratos.example',
+    custody,
+    boundaries: [{value: 'did:web:stratos.example/nerve'}],
+    signingKey: 'did:key:zQ3shjRei',
+    attestation: null,
+    createdAt: '1998-04-03T00:00:00.000Z',
+    rkey: 'nerve',
+  }
+}
+
+function session(scope = '') {
+  return {
+    sub: 'did:plc:faye',
+    did: 'did:plc:faye',
+    getTokenInfo: vi.fn().mockResolvedValue({scope}),
+    fetchHandler: vi.fn().mockResolvedValue(new Response('', {status: 200})),
+  }
+}
+
+function props(overrides: Record<string, unknown> = {}) {
+  return {
+    session: session(),
+    enrollment: enrollment('stratos'),
+    attestationVerified: true,
     stratosAgent: {
-      zone: {
-        stratos: {
-          repo: { uploadBlob: vi.fn(), createRecord: vi.fn() },
-        },
-      },
-    } as unknown as {
-      zone: {
-        stratos: {
-          repo: { uploadBlob: unknown; createRecord: unknown }
-        }
-      }
+      com: {atproto: {repo: {uploadBlob: vi.fn(), createRecord: stratosCreateRecord}}},
     },
     replyingTo: null,
     onpost: vi.fn(),
     oncancelreply: vi.fn(),
+    ...overrides,
   }
+}
 
-  it('renders correctly', () => {
-    render(Composer, { props: mockProps })
-    expect(
-      screen.getByPlaceholderText(/Post to example.com…/i),
-    ).toBeInTheDocument()
-    expect(screen.getByText('Post')).toBeInTheDocument()
+describe('Composer.svelte', () => {
+  it('renders a private Stratos composer', () => {
+    render(Composer, {props: props()})
+
+    expect(screen.getByPlaceholderText(/Post to nerve…/i)).toBeInTheDocument()
+    expect(screen.getByRole('checkbox', {name: /Private/i})).toBeChecked()
   })
 
-  it('toggles privacy', async () => {
-    render(Composer, { props: mockProps })
-    const toggle = screen.getByRole('checkbox', { name: /Private/i })
-    expect(toggle).toBeChecked()
+  it('unchecks and disables private mode when the attestation fails', async () => {
+    render(Composer, {props: props({attestationVerified: false})})
 
-    await fireEvent.click(toggle)
-    expect(toggle).not.toBeChecked()
+    const toggle = screen.getByRole('checkbox', {name: /Private/i})
+    await waitFor(() => expect(toggle).not.toBeChecked())
+    expect(toggle).toBeDisabled()
+  })
+
+  it('does not fall back to a public post when private Stratos routing is unavailable', async () => {
+    render(Composer, {props: props({stratosAgent: null})})
+
+    await fireEvent.input(screen.getByRole('textbox'), {target: {value: 'Faye holds the line.'}})
+    await fireEvent.click(screen.getByRole('button', {name: /Post$/}))
+
+    expect(screen.getByText(/Stratos service is not connected/i)).toBeInTheDocument()
+    expect(stratosCreateRecord).not.toHaveBeenCalled()
+  })
+
+  it('writes a private Stratos post with its boundary', async () => {
+    const createRecord = vi.fn().mockResolvedValue({})
+    const onpost = vi.fn()
+    render(Composer, {
+      props: props({
+        stratosAgent: {com: {atproto: {repo: {uploadBlob: vi.fn(), createRecord}}}},
+        onpost,
+      }),
+    })
+
+    await fireEvent.input(screen.getByRole('textbox'), {target: {value: 'Motoko checks the perimeter.'}})
+    await fireEvent.click(screen.getByRole('button', {name: /Post$/}))
+
+    await waitFor(() => expect(createRecord).toHaveBeenCalledTimes(1))
+    expect(createRecord).toHaveBeenCalledWith(expect.objectContaining({
+      repo: 'did:plc:faye',
+      collection: 'zone.stratos.feed.post',
+      record: expect.objectContaining({
+        text: 'Motoko checks the perimeter.',
+        boundary: {
+          $type: 'zone.stratos.boundary.defs#Domains',
+          values: [{value: 'did:web:stratos.example/nerve'}],
+        },
+      }),
+    }))
+    expect(onpost).toHaveBeenCalledTimes(1)
+  })
+
+  it('writes PDS-custody posts through the space endpoint without a boundary or embed', async () => {
+    const pdsSession = session(SPACE_WRITE_SCOPE)
+    render(Composer, {
+      props: props({session: pdsSession, enrollment: enrollment('pds'), stratosAgent: null}),
+    })
+
+    await waitFor(() => expect(screen.getByRole('checkbox', {name: /Private/i})).not.toBeDisabled())
+    await fireEvent.input(screen.getByRole('textbox'), {target: {value: 'Rei keeps the record.'}})
+    await fireEvent.click(screen.getByRole('button', {name: /Post$/}))
+
+    await waitFor(() => expect(pdsSession.fetchHandler).toHaveBeenCalledTimes(1))
+    const [path, init] = pdsSession.fetchHandler.mock.calls[0]
+    expect(path).toBe('/xrpc/com.atproto.space.createRecord')
+    expect(init).toMatchObject({method: 'POST', headers: {'content-type': 'application/json'}})
+    expect(JSON.parse(init.body)).toEqual(expect.objectContaining({
+      space: 'at://did:web:stratos.example/space/zone.stratos.space.feed/nerve',
+      repo: 'did:plc:faye',
+      collection: 'zone.stratos.feed.post',
+      validate: false,
+      record: {
+        $type: 'zone.stratos.feed.post',
+        text: 'Rei keeps the record.',
+        createdAt: expect.any(String),
+      },
+    }))
+    const body = JSON.parse(init.body)
+    expect(body.record).not.toHaveProperty('boundary')
+    expect(body.record).not.toHaveProperty('embed')
+  })
+
+  it('shows distinct guidance for a missing and an unavailable PDS space scope', async () => {
+    const missing = render(Composer, {
+      props: props({session: session(), enrollment: enrollment('pds'), stratosAgent: null}),
+    })
+    await waitFor(() => expect(screen.getByText(/requires a new space permission/i)).toBeInTheDocument())
+    expect(screen.getByRole('checkbox', {name: /Private/i})).not.toBeChecked()
+    expect(screen.getByRole('checkbox', {name: /Private/i})).toBeDisabled()
+    missing.unmount()
+
+    render(Composer, {
+      props: props({
+        session: {...session(), getTokenInfo: vi.fn().mockRejectedValue(new Error('Misato lost the token'))},
+        enrollment: enrollment('pds'),
+        stratosAgent: null,
+      }),
+    })
+    await waitFor(() => expect(screen.getByText(/could not be verified/i)).toBeInTheDocument())
+  })
+
+  it('shows an image preview for Stratos custody and blocks image selection for PDS custody', async () => {
+    const {unmount} = render(Composer, {props: props()})
+    const image = new File(['misa'], 'misato.png', {type: 'image/png'})
+    await fireEvent.change(screen.getByLabelText(/🖼️/i), {target: {files: [image]}})
+    await waitFor(() => expect(screen.getByAltText('Preview')).toBeInTheDocument())
+    unmount()
+
+    render(Composer, {
+      props: props({session: session(SPACE_WRITE_SCOPE), enrollment: enrollment('pds'), stratosAgent: null}),
+    })
+    await waitFor(() => expect(screen.getByText(/Images are not available for PDS-hosted private posts yet/i)).toBeInTheDocument())
+    expect(screen.getByLabelText(/🖼️/i)).toBeDisabled()
   })
 })

--- a/webapp/tests/e2e/private-post-image.spec.ts
+++ b/webapp/tests/e2e/private-post-image.spec.ts
@@ -1,12 +1,28 @@
 import { expect, test } from '@playwright/test'
+import { encode as cborEncode } from '@atcute/cbor'
+import { Secp256k1Keypair } from '@atproto/crypto'
 
 import { TEST_PNG } from './fixtures/test-image'
 
 const STRATOS_URL = 'https://stratos.example.com'
 const APPVIEW_URL = 'https://appview.example.com'
+const USER_DID = 'did:plc:mock'
+const USER_SIGNING_KEY = 'did:key:zMockUserSigningKey'
+
+const toBase64 = (bytes: Uint8Array) =>
+  btoa(String.fromCharCode(...Array.from(bytes)))
 
 test.describe('Private Post with Image', () => {
   test.beforeEach(async ({ page }) => {
+    const serviceKeypair = await Secp256k1Keypair.create({ exportable: true })
+    const attestationSignature = await serviceKeypair.sign(
+      cborEncode({
+        boundaries: ['example.com'],
+        did: USER_DID,
+        signingKey: USER_SIGNING_KEY,
+      }),
+    )
+
     // Inject mock session
     await page.addInitScript(() => {
       interface CustomWindow extends Window {
@@ -65,10 +81,10 @@ test.describe('Private Post with Image', () => {
                   $type: 'zone.stratos.actor.enrollment',
                   service: 'https://stratos.example.com',
                   boundaries: [{ value: 'example.com' }],
-                  signingKey: 'did:key:zMockUserSigningKey',
+                  signingKey: USER_SIGNING_KEY,
                   attestation: {
-                    sig: { $bytes: 'AAAA' },
-                    signingKey: 'did:key:zMockServiceSigningKey',
+                    sig: { $bytes: toBase64(attestationSignature) },
+                    signingKey: serviceKeypair.did(),
                   },
                   createdAt: new Date().toISOString(),
                 },

--- a/webapp/tests/feed.test.ts
+++ b/webapp/tests/feed.test.ts
@@ -6,6 +6,7 @@ import {
   feedStats,
   resolveHandles,
   groupIntoThreads,
+  authorFromUri,
   type FeedPost,
 } from '../src/lib/feed'
 
@@ -23,6 +24,19 @@ const createPost = (overrides: Partial<FeedPost> = {}): FeedPost => ({
 })
 
 describe('feed logic', () => {
+  describe('authorFromUri', () => {
+    it('extracts authors from custody and space record URIs', () => {
+      expect(
+        authorFromUri(
+          'at://did:web:stratos.example/space/zone.stratos.space.feed/engineering/did:plc:faye/zone.stratos.feed.post/1',
+        ),
+      ).toBe('did:plc:faye')
+      expect(authorFromUri('at://did:plc:spike/zone.stratos.feed.post/1')).toBe(
+        'did:plc:spike',
+      )
+    })
+  })
+
   describe('buildUnifiedFeed', () => {
     it('combines and sorts posts by date descending', () => {
       const p1 = createPost({

--- a/webapp/tests/feed_extended.test.ts
+++ b/webapp/tests/feed_extended.test.ts
@@ -248,14 +248,14 @@ describe('feed extended logic', () => {
             feed: [
               {
                 post: {
-                  uri: 'at://did:web:service.test/space/zone.stratos.space.feed/engineering/did:plc:motoko/zone.stratos.feed.post/1',
+                  uri: 'at://did:web:section-9.test/space/zone.stratos.space.feed/section-9/did:plc:motoko/zone.stratos.feed.post/1',
                   cid: 'cid1',
                   record: {
                     text: 'Motoko posts from the PDS space.',
                     createdAt: '2024-01-01T12:00:00Z',
                   },
                   author: { did: 'did:plc:motoko' },
-                  boundaries: ['engineering'],
+                  boundaries: ['section-9'],
                 },
               },
             ],
@@ -265,17 +265,17 @@ describe('feed extended logic', () => {
 
       const result = await fetchFeedgenPosts(
         mockSession,
-        'did:web:feedgen.test',
-        'engineering',
+        'did:web:batou.test',
+        'section-9',
       )
 
       expect(result.posts).toHaveLength(1)
-      expect(result.posts[0]?.boundaries).toEqual(['engineering'])
+      expect(result.posts[0]?.boundaries).toEqual(['section-9'])
       expect(mockSession.fetchHandler).toHaveBeenCalledWith(
         expect.stringContaining('/xrpc/zone.stratos.feedgen.getFeed'),
         expect.objectContaining({
           headers: {
-            'atproto-proxy': 'did:web:feedgen.test#stratos_feedgen',
+            'atproto-proxy': 'did:web:batou.test#stratos_feedgen',
           },
           method: 'GET',
         }),

--- a/webapp/tests/feed_extended.test.ts
+++ b/webapp/tests/feed_extended.test.ts
@@ -4,6 +4,7 @@ import {
   fetchPublicPosts,
   fetchStratosPosts,
   fetchAppviewStratosPosts,
+  fetchFeedgenPosts,
   findPost,
   type FeedPost,
 } from '../src/lib/feed'
@@ -235,6 +236,50 @@ describe('feed extended logic', () => {
         'https://appview.stratos.actor',
       )
       expect(result.posts).toEqual([])
+    })
+  })
+
+  describe('fetchFeedgenPosts', () => {
+    it('uses feedgen boundaries for a PDS-custody post', async () => {
+      const mockSession = {
+        fetchHandler: vi.fn().mockResolvedValue({
+          ok: true,
+          json: async () => ({
+            feed: [
+              {
+                post: {
+                  uri: 'at://did:web:service.test/space/zone.stratos.space.feed/engineering/did:plc:motoko/zone.stratos.feed.post/1',
+                  cid: 'cid1',
+                  record: {
+                    text: 'Motoko posts from the PDS space.',
+                    createdAt: '2024-01-01T12:00:00Z',
+                  },
+                  author: { did: 'did:plc:motoko' },
+                  boundaries: ['engineering'],
+                },
+              },
+            ],
+          }),
+        }),
+      } as unknown as OAuthSession
+
+      const result = await fetchFeedgenPosts(
+        mockSession,
+        'did:web:feedgen.test',
+        'engineering',
+      )
+
+      expect(result.posts).toHaveLength(1)
+      expect(result.posts[0]?.boundaries).toEqual(['engineering'])
+      expect(mockSession.fetchHandler).toHaveBeenCalledWith(
+        expect.stringContaining('/xrpc/zone.stratos.feedgen.getFeed'),
+        expect.objectContaining({
+          headers: {
+            'atproto-proxy': 'did:web:feedgen.test#stratos_feedgen',
+          },
+          method: 'GET',
+        }),
+      )
     })
   })
 

--- a/webapp/tests/mixed-feed.test.ts
+++ b/webapp/tests/mixed-feed.test.ts
@@ -1,9 +1,85 @@
 import { describe, expect, it, vi } from 'vitest'
 import { render, screen } from '@testing-library/svelte'
+import type { OAuthSession } from '@atproto/oauth-client-browser'
 import Feed from '../src/lib/Feed.svelte'
+import { fetchFeedgenPosts } from '../src/lib/feed'
 
 describe('Feed.svelte', () => {
-  it('renders public and private authors from the same unified feed', () => {
+  it('renders both custody classes with real authors from the feedgen path', async () => {
+    const fetchHandler = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          feed: [
+            {
+              post: {
+                uri: 'at://did:plc:misato/zone.stratos.feed.post/one',
+                cid: 'misato-cid',
+                author: { did: 'did:plc:misato' },
+                indexedAt: '1998-04-03T00:00:00.000Z',
+                record: {
+                  $type: 'zone.stratos.feed.post',
+                  text: 'Misato keeps the Stratos copy.',
+                  createdAt: '1998-04-03T00:00:00.000Z',
+                  boundary: {
+                    $type: 'zone.stratos.boundary.defs#Domains',
+                    values: [{ value: 'did:web:stratos.example/nerve' }],
+                  },
+                },
+              },
+            },
+            {
+              post: {
+                uri: 'at://did:web:stratos.example/space/zone.stratos.space.feed/nerve/did:plc:asuka/zone.stratos.feed.post/two',
+                cid: 'asuka-cid',
+                author: { did: 'did:plc:asuka' },
+                indexedAt: '1998-04-04T00:00:00.000Z',
+                record: {
+                  $type: 'zone.stratos.feed.post',
+                  text: 'Asuka keeps the PDS copy.',
+                  createdAt: '1998-04-04T00:00:00.000Z',
+                },
+              },
+            },
+          ],
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      ),
+    )
+    const session = {
+      sub: 'did:plc:shinji',
+      fetchHandler,
+    } as unknown as OAuthSession
+
+    const { posts } = await fetchFeedgenPosts(
+      session,
+      'did:web:feedgen.example',
+      'nerve',
+    )
+
+    expect(fetchHandler).toHaveBeenCalledWith(
+      '/xrpc/zone.stratos.feedgen.getFeed?feed=nerve&limit=50',
+      {
+        method: 'GET',
+        headers: {
+          'atproto-proxy': 'did:web:feedgen.example#stratos_feedgen',
+        },
+      },
+    )
+    expect(posts.map(({ author }) => author)).toEqual([
+      'did:plc:misato',
+      'did:plc:asuka',
+    ])
+    expect(posts).toMatchObject([
+      {
+        uri: 'at://did:plc:misato/zone.stratos.feed.post/one',
+        isPrivate: true,
+      },
+      {
+        uri: 'at://did:web:stratos.example/space/zone.stratos.space.feed/nerve/did:plc:asuka/zone.stratos.feed.post/two',
+        isPrivate: true,
+      },
+    ])
+
     render(Feed, {
       props: {
         loading: false,
@@ -11,37 +87,16 @@ describe('Feed.svelte', () => {
         publicAgent: null,
         serviceUrl: 'https://stratos.example',
         onreply: vi.fn(),
-        posts: [
-          {
-            uri: 'at://did:plc:faye/app.bsky.feed.post/one',
-            cid: 'faye-cid',
-            author: 'did:plc:faye',
-            authorHandle: 'faye.example',
-            text: 'Faye posts in public.',
-            createdAt: '1999-02-01T00:00:00.000Z',
-            boundaries: [],
-            isPrivate: false,
-            reply: null,
-          },
-          {
-            uri: 'at://did:web:stratos.example/space/zone.stratos.space.feed/nerve/did:plc:rei/zone.stratos.feed.post/two',
-            cid: 'rei-cid',
-            author: 'did:plc:rei',
-            authorHandle: 'rei.example',
-            text: 'Rei posts in private.',
-            createdAt: '1999-02-02T00:00:00.000Z',
-            boundaries: ['did:web:stratos.example/nerve'],
-            isPrivate: true,
-            reply: null,
-          },
-        ],
+        posts,
       },
     })
 
-    expect(screen.getByText('@faye.example')).toBeInTheDocument()
-    expect(screen.getByText('@rei.example')).toBeInTheDocument()
-    expect(screen.getByText('Faye posts in public.')).toBeInTheDocument()
-    expect(screen.getByText('Rei posts in private.')).toBeInTheDocument()
-    expect(screen.getByText('Private')).toBeInTheDocument()
+    expect(screen.getByText('@did:plc:misato')).toBeInTheDocument()
+    expect(screen.getByText('@did:plc:asuka')).toBeInTheDocument()
+    expect(
+      screen.getByText('Misato keeps the Stratos copy.'),
+    ).toBeInTheDocument()
+    expect(screen.getByText('Asuka keeps the PDS copy.')).toBeInTheDocument()
+    expect(screen.getAllByText('Private')).toHaveLength(2)
   })
 })

--- a/webapp/tests/mixed-feed.test.ts
+++ b/webapp/tests/mixed-feed.test.ts
@@ -1,0 +1,47 @@
+import {describe, expect, it, vi} from 'vitest'
+import {render, screen} from '@testing-library/svelte'
+import Feed from '../src/lib/Feed.svelte'
+
+describe('Feed.svelte', () => {
+  it('renders public and private authors from the same unified feed', () => {
+    render(Feed, {
+      props: {
+        loading: false,
+        stratosAgent: null,
+        publicAgent: null,
+        serviceUrl: 'https://stratos.example',
+        onreply: vi.fn(),
+        posts: [
+          {
+            uri: 'at://did:plc:faye/app.bsky.feed.post/one',
+            cid: 'faye-cid',
+            author: 'did:plc:faye',
+            authorHandle: 'faye.example',
+            text: 'Faye posts in public.',
+            createdAt: '1999-02-01T00:00:00.000Z',
+            boundaries: [],
+            isPrivate: false,
+            reply: null,
+          },
+          {
+            uri: 'at://did:web:stratos.example/space/zone.stratos.space.feed/nerve/did:plc:rei/zone.stratos.feed.post/two',
+            cid: 'rei-cid',
+            author: 'did:plc:rei',
+            authorHandle: 'rei.example',
+            text: 'Rei posts in private.',
+            createdAt: '1999-02-02T00:00:00.000Z',
+            boundaries: ['did:web:stratos.example/nerve'],
+            isPrivate: true,
+            reply: null,
+          },
+        ],
+      },
+    })
+
+    expect(screen.getByText('@faye.example')).toBeInTheDocument()
+    expect(screen.getByText('@rei.example')).toBeInTheDocument()
+    expect(screen.getByText('Faye posts in public.')).toBeInTheDocument()
+    expect(screen.getByText('Rei posts in private.')).toBeInTheDocument()
+    expect(screen.getByText('Private')).toBeInTheDocument()
+  })
+})

--- a/webapp/tests/mixed-feed.test.ts
+++ b/webapp/tests/mixed-feed.test.ts
@@ -1,5 +1,5 @@
-import {describe, expect, it, vi} from 'vitest'
-import {render, screen} from '@testing-library/svelte'
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/svelte'
 import Feed from '../src/lib/Feed.svelte'
 
 describe('Feed.svelte', () => {

--- a/webapp/tests/post-card.test.ts
+++ b/webapp/tests/post-card.test.ts
@@ -22,6 +22,30 @@ describe('PostCard.svelte', () => {
     expect(screen.getByText('@alice.bsky.social')).toBeInTheDocument()
   })
 
+  it('removes unsafe schemes from record-derived URLs', () => {
+    const postWithExternal = {
+      ...mockPost,
+      embed: {
+        $type: 'app.bsky.embed.external',
+        external: {
+          uri: 'javascript:alert(1)',
+          title: 'Unsafe link',
+          description: 'Untrusted record input',
+        },
+      },
+    }
+
+    render(PostCard, {
+      post: postWithExternal,
+      stratosAgent: null,
+      onreply: () => {},
+    })
+
+    expect(screen.getByText('Unsafe link').closest('a')).not.toHaveAttribute(
+      'href',
+    )
+  })
+
   it('handles image extraction from $link structure', () => {
     const postWithImage = {
       ...mockPost,

--- a/webapp/tests/post-card.test.ts
+++ b/webapp/tests/post-card.test.ts
@@ -22,6 +22,28 @@ describe('PostCard.svelte', () => {
     expect(screen.getByText('@alice.bsky.social')).toBeInTheDocument()
   })
 
+  it('attributes a space reply parent to its record author', () => {
+    render(PostCard, {
+      post: {
+        ...mockPost,
+        reply: {
+          root: { uri: mockPost.uri, cid: mockPost.cid },
+          parent: {
+            uri: 'at://did:web:stratos.example/space/zone.stratos.space.feed/nerve/did:plc:asuka/zone.stratos.feed.post/two',
+            cid: 'asuka-cid',
+          },
+        },
+      },
+      stratosAgent: null,
+      onreply: () => {},
+    })
+
+    expect(screen.getByText('↩ replying to did:plc:asuka')).toBeInTheDocument()
+    expect(
+      screen.queryByText(/replying to did:web:stratos\.example/),
+    ).not.toBeInTheDocument()
+  })
+
   it('removes unsafe schemes from record-derived URLs', () => {
     const postWithExternal = {
       ...mockPost,

--- a/webapp/tests/sidebar.test.ts
+++ b/webapp/tests/sidebar.test.ts
@@ -1,0 +1,37 @@
+import {describe, expect, it, vi} from 'vitest'
+import {render, screen} from '@testing-library/svelte'
+import Sidebar from '../src/lib/Sidebar.svelte'
+
+describe('Sidebar.svelte', () => {
+  it('shows PDS custody from the enrollment record and persistent attestation failure text', () => {
+    render(Sidebar, {
+      props: {
+        handle: 'misato.example',
+        enrollment: {
+          service: 'https://stratos.example',
+          custody: 'pds',
+          boundaries: [{value: 'did:web:stratos.example/nerve'}],
+          signingKey: 'did:key:zQ3shjMisato',
+          attestation: null,
+          createdAt: '1995-10-04T00:00:00.000Z',
+          rkey: 'nerve',
+        },
+        serviceUrl: 'https://stratos.example',
+        stratosStatus: {enrolled: true},
+        attestationVerified: false,
+        allDomains: ['did:web:stratos.example/nerve'],
+        enrolledDomains: ['did:web:stratos.example/nerve'],
+        postCount: 3,
+        userCount: 1,
+        activeFeed: null,
+        onSelectFeed: vi.fn(),
+      },
+    })
+
+    expect(screen.getByText('Record custody')).toBeInTheDocument()
+    expect(screen.getByText('PDS')).toBeInTheDocument()
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'The enrollment attestation could not be verified. Private posting is disabled.',
+    )
+  })
+})

--- a/webapp/tests/sidebar.test.ts
+++ b/webapp/tests/sidebar.test.ts
@@ -1,5 +1,5 @@
-import {describe, expect, it, vi} from 'vitest'
-import {render, screen} from '@testing-library/svelte'
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/svelte'
 import Sidebar from '../src/lib/Sidebar.svelte'
 
 describe('Sidebar.svelte', () => {
@@ -10,14 +10,14 @@ describe('Sidebar.svelte', () => {
         enrollment: {
           service: 'https://stratos.example',
           custody: 'pds',
-          boundaries: [{value: 'did:web:stratos.example/nerve'}],
+          boundaries: [{ value: 'did:web:stratos.example/nerve' }],
           signingKey: 'did:key:zQ3shjMisato',
           attestation: null,
           createdAt: '1995-10-04T00:00:00.000Z',
           rkey: 'nerve',
         },
         serviceUrl: 'https://stratos.example',
-        stratosStatus: {enrolled: true},
+        stratosStatus: { enrolled: true },
         attestationVerified: false,
         allDomains: ['did:web:stratos.example/nerve'],
         enrolledDomains: ['did:web:stratos.example/nerve'],

--- a/webapp/tests/stratos.test.ts
+++ b/webapp/tests/stratos.test.ts
@@ -79,6 +79,7 @@ describe('stratos logic', () => {
       const enrollment = await discoverStratosEnrollment(mockSession)
       expect(enrollment).not.toBeNull()
       expect(enrollment?.service).toBe('https://stratos.example.com')
+      expect(enrollment?.custody).toBe('stratos')
       expect(enrollment?.rkey).toBe('1')
       expect(mockAgent.com.atproto.repo.listRecords).toHaveBeenCalled()
     })
@@ -91,6 +92,8 @@ describe('stratos logic', () => {
           uri: 'at://did:plc:user1/zone.stratos.actor.enrollment/did:web:test.stratos.actor',
           value: {
             service: 'https://stratos.example.com',
+            custody: 'pds',
+            repoHost: 'https://pds.example.com',
             boundaries: [{ value: 'eng' }],
             signingKey: 'key1',
             createdAt: '2024-01-01T12:00:00Z',
@@ -102,6 +105,8 @@ describe('stratos logic', () => {
       expect(enrollment).not.toBeNull()
       expect(enrollment?.service).toBe('https://stratos.example.com')
       expect(enrollment?.rkey).toBe('did:web:test.stratos.actor')
+      expect(enrollment?.custody).toBe('pds')
+      expect(enrollment?.repoHost).toBe('https://pds.example.com')
       expect(mockAgent.com.atproto.repo.getRecord).toHaveBeenCalledWith({
         repo: 'did:plc:user1',
         collection: 'zone.stratos.actor.enrollment',
@@ -225,6 +230,7 @@ describe('stratos logic', () => {
     it('returns false if no attestation', async () => {
       const enrollment: StratosEnrollment = {
         service: 'https://s1.com',
+        custody: 'stratos',
         boundaries: [],
         signingKey: 'k1',
         attestation: null,
@@ -241,6 +247,7 @@ describe('stratos logic', () => {
 
       const enrollment: StratosEnrollment = {
         service: 'https://s1.com',
+        custody: 'stratos',
         boundaries: [{ value: 'eng' }],
         signingKey: 'k1',
         attestation: {


### PR DESCRIPTION
## Summary

- Add mixed Stratos and PDS custody state to the web application.
- Route private post creation according to the selected custody mode.
- Show custody and mixed-feed state in the composer, sidebar, and post cards.
- Add focused webapp coverage for enrollment discovery, composing, feed merging, and rendering.
- Use a valid signed attestation in the private-image Playwright fixture.

## Stack

- Depends on #170
- Next: #173

## Verification

The reconstructed full stack passes:

- `pnpm format:check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` — 197 files passed, 2,484 tests passed, 32 skipped
- Private-image Playwright scenario — passed in Docker


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for private posts stored on either Stratos or a personal data server.
  - Added permission checks and guidance for private posting, including image-upload restrictions.
  - Added support for the Stratos Feed space and improved custody details in enrollment information.
  - Added attestation verification status and clearer warnings when verification fails.
  - Improved feed boundary handling and author attribution.

- **Bug Fixes**
  - Prevented outdated discovery and feed refresh results from overwriting current session data.
  - Blocked unsafe external URLs, including unsupported protocols, from being rendered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->