### PR TITLE
MM-08: Add custody to the admin interface

### DIFF
--- a/lexicons/zone/stratos/admin/getRepoHost.json
+++ b/lexicons/zone/stratos/admin/getRepoHost.json
@@ -1,0 +1,72 @@
+{
+  "lexicon": 1,
+  "id": "zone.stratos.admin.getRepoHost",
+  "defs": {
+    "main": {
+      "type": "query",
+      "description": "Resolve repository hosts for an enrolled member's spaces. Requires admin authorization.",
+      "parameters": {
+        "type": "params",
+        "required": ["did"],
+        "properties": {
+          "did": {
+            "type": "string",
+            "format": "did",
+            "description": "The enrolled member DID."
+          }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["did", "custody", "isService", "resolutions"],
+          "properties": {
+            "did": {
+              "type": "string",
+              "format": "did"
+            },
+            "custody": {
+              "type": "string",
+              "enum": ["stratos", "pds"],
+              "description": "Who hosts the member repository."
+            },
+            "isService": {
+              "type": "boolean",
+              "description": "Whether this is a service enrollment."
+            },
+            "resolutions": {
+              "type": "array",
+              "items": {
+                "type": "ref",
+                "ref": "#resolution"
+              }
+            }
+          }
+        }
+      }
+    },
+    "resolution": {
+      "type": "object",
+      "required": ["boundary", "spaceUri"],
+      "properties": {
+        "boundary": {
+          "type": "ref",
+          "ref": "zone.stratos.boundary.defs#Domain"
+        },
+        "spaceUri": {
+          "type": "string",
+          "format": "uri"
+        },
+        "host": {
+          "type": "string",
+          "format": "uri"
+        },
+        "source": {
+          "type": "string",
+          "enum": ["authority-override", "did-document"]
+        }
+      }
+    }
+  }
+}

--- a/lexicons/zone/stratos/admin/listEnrollments.json
+++ b/lexicons/zone/stratos/admin/listEnrollments.json
@@ -29,7 +29,7 @@
           },
           "custody": {
             "type": "string",
-            "enum": ["stratos", "pds"],
+            "knownValues": ["stratos", "pds"],
             "description": "Only return enrollments with this repo custody."
           }
         }
@@ -53,7 +53,7 @@
             },
             "total": {
               "type": "integer",
-              "description": "Total number of enrollments in the service. Absent when a boundary filter is applied."
+              "description": "Total number of enrollments in the service. Absent when any filter is applied."
             }
           }
         }
@@ -83,7 +83,7 @@
         },
         "custody": {
           "type": "string",
-          "enum": ["stratos", "pds"],
+          "knownValues": ["stratos", "pds"],
           "description": "Who hosts the member repository."
         },
         "repoHost": {

--- a/lexicons/zone/stratos/admin/listEnrollments.json
+++ b/lexicons/zone/stratos/admin/listEnrollments.json
@@ -22,6 +22,15 @@
           "boundary": {
             "type": "string",
             "description": "Only return members holding this boundary."
+          },
+          "active": {
+            "type": "boolean",
+            "description": "Only return active or inactive enrollments."
+          },
+          "custody": {
+            "type": "string",
+            "enum": ["stratos", "pds"],
+            "description": "Only return enrollments with this repo custody."
           }
         }
       },
@@ -52,7 +61,7 @@
     },
     "enrollment": {
       "type": "object",
-      "required": ["did", "enrolledAt", "active", "boundaries"],
+      "required": ["did", "enrolledAt", "active", "custody", "boundaries"],
       "properties": {
         "did": {
           "type": "string",
@@ -71,6 +80,16 @@
         "isService": {
           "type": "boolean",
           "description": "Whether this is a service enrollment rather than a user."
+        },
+        "custody": {
+          "type": "string",
+          "enum": ["stratos", "pds"],
+          "description": "Who hosts the member repository."
+        },
+        "repoHost": {
+          "type": "string",
+          "format": "uri",
+          "description": "The repository host recorded for a PDS-custody member."
         },
         "boundaries": {
           "type": "array",

--- a/stratos-client/README.md
+++ b/stratos-client/README.md
@@ -644,6 +644,11 @@ The bundle contains only the `zone.stratos.*` lexicons — the standard `com.atp
 any overlap. The bundle is generated from the canonical lexicon JSON at build time (`pnpm lexgen`)
 and exported from the `./lexicons` subpath to keep the package root lightweight for atcute consumers.
 
+The bundle also includes the admin-only `zone.stratos.admin.listEnrollments` and
+`zone.stratos.admin.getRepoHost` queries. These endpoints require an operator session. The former
+filters by boundary, active state, or repo custody. The latter reports one repository-host resolution
+per member space; a PDS-custody member's stored host overrides every one of their spaces.
+
 ---
 
 ## 10. CORS and Header Requirements

--- a/stratos-client/src/lexicons.gen.ts
+++ b/stratos-client/src/lexicons.gen.ts
@@ -263,7 +263,7 @@ export const stratosLexicons: LexiconDoc[] = [
           },
           "custody": {
             "type": "string",
-            "enum": ["stratos", "pds"],
+            "knownValues": ["stratos", "pds"],
             "description": "Only return enrollments with this repo custody."
           }
         }
@@ -287,7 +287,7 @@ export const stratosLexicons: LexiconDoc[] = [
             },
             "total": {
               "type": "integer",
-              "description": "Total number of enrollments in the service. Absent when a boundary filter is applied."
+              "description": "Total number of enrollments in the service. Absent when any filter is applied."
             }
           }
         }
@@ -317,7 +317,7 @@ export const stratosLexicons: LexiconDoc[] = [
         },
         "custody": {
           "type": "string",
-          "enum": ["stratos", "pds"],
+          "knownValues": ["stratos", "pds"],
           "description": "Who hosts the member repository."
         },
         "repoHost": {

--- a/stratos-client/src/lexicons.gen.ts
+++ b/stratos-client/src/lexicons.gen.ts
@@ -112,6 +112,78 @@ export const stratosLexicons: LexiconDoc[] = [
 },
 {
   "lexicon": 1,
+  "id": "zone.stratos.admin.getRepoHost",
+  "defs": {
+    "main": {
+      "type": "query",
+      "description": "Resolve repository hosts for an enrolled member's spaces. Requires admin authorization.",
+      "parameters": {
+        "type": "params",
+        "required": ["did"],
+        "properties": {
+          "did": {
+            "type": "string",
+            "format": "did",
+            "description": "The enrolled member DID."
+          }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["did", "custody", "isService", "resolutions"],
+          "properties": {
+            "did": {
+              "type": "string",
+              "format": "did"
+            },
+            "custody": {
+              "type": "string",
+              "enum": ["stratos", "pds"],
+              "description": "Who hosts the member repository."
+            },
+            "isService": {
+              "type": "boolean",
+              "description": "Whether this is a service enrollment."
+            },
+            "resolutions": {
+              "type": "array",
+              "items": {
+                "type": "ref",
+                "ref": "#resolution"
+              }
+            }
+          }
+        }
+      }
+    },
+    "resolution": {
+      "type": "object",
+      "required": ["boundary", "spaceUri"],
+      "properties": {
+        "boundary": {
+          "type": "ref",
+          "ref": "zone.stratos.boundary.defs#Domain"
+        },
+        "spaceUri": {
+          "type": "string",
+          "format": "uri"
+        },
+        "host": {
+          "type": "string",
+          "format": "uri"
+        },
+        "source": {
+          "type": "string",
+          "enum": ["authority-override", "did-document"]
+        }
+      }
+    }
+  }
+},
+{
+  "lexicon": 1,
   "id": "zone.stratos.admin.listAdmins",
   "defs": {
     "main": {
@@ -184,6 +256,15 @@ export const stratosLexicons: LexiconDoc[] = [
           "boundary": {
             "type": "string",
             "description": "Only return members holding this boundary."
+          },
+          "active": {
+            "type": "boolean",
+            "description": "Only return active or inactive enrollments."
+          },
+          "custody": {
+            "type": "string",
+            "enum": ["stratos", "pds"],
+            "description": "Only return enrollments with this repo custody."
           }
         }
       },
@@ -214,7 +295,7 @@ export const stratosLexicons: LexiconDoc[] = [
     },
     "enrollment": {
       "type": "object",
-      "required": ["did", "enrolledAt", "active", "boundaries"],
+      "required": ["did", "enrolledAt", "active", "custody", "boundaries"],
       "properties": {
         "did": {
           "type": "string",
@@ -233,6 +314,16 @@ export const stratosLexicons: LexiconDoc[] = [
         "isService": {
           "type": "boolean",
           "description": "Whether this is a service enrollment rather than a user."
+        },
+        "custody": {
+          "type": "string",
+          "enum": ["stratos", "pds"],
+          "description": "Who hosts the member repository."
+        },
+        "repoHost": {
+          "type": "string",
+          "format": "uri",
+          "description": "The repository host recorded for a PDS-custody member."
         },
         "boundaries": {
           "type": "array",

--- a/stratos-core/src/lexicons/index.ts
+++ b/stratos-core/src/lexicons/index.ts
@@ -2,6 +2,7 @@ import type { LexiconDoc } from '@atproto/lexicon'
 import { atprotoLexicons } from './atproto.js'
 import zoneStratosActorEnrollment from '../../../lexicons/zone/stratos/actor/enrollment.json' with { type: 'json' }
 import zoneStratosAdminListEnrollments from '../../../lexicons/zone/stratos/admin/listEnrollments.json' with { type: 'json' }
+import zoneStratosAdminGetRepoHost from '../../../lexicons/zone/stratos/admin/getRepoHost.json' with { type: 'json' }
 import zoneStratosAdminAddAdmin from '../../../lexicons/zone/stratos/admin/addAdmin.json' with { type: 'json' }
 import zoneStratosAdminListAdmins from '../../../lexicons/zone/stratos/admin/listAdmins.json' with { type: 'json' }
 import zoneStratosAdminRemoveAdmin from '../../../lexicons/zone/stratos/admin/removeAdmin.json' with { type: 'json' }
@@ -37,6 +38,7 @@ export const stratosLexicons: LexiconDoc[] = [
   ...atprotoLexicons,
   zoneStratosActorEnrollment as LexiconDoc,
   zoneStratosAdminListEnrollments as LexiconDoc,
+  zoneStratosAdminGetRepoHost as LexiconDoc,
   zoneStratosAdminAddAdmin as LexiconDoc,
   zoneStratosAdminListAdmins as LexiconDoc,
   zoneStratosAdminRemoveAdmin as LexiconDoc,

--- a/stratos-service/admin-ui/src/lib/api/client.ts
+++ b/stratos-service/admin-ui/src/lib/api/client.ts
@@ -39,11 +39,31 @@ export interface EnrollmentStatusResponse {
   boundaries?: string[]
 }
 
+export type Custody = 'stratos' | 'pds'
+
+export type HostSource = 'authority-override' | 'did-document'
+
+export interface RepoHostResolution {
+  boundary: string
+  spaceUri: string
+  host?: string
+  source?: HostSource
+}
+
+export interface GetRepoHostResponse {
+  did: string
+  custody: Custody
+  isService: boolean
+  resolutions: RepoHostResolution[]
+}
+
 export interface EnrollmentSummary {
   did: string
   enrolledAt: string
   active: boolean
   isService: boolean
+  custody: Custody
+  repoHost?: string
   boundaries: string[]
 }
 
@@ -189,8 +209,8 @@ export function listDomains(): Promise<ListDomainsResponse> {
 
 /**
  * List enrolled members, newest page first by DID order.
- * @param options - Page size, resume cursor, and optional boundary/active
- * filters
+ * @param options - Page size, resume cursor, and optional space, active, or
+ * custody filters
  * @returns A page of members, a cursor when more follow, and the total when
  * unfiltered
  */
@@ -200,6 +220,7 @@ export function listEnrollments(
     cursor?: string
     boundary?: string
     active?: boolean
+    custody?: Custody
   } = {},
 ): Promise<ListEnrollmentsResponse> {
   const params = new URLSearchParams()
@@ -207,9 +228,21 @@ export function listEnrollments(
   if (options.cursor !== undefined) params.set('cursor', options.cursor)
   if (options.boundary !== undefined) params.set('boundary', options.boundary)
   if (options.active !== undefined) params.set('active', String(options.active))
+  if (options.custody !== undefined) params.set('custody', options.custody)
   const query = params.toString()
   return request<ListEnrollmentsResponse>(
     `/xrpc/zone.stratos.admin.listEnrollments${query ? `?${query}` : ''}`,
+  )
+}
+
+/**
+ * Resolve the repository host for every space a member holds.
+ * @param did - The member to inspect
+ * @returns The host resolution rows for the member's spaces
+ */
+export function getRepoHost(did: string): Promise<GetRepoHostResponse> {
+  return request<GetRepoHostResponse>(
+    `/xrpc/zone.stratos.admin.getRepoHost?did=${encodeURIComponent(did)}`,
   )
 }
 

--- a/stratos-service/admin-ui/src/lib/api/client.ts
+++ b/stratos-service/admin-ui/src/lib/api/client.ts
@@ -235,11 +235,6 @@ export function listEnrollments(
   )
 }
 
-/**
- * Resolve the repository host for every space a member holds.
- * @param did - The member to inspect
- * @returns The host resolution rows for the member's spaces
- */
 export function getRepoHost(did: string): Promise<GetRepoHostResponse> {
   return request<GetRepoHostResponse>(
     `/xrpc/zone.stratos.admin.getRepoHost?did=${encodeURIComponent(did)}`,

--- a/stratos-service/admin-ui/src/routes/Enrollments.svelte
+++ b/stratos-service/admin-ui/src/routes/Enrollments.svelte
@@ -547,7 +547,11 @@
                   {collapsedHost.host} ({collapsedHost.source})
                 </p>
               {:else if hostResolutions.length === 0}
-                <p class="text-sm text-muted">No spaces assigned.</p>
+                <p class="text-sm text-muted">
+                  {boundaries.length === 0
+                    ? 'No spaces assigned.'
+                    : 'Repository host unresolved for assigned spaces.'}
+                </p>
               {:else}
                 <ul class="space-y-1 text-sm text-muted">
                   {#each hostResolutions as resolution (resolution.spaceUri)}

--- a/stratos-service/admin-ui/src/routes/Enrollments.svelte
+++ b/stratos-service/admin-ui/src/routes/Enrollments.svelte
@@ -4,6 +4,7 @@
   import {
     addBoundary,
     getEnrollmentStatus,
+    getRepoHost,
     listDomains,
     listEnrollments,
     removeBoundary,
@@ -11,8 +12,10 @@
     setActive,
     setBoundaries,
     type BoundariesResponse,
+    type Custody,
     type EnrollmentStatusResponse,
     type EnrollmentSummary,
+    type RepoHostResolution,
   } from '../lib/api/client'
   import Button from '../lib/components/ui/Button.svelte'
   import Card from '../lib/components/ui/Card.svelte'
@@ -28,6 +31,10 @@
   let enrolled = $state(false)
   let boundaries = $state<string[]>([])
   let status = $state<EnrollmentStatusResponse | null>(null)
+  let detailCustody = $state<Custody | null>(null)
+  let detailIsService = $state(false)
+  let hostResolutions = $state<RepoHostResolution[]>([])
+  let hostError = $state<string | null>(null)
   let domains = $state<string[]>([])
   let selectedDomain = $state('')
   let setInput = $state('')
@@ -46,6 +53,7 @@
   let boundaryFilter = $state('')
   /** '' shows everyone, otherwise only active or only deactivated members. */
   let activeFilter = $state<'' | 'active' | 'inactive'>('')
+  let custodyFilter = $state<'' | 'stratos' | 'pds'>('')
 
   $effect(() => {
     listDomains()
@@ -71,6 +79,7 @@
         cursor,
         boundary: boundaryFilter || undefined,
         active: activeFilter === '' ? undefined : activeFilter === 'active',
+        custody: custodyFilter || undefined,
       })
       members = cursor ? [...members, ...res.enrollments] : res.enrollments
       membersCursor = res.cursor
@@ -106,7 +115,14 @@
   }
 
   function applyActiveFilter(value: string) {
-    activeFilter = value as '' | 'active' | 'inactive'
+    if (value !== '' && value !== 'active' && value !== 'inactive') return
+    activeFilter = value
+    reloadMembers()
+  }
+
+  function applyCustodyFilter(value: string) {
+    if (value !== '' && value !== 'stratos' && value !== 'pds') return
+    custodyFilter = value
     reloadMembers()
   }
 
@@ -121,13 +137,32 @@
     loadedDid = null
     boundaries = []
     status = null
+    const member = members.find((entry) => entry.did === did)
+    detailCustody = member?.custody ?? null
+    detailIsService = member?.isService ?? false
+    hostResolutions = []
+    hostError = null
     setInput = ''
     try {
       const res = await resolveEnrollments(did)
       loadedDid = res.did
       enrolled = res.enrolled
       boundaries = res.boundaries
-      status = await getEnrollmentStatus(did).catch(() => null)
+      const [statusResult, hostResult] = await Promise.allSettled([
+        getEnrollmentStatus(did),
+        getRepoHost(did),
+      ])
+      status = statusResult.status === 'fulfilled' ? statusResult.value : null
+      if (hostResult.status === 'fulfilled') {
+        detailCustody = hostResult.value.custody
+        detailIsService = hostResult.value.isService
+        hostResolutions = hostResult.value.resolutions
+      } else {
+        hostError =
+          hostResult.reason instanceof Error
+            ? hostResult.reason.message
+            : String(hostResult.reason)
+      }
       setInput = res.boundaries.join(', ')
     } catch (err) {
       loadedDid = null
@@ -235,6 +270,22 @@
       busy = false
     }
   }
+
+  function collapseHostResolutions(
+    resolutions: RepoHostResolution[],
+  ): RepoHostResolution | undefined {
+    if (resolutions.length === 0) return undefined
+    const [first] = resolutions
+    if (!first.host || !first.source) return undefined
+    return resolutions.every(
+      (resolution) =>
+        resolution.host === first.host && resolution.source === first.source,
+    )
+      ? first
+      : undefined
+  }
+
+  const collapsedHost = $derived(collapseHostResolutions(hostResolutions))
 </script>
 
 <div class="space-y-6" data-testid="enrollments-screen">
@@ -266,7 +317,7 @@
       <h2 class="font-display text-lg italic">Members</h2>
       <div class="flex items-center gap-3">
         <label class="flex items-center gap-2">
-          <span class="text-sm text-muted">Domain</span>
+          <span class="text-sm text-muted">Space</span>
           <select
             class="pill cursor-pointer px-4 py-1.5 text-sm outline-none"
             data-testid="members-filter"
@@ -276,7 +327,7 @@
               )}
             value={boundaryFilter}
           >
-            <option value="">All domains</option>
+            <option value="">All spaces</option>
             {#if boundaryFilter && !domains.includes(boundaryFilter)}
               <!--
                 A filter from the URL may name a domain no longer in the
@@ -304,6 +355,20 @@
             <option value="">All</option>
             <option value="active">Active</option>
             <option value="inactive">Deactivated</option>
+          </select>
+        </label>
+        <label class="flex items-center gap-2">
+          <span class="text-sm text-muted">Custody</span>
+          <select
+            class="pill cursor-pointer px-4 py-1.5 text-sm outline-none"
+            data-testid="members-custody-filter"
+            onchange={(event) =>
+              applyCustodyFilter((event.currentTarget as HTMLSelectElement).value)}
+            value={custodyFilter}
+          >
+            <option value="">All</option>
+            <option value="stratos">Stratos</option>
+            <option value="pds">PDS</option>
           </select>
         </label>
         <span class="text-sm text-muted" data-testid="members-total">
@@ -351,7 +416,9 @@
                 <Identity did={member.did} />
                 <div class="flex items-center gap-3">
                   {#if member.isService}
-                    <span class="text-xs text-muted">service</span>
+                    <Chip label="service" />
+                  {:else}
+                    <Chip label={member.custody} />
                   {/if}
                   <StatusDot
                     label={member.active ? 'active' : 'deactivated'}
@@ -442,10 +509,10 @@
         </div>
 
         <div>
-          <h3 class="mb-2 text-sm font-medium text-muted">Boundaries</h3>
+          <h3 class="mb-2 text-sm font-medium text-muted">Spaces</h3>
           {#if boundaries.length === 0}
             <p class="text-sm text-muted" data-testid="no-boundaries">
-              No boundaries assigned.
+              No spaces assigned.
             </p>
           {:else}
             <div class="flex flex-wrap gap-2">
@@ -461,18 +528,53 @@
           {/if}
         </div>
 
+        {#if hostError}
+          <p class="text-sm text-error" data-testid="repo-host-error">
+            Failed to resolve repository host: {hostError}
+          </p>
+        {/if}
+
+        {#if !detailIsService}
+          {#if detailCustody === 'stratos'}
+            <p class="text-sm text-muted" data-testid="repo-host-detail">
+              Hosted by this service.
+            </p>
+          {:else if detailCustody === 'pds'}
+            <div data-testid="repo-host-detail">
+              <h3 class="mb-2 text-sm font-medium text-muted">Repository host</h3>
+              {#if collapsedHost}
+                <p class="text-sm text-muted">
+                  {collapsedHost.host} ({collapsedHost.source})
+                </p>
+              {:else if hostResolutions.length === 0}
+                <p class="text-sm text-muted">No spaces assigned.</p>
+              {:else}
+                <ul class="space-y-1 text-sm text-muted">
+                  {#each hostResolutions as resolution (resolution.spaceUri)}
+                    <li>
+                      {boundaryName(resolution.boundary)}: {resolution.host
+                        ? `${resolution.host} (${resolution.source})`
+                        : 'Unresolved'}
+                    </li>
+                  {/each}
+                </ul>
+              {/if}
+            </div>
+          {/if}
+        {/if}
+
         {#if enrolled}
           <div class="flex items-end gap-3">
             <label class="block grow">
               <span class="mb-1 block text-sm font-medium text-muted">
-                Add boundary
+                Add space
               </span>
               <select
                 bind:value={selectedDomain}
                 class="pill w-full cursor-pointer px-4 py-2 text-sm outline-none"
                 data-testid="add-boundary-select"
               >
-                <option value="">Select a domain…</option>
+                <option value="">Select a space…</option>
                 {#each availableDomains as domain (domain)}
                   <option value={domain}>{boundaryName(domain)}</option>
                 {/each}
@@ -483,7 +585,7 @@
               onclick={handleAdd}
               testid="add-boundary"
             >
-              Add
+              Add space
             </Button>
           </div>
 
@@ -492,13 +594,13 @@
               class="cursor-pointer text-sm font-medium text-muted select-none"
               data-testid="set-boundaries-toggle"
             >
-              Set boundaries
+              Set spaces
             </summary>
             <div class="mt-3 flex items-end gap-3">
               <div class="grow">
                 <TextField
                   bind:value={setInput}
-                  ariaLabel="Boundaries, comma-separated"
+                  ariaLabel="Spaces, comma-separated"
                   onenter={handleSet}
                   placeholder="engineering, leadership"
                   testid="set-boundaries-input"
@@ -514,8 +616,8 @@
               </Button>
             </div>
             <p class="mt-2 text-xs text-muted">
-              Replaces every boundary at once. Values are full domains, not
-              short names.
+              Replaces every space at once. Values are full domains, not short
+              names.
             </p>
           </details>
         {/if}

--- a/stratos-service/admin-ui/src/routes/Enrollments.svelte
+++ b/stratos-service/admin-ui/src/routes/Enrollments.svelte
@@ -331,7 +331,7 @@
             {#if boundaryFilter && !domains.includes(boundaryFilter)}
               <!--
                 A filter from the URL may name a domain no longer in the
-                allowed list. Show it so the control cannot read "All domains"
+                allowed list. Show it so the control cannot read "All spaces"
                 while a filter is applied.
               -->
               <option value={boundaryFilter}>

--- a/stratos-service/src/features/enrollment/handler.ts
+++ b/stratos-service/src/features/enrollment/handler.ts
@@ -1,5 +1,4 @@
 import express, { type Request, type Response } from 'express'
-import { Agent } from '@atproto/api'
 import { ensureValidDid } from '@atproto/syntax'
 import { InvalidRequestError, Server as XrpcServer } from '@atproto/xrpc-server'
 import {
@@ -12,7 +11,7 @@ import {
 import type { AppContext } from '../../context-types.js'
 import { type XrpcServerInternal } from '../../api/types.js'
 import { createXrpcHandler } from '../../api/util.js'
-import { serviceDIDToRkey, SPACE_TYPE } from '../../oauth'
+import { SPACE_TYPE } from '../../oauth'
 import { createRepoHostResolverDeps } from '../space-read/index.js'
 import { verifyEnrolled } from './internal/auth.js'
 import type { PdsSyncPageKey } from './internal/pds-sync-store.js'

--- a/stratos-service/src/features/enrollment/handler.ts
+++ b/stratos-service/src/features/enrollment/handler.ts
@@ -1237,7 +1237,13 @@ function registerGetRepoHostHandler(ctx: AppContext): void {
         const resolutions = await Promise.all(
           boundaries.flatMap((boundary) => {
             const result = boundaryToSpaceUri(boundary, SPACE_TYPE)
-            if (!result.ok) return []
+            if (!result.ok) {
+              ctx.logger?.warn(
+                { did, boundary },
+                'admin.getRepoHost could not convert boundary to a space URI',
+              )
+              return []
+            }
             return [
               resolveRepoHost(result.value, did, hostDeps).then((resolved) => ({
                 boundary,

--- a/stratos-service/src/features/enrollment/handler.ts
+++ b/stratos-service/src/features/enrollment/handler.ts
@@ -4,6 +4,7 @@ import { ensureValidDid } from '@atproto/syntax'
 import { InvalidRequestError, Server as XrpcServer } from '@atproto/xrpc-server'
 import {
   boundaryToSpaceUri,
+  type Custody,
   type Enrollment,
   EnrollmentDeniedError,
   resolveRepoHost,
@@ -12,7 +13,7 @@ import type { AppContext } from '../../context-types.js'
 import { type XrpcServerInternal } from '../../api/types.js'
 import { createXrpcHandler } from '../../api/util.js'
 import { serviceDIDToRkey, SPACE_TYPE } from '../../oauth'
-import { createRepoHostResolverDeps } from '../space-read/host-resolution.js'
+import { createRepoHostResolverDeps } from '../space-read/index.js'
 import { verifyEnrolled } from './internal/auth.js'
 import type { PdsSyncPageKey } from './internal/pds-sync-store.js'
 
@@ -890,7 +891,7 @@ interface ListedEnrollment {
   enrolledAt: string
   active: boolean
   isService: boolean
-  custody: 'stratos' | 'pds'
+  custody: Custody
   repoHost?: string
   boundaries: string[]
 }
@@ -911,7 +912,7 @@ async function withBoundaries(
     enrolledAt: string
     active: boolean
     isService?: boolean
-    custody?: 'stratos' | 'pds'
+    custody?: Custody
     repoHost?: string
   }>,
 ): Promise<ListedEnrollment[]> {

--- a/stratos-service/src/features/enrollment/handler.ts
+++ b/stratos-service/src/features/enrollment/handler.ts
@@ -1,12 +1,18 @@
 import express, { type Request, type Response } from 'express'
+import { Agent } from '@atproto/api'
+import { ensureValidDid } from '@atproto/syntax'
 import { InvalidRequestError, Server as XrpcServer } from '@atproto/xrpc-server'
 import {
+  boundaryToSpaceUri,
   type Enrollment,
   EnrollmentDeniedError,
+  resolveRepoHost,
 } from '@northskysocial/stratos-core'
 import type { AppContext } from '../../context-types.js'
 import { type XrpcServerInternal } from '../../api/types.js'
 import { createXrpcHandler } from '../../api/util.js'
+import { serviceDIDToRkey, SPACE_TYPE } from '../../oauth'
+import { createRepoHostResolverDeps } from '../space-read/host-resolution.js'
 import { verifyEnrolled } from './internal/auth.js'
 import type { PdsSyncPageKey } from './internal/pds-sync-store.js'
 
@@ -90,6 +96,7 @@ export function registerEnrollmentHandlers(
   registerResolveEnrollmentsHandler(ctx, resolveCache)
   registerAdminBoundaryHandlers(ctx, resolveCache)
   registerListEnrollmentsHandler(ctx)
+  registerGetRepoHostHandler(ctx)
   registerListDomainsHandler(ctx)
   registerListPdsSyncStatusHandler(ctx)
   registerRequeuePdsSyncHandler(ctx)
@@ -883,6 +890,8 @@ interface ListedEnrollment {
   enrolledAt: string
   active: boolean
   isService: boolean
+  custody: 'stratos' | 'pds'
+  repoHost?: string
   boundaries: string[]
 }
 
@@ -902,6 +911,8 @@ async function withBoundaries(
     enrolledAt: string
     active: boolean
     isService?: boolean
+    custody?: 'stratos' | 'pds'
+    repoHost?: string
   }>,
 ): Promise<ListedEnrollment[]> {
   const boundaries = await Promise.all(
@@ -912,6 +923,8 @@ async function withBoundaries(
     enrolledAt: row.enrolledAt,
     active: row.active,
     isService: row.isService ?? false,
+    custody: row.custody ?? 'stratos',
+    ...(row.repoHost ? { repoHost: row.repoHost } : {}),
     boundaries: boundaries[index],
   }))
 }
@@ -1112,7 +1125,22 @@ function registerListEnrollmentsHandler(ctx: AppContext): void {
         const wantActive =
           rawActive === undefined ? undefined : rawActive === 'true'
 
-        const filtered = rawBoundary !== undefined || wantActive !== undefined
+        const rawCustody = req.query.custody
+        if (
+          rawCustody !== undefined &&
+          rawCustody !== 'stratos' &&
+          rawCustody !== 'pds'
+        ) {
+          return res.status(400).json({
+            error: 'InvalidRequest',
+            message: "custody must be 'stratos' or 'pds'",
+          })
+        }
+
+        const filtered =
+          rawBoundary !== undefined ||
+          wantActive !== undefined ||
+          rawCustody !== undefined
         const { enrollments, hasMore, nextCursor } = filtered
           ? await collectFilteredPage(
               ctx,
@@ -1120,7 +1148,9 @@ function registerListEnrollmentsHandler(ctx: AppContext): void {
               (enrollment) =>
                 (rawBoundary === undefined ||
                   enrollment.boundaries.includes(rawBoundary)) &&
-                (wantActive === undefined || enrollment.active === wantActive),
+                (wantActive === undefined ||
+                  enrollment.active === wantActive) &&
+                (rawCustody === undefined || enrollment.custody === rawCustody),
               rawCursor,
             )
           : await collectPage(ctx, limit, rawCursor)
@@ -1147,6 +1177,92 @@ function registerListEnrollmentsHandler(ctx: AppContext): void {
         res.status(500).json({
           error: 'InternalError',
           message: 'Failed to list enrollments',
+        })
+      }
+    },
+  )
+}
+
+function registerGetRepoHostHandler(ctx: AppContext): void {
+  ctx.app.get(
+    '/xrpc/zone.stratos.admin.getRepoHost',
+    async (req: Request, res: Response) => {
+      try {
+        await ctx.authVerifier.admin({ req, res })
+      } catch {
+        return res
+          .status(401)
+          .json({ error: 'AuthRequired', message: 'Admin auth required' })
+      }
+
+      const did = req.query.did
+      if (typeof did !== 'string' || did.length === 0) {
+        return res.status(400).json({
+          error: 'InvalidRequest',
+          message: 'did must be a non-empty string',
+        })
+      }
+      try {
+        ensureValidDid(did)
+      } catch {
+        return res.status(400).json({
+          error: 'InvalidRequest',
+          message: 'did must be a valid DID',
+        })
+      }
+
+      try {
+        const enrollment = await ctx.enrollmentStore.getEnrollment(did)
+        if (!enrollment) {
+          return res.status(404).json({
+            error: 'NotFound',
+            message: 'Enrollment not found',
+          })
+        }
+        const custody = enrollment.custody ?? 'stratos'
+        if (enrollment.isService || custody === 'stratos') {
+          return res.json({
+            did,
+            custody,
+            isService: enrollment.isService ?? false,
+            resolutions: [],
+          })
+        }
+
+        const boundaries = await ctx.enrollmentStore.getBoundaries(did)
+        const hostDeps = createRepoHostResolverDeps(
+          ctx.idResolver,
+          enrollment.repoHost,
+        )
+        const resolutions = await Promise.all(
+          boundaries.flatMap((boundary) => {
+            const result = boundaryToSpaceUri(boundary, SPACE_TYPE)
+            if (!result.ok) return []
+            return [
+              resolveRepoHost(result.value, did, hostDeps).then((resolved) => ({
+                boundary,
+                spaceUri: result.value,
+                ...(resolved
+                  ? { host: resolved.host, source: resolved.source }
+                  : {}),
+              })),
+            ]
+          }),
+        )
+        return res.json({
+          did,
+          custody,
+          isService: false,
+          resolutions,
+        })
+      } catch (err) {
+        ctx.logger?.error(
+          { err: err instanceof Error ? err.message : String(err), did },
+          'admin.getRepoHost failed',
+        )
+        return res.status(500).json({
+          error: 'InternalError',
+          message: 'Failed to resolve repository hosts',
         })
       }
     },

--- a/stratos-service/src/features/space-read/index.ts
+++ b/stratos-service/src/features/space-read/index.ts
@@ -4,3 +4,4 @@ export {
   LIST_SPACE_REPOS_METHOD,
   registerSpaceReadHandlers,
 } from './handler.js'
+export { createRepoHostResolverDeps } from './host-resolution.js'

--- a/stratos-service/tests/admin-list-enrollments.test.ts
+++ b/stratos-service/tests/admin-list-enrollments.test.ts
@@ -81,6 +81,7 @@ function createCtx(opts: {
 }): {
   app: express.Application
   enrollmentStore: AppContext['enrollmentStore']
+  logger: { warn: ReturnType<typeof vi.fn> }
 } {
   const enrollmentStore = {
     isEnrolled: vi.fn(async () => true),
@@ -100,6 +101,12 @@ function createCtx(opts: {
   const app = express()
   const enrollmentEvents: EnrollmentEventEmitter = new EventEmitter()
 
+  const logger = {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }
   const ctx = {
     app,
     enrollmentStore,
@@ -129,16 +136,11 @@ function createCtx(opts: {
       service: { publicUrl: 'https://stratos.example.com' },
       stratos: { serviceDid: NERV, allowedDomains: [`${NERV}/general`] },
     },
-    logger: {
-      info: vi.fn(),
-      warn: vi.fn(),
-      error: vi.fn(),
-      debug: vi.fn(),
-    },
+    logger,
   } as unknown as AppContext
 
   registerEnrollmentHandlers({ method: vi.fn() } as never, ctx)
-  return { app, enrollmentStore }
+  return { app, enrollmentStore, logger }
 }
 
 const ROUTE = '/xrpc/zone.stratos.admin.listEnrollments'
@@ -681,6 +683,31 @@ describe('GET /xrpc/zone.stratos.admin.getRepoHost', () => {
         },
       ],
     })
+  })
+
+  it('warns when a member boundary cannot convert to a space URI', async () => {
+    const boundary = 'unresolved-space'
+    const { app, logger } = createCtx({
+      enrollmentStore: {
+        getEnrollment: vi.fn(async () =>
+          storedEnrollment('did:plc:rei', { custody: 'pds' }),
+        ),
+        getBoundaries: vi.fn(async () => [boundary]),
+      } as unknown as Partial<EnrollmentStore>,
+    })
+
+    const res = await invokeGetRoute(app, HOST_ROUTE, { did: 'did:plc:rei' })
+
+    expect(res.body).toEqual({
+      did: 'did:plc:rei',
+      custody: 'pds',
+      isService: false,
+      resolutions: [],
+    })
+    expect(logger.warn).toHaveBeenCalledWith(
+      { did: 'did:plc:rei', boundary },
+      'admin.getRepoHost could not convert boundary to a space URI',
+    )
   })
 
   it('returns no host resolution for stratos or service enrollment', async () => {

--- a/stratos-service/tests/admin-list-enrollments.test.ts
+++ b/stratos-service/tests/admin-list-enrollments.test.ts
@@ -77,6 +77,7 @@ function storedEnrollment(
 function createCtx(opts: {
   enrollmentStore?: Partial<EnrollmentStore>
   adminAuthFails?: boolean
+  idResolver?: AppContext['idResolver']
 }): {
   app: express.Application
   enrollmentStore: AppContext['enrollmentStore']
@@ -119,6 +120,11 @@ function createCtx(opts: {
       optionalStandard: vi.fn(async () => ({ credentials: { did: null } })),
     },
     serviceDid: NERV,
+    idResolver:
+      opts.idResolver ??
+      ({
+        did: { resolve: vi.fn(async () => undefined) },
+      } as unknown as AppContext['idResolver']),
     cfg: {
       service: { publicUrl: 'https://stratos.example.com' },
       stratos: { serviceDid: NERV, allowedDomains: [`${NERV}/general`] },
@@ -155,7 +161,11 @@ describe('GET /xrpc/zone.stratos.admin.listEnrollments', () => {
           storedEnrollment('did:plc:motoko', { isService: true }),
           // Older rows predate the isService column, so the key is absent
           // rather than false; the handler must still report a boolean.
-          storedEnrollment('did:plc:faye', { isService: undefined }),
+          storedEnrollment('did:plc:faye', {
+            isService: undefined,
+            custody: 'pds',
+            repoHost: 'https://pds.faye.example',
+          }),
         ]),
         getBoundaries: vi.fn(async (did: string) =>
           did === 'did:plc:usagi'
@@ -176,6 +186,7 @@ describe('GET /xrpc/zone.stratos.admin.listEnrollments', () => {
           enrolledAt: '2026-01-01T00:00:00.000Z',
           active: true,
           isService: false,
+          custody: 'stratos',
           boundaries: [`${NERV}/general`, `${NERV}/swordsmith`],
         },
         {
@@ -183,6 +194,7 @@ describe('GET /xrpc/zone.stratos.admin.listEnrollments', () => {
           enrolledAt: '2026-01-01T00:00:00.000Z',
           active: true,
           isService: true,
+          custody: 'stratos',
           boundaries: [`${NERV}/general`],
         },
         {
@@ -190,6 +202,8 @@ describe('GET /xrpc/zone.stratos.admin.listEnrollments', () => {
           enrolledAt: '2026-01-01T00:00:00.000Z',
           active: true,
           isService: false,
+          custody: 'pds',
+          repoHost: 'https://pds.faye.example',
           boundaries: [`${NERV}/general`],
         },
       ],
@@ -459,6 +473,51 @@ describe('GET /xrpc/zone.stratos.admin.listEnrollments', () => {
       },
     )
 
+    it('filters by custody and defaults absent custody to stratos', async () => {
+      const { app } = createCtx({
+        enrollmentStore: {
+          listEnrollments: vi.fn(async () => [
+            storedEnrollment('did:plc:usagi'),
+            storedEnrollment('did:plc:rei', {
+              custody: 'pds',
+              repoHost: 'https://pds.rei.example',
+            }),
+          ]),
+          enrollmentCount: vi.fn(async () => 2),
+        } as unknown as Partial<EnrollmentStore>,
+      })
+
+      const stratos = await invokeGetRoute(app, ROUTE, { custody: 'stratos' })
+      const pds = await invokeGetRoute(app, ROUTE, { custody: 'pds' })
+
+      expect(
+        (stratos.body as { enrollments: Array<{ did: string }> }).enrollments,
+      ).toEqual([
+        expect.objectContaining({ did: 'did:plc:usagi', custody: 'stratos' }),
+      ])
+      expect(
+        (pds.body as { enrollments: Array<{ did: string }> }).enrollments,
+      ).toEqual([
+        expect.objectContaining({
+          did: 'did:plc:rei',
+          custody: 'pds',
+          repoHost: 'https://pds.rei.example',
+        }),
+      ])
+    })
+
+    it.each([['unknown'], [['pds']]])(
+      'rejects a malformed custody value (%o)',
+      async (custody) => {
+        const { app, enrollmentStore } = createCtx({})
+
+        const res = await invokeGetRoute(app, ROUTE, { custody })
+
+        expect(res.statusCode).toBe(400)
+        expect(enrollmentStore.listEnrollments).not.toHaveBeenCalled()
+      },
+    )
+
     it('bounds the scan when nothing matches, and stays resumable', async () => {
       // 5000 members, none matching: without a budget this would scan the
       // whole table and issue a boundary read per row.
@@ -506,5 +565,173 @@ describe('GET /xrpc/zone.stratos.admin.listEnrollments', () => {
       expect(res.statusCode).toBe(400)
       expect(enrollmentStore.listEnrollments).not.toHaveBeenCalled()
     })
+  })
+})
+
+const HOST_ROUTE = '/xrpc/zone.stratos.admin.getRepoHost'
+
+describe('GET /xrpc/zone.stratos.admin.getRepoHost', () => {
+  it('returns one authority override for every member space', async () => {
+    const { app } = createCtx({
+      enrollmentStore: {
+        getEnrollment: vi.fn(async () =>
+          storedEnrollment('did:plc:usagi', {
+            custody: 'pds',
+            repoHost: 'https://override.example',
+          }),
+        ),
+        getBoundaries: vi.fn(async () => [
+          `${NERV}/general`,
+          `${NERV}/swordsmith`,
+        ]),
+      } as unknown as Partial<EnrollmentStore>,
+    })
+
+    const res = await invokeGetRoute(app, HOST_ROUTE, { did: 'did:plc:usagi' })
+
+    expect(res.statusCode).toBe(200)
+    expect(res.body).toEqual({
+      did: 'did:plc:usagi',
+      custody: 'pds',
+      isService: false,
+      resolutions: [
+        {
+          boundary: `${NERV}/general`,
+          spaceUri: `at://${NERV}/space/zone.stratos.space.feed/general`,
+          host: 'https://override.example',
+          source: 'authority-override',
+        },
+        {
+          boundary: `${NERV}/swordsmith`,
+          spaceUri: `at://${NERV}/space/zone.stratos.space.feed/swordsmith`,
+          host: 'https://override.example',
+          source: 'authority-override',
+        },
+      ],
+    })
+  })
+
+  it('falls back to the DID document and keeps unresolved spaces', async () => {
+    const { app } = createCtx({
+      enrollmentStore: {
+        getEnrollment: vi.fn(async () =>
+          storedEnrollment('did:plc:rei', { custody: 'pds' }),
+        ),
+        getBoundaries: vi.fn(async () => [
+          `${NERV}/general`,
+          `${NERV}/swordsmith`,
+        ]),
+      } as unknown as Partial<EnrollmentStore>,
+      idResolver: {
+        did: {
+          resolve: vi.fn(async () => ({
+            service: [
+              {
+                id: '#atproto_pds',
+                serviceEndpoint: 'https://pds.rei.example',
+              },
+            ],
+          })),
+        },
+      } as unknown as AppContext['idResolver'],
+    })
+
+    const resolved = await invokeGetRoute(app, HOST_ROUTE, {
+      did: 'did:plc:rei',
+    })
+    expect(resolved.body).toEqual({
+      did: 'did:plc:rei',
+      custody: 'pds',
+      isService: false,
+      resolutions: [
+        {
+          boundary: `${NERV}/general`,
+          spaceUri: `at://${NERV}/space/zone.stratos.space.feed/general`,
+          host: 'https://pds.rei.example',
+          source: 'did-document',
+        },
+        {
+          boundary: `${NERV}/swordsmith`,
+          spaceUri: `at://${NERV}/space/zone.stratos.space.feed/swordsmith`,
+          host: 'https://pds.rei.example',
+          source: 'did-document',
+        },
+      ],
+    })
+
+    const { app: unresolvedApp } = createCtx({
+      enrollmentStore: {
+        getEnrollment: vi.fn(async () =>
+          storedEnrollment('did:plc:rei', { custody: 'pds' }),
+        ),
+        getBoundaries: vi.fn(async () => [`${NERV}/general`]),
+      } as unknown as Partial<EnrollmentStore>,
+    })
+    const unresolved = await invokeGetRoute(unresolvedApp, HOST_ROUTE, {
+      did: 'did:plc:rei',
+    })
+    expect(unresolved.body).toEqual({
+      did: 'did:plc:rei',
+      custody: 'pds',
+      isService: false,
+      resolutions: [
+        {
+          boundary: `${NERV}/general`,
+          spaceUri: `at://${NERV}/space/zone.stratos.space.feed/general`,
+        },
+      ],
+    })
+  })
+
+  it('returns no host resolution for stratos or service enrollment', async () => {
+    for (const enrollment of [
+      storedEnrollment('did:plc:motoko'),
+      storedEnrollment('did:plc:batou', {
+        custody: 'pds',
+        isService: true,
+        repoHost: 'https://service.example',
+      }),
+    ]) {
+      const { app } = createCtx({
+        enrollmentStore: {
+          getEnrollment: vi.fn(async () => enrollment),
+        } as unknown as Partial<EnrollmentStore>,
+      })
+      const res = await invokeGetRoute(app, HOST_ROUTE, { did: enrollment.did })
+      expect(res.body).toEqual({
+        did: enrollment.did,
+        custody: enrollment.custody ?? 'stratos',
+        isService: enrollment.isService ?? false,
+        resolutions: [],
+      })
+    }
+  })
+
+  it('rejects unauthenticated callers', async () => {
+    const { app, enrollmentStore } = createCtx({ adminAuthFails: true })
+
+    expect(
+      (await invokeGetRoute(app, HOST_ROUTE, { did: 'did:plc:rei' }))
+        .statusCode,
+    ).toBe(401)
+    expect(enrollmentStore.getEnrollment).not.toHaveBeenCalled()
+  })
+
+  it('rejects invalid DID input and returns 404 for an unknown enrollment', async () => {
+    const { app, enrollmentStore } = createCtx({})
+
+    expect((await invokeGetRoute(app, HOST_ROUTE)).statusCode).toBe(400)
+    expect(
+      (await invokeGetRoute(app, HOST_ROUTE, { did: ['did:plc:rei'] }))
+        .statusCode,
+    ).toBe(400)
+    expect(
+      (await invokeGetRoute(app, HOST_ROUTE, { did: 'not-a-did' })).statusCode,
+    ).toBe(400)
+    expect(enrollmentStore.getEnrollment).not.toHaveBeenCalled()
+    expect(
+      (await invokeGetRoute(app, HOST_ROUTE, { did: 'did:plc:rei' }))
+        .statusCode,
+    ).toBe(404)
   })
 })

--- a/test/scripts/test-admin-api.ts
+++ b/test/scripts/test-admin-api.ts
@@ -127,6 +127,20 @@ async function run(): Promise<void> {
     `status=${unauthList.status}`,
   )
 
+  const pdsMembers = await adminList(
+    'zone.stratos.admin.listEnrollments?custody=pds',
+    sessionCookie,
+  )
+  const pdsMembersBody = pdsMembers.body as {
+    enrollments?: Array<{ custody?: string }>
+  }
+  assert(
+    pdsMembers.status === 200 &&
+      (pdsMembersBody.enrollments?.length ?? 0) === 0,
+    'listEnrollments returns an empty PDS-custody partition before the PDS fixture',
+    `status=${pdsMembers.status}, returned=${pdsMembersBody.enrollments?.length ?? 0}`,
+  )
+
   // 2. addBoundary via the admin API.
   const add = await adminFetch(
     'zone.stratos.admin.addBoundary',

--- a/test/scripts/test-admin-ui.ts
+++ b/test/scripts/test-admin-ui.ts
@@ -171,6 +171,14 @@ async function run(): Promise<void> {
       'Member list loads enrolled members without searching',
       `${memberRows} rows`,
     )
+    const memberRowText = await page
+      .locator('[data-testid="member-row"]')
+      .allTextContents()
+    assert(
+      memberRowText.every((text) => /\b(?:pds|service|stratos)\b/i.test(text)),
+      'Every member row shows a custody or service badge',
+      memberRowText.join(' | '),
+    )
 
     const targetRow = page
       .locator('[data-testid="member-row"]')
@@ -184,6 +192,16 @@ async function run(): Promise<void> {
     assert(
       rowText?.includes('stratos') === true,
       'Member row shows the Stratos custody badge',
+    )
+    await page.selectOption('[data-testid="members-custody-filter"]', {
+      value: 'pds',
+    })
+    await page.waitForSelector('[data-testid="members-empty"]', {
+      timeout: 15_000,
+    })
+    assert(
+      (await page.locator('[data-testid="member-row"]').count()) === 0,
+      'PDS custody filter excludes the Stratos-only fixture members',
     )
     await page.selectOption('[data-testid="members-custody-filter"]', {
       value: 'stratos',

--- a/test/scripts/test-admin-ui.ts
+++ b/test/scripts/test-admin-ui.ts
@@ -180,6 +180,21 @@ async function run(): Promise<void> {
       'Target user appears in the member list',
       `${target.handle} (${target.did})`,
     )
+    const rowText = await targetRow.first().textContent()
+    assert(
+      rowText?.includes('stratos') === true,
+      'Member row shows the Stratos custody badge',
+    )
+    await page.selectOption('[data-testid="members-custody-filter"]', {
+      value: 'stratos',
+    })
+    await page.waitForSelector('[data-testid="members-list"]', {
+      timeout: 15_000,
+    })
+    assert(
+      (await page.locator('[data-testid="member-row"]').count()) > 0,
+      'Custody filter keeps Stratos-custody members visible',
+    )
     await screenshot(page, 'admin-ui-02-member-list')
 
     await targetRow.first().click()
@@ -192,6 +207,11 @@ async function run(): Promise<void> {
     assert(
       rowDetail?.includes(target.did) === true,
       'Selecting a member row opens that member detail',
+    )
+    assert(
+      rowDetail?.includes('Spaces') === true &&
+        rowDetail?.includes('Hosted by this service.') === true,
+      'Enrollment detail uses space labels and shows the Stratos repository host',
     )
 
     // Search by DID still jumps straight to a member.


### PR DESCRIPTION
## Summary

- Expose repository custody and host information through the admin API.
- Generate and export the new admin lexicon through `stratos-client`.
- Show custody details in the enrollment administration interface.
- Add admin API, UI, and service tests for mixed-custody enrollments.

## Stack

- Depends on #172
- Next: #171

## Verification

The reconstructed full stack passes:

- `pnpm format:check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` — 197 files passed, 2,484 tests passed, 32 skipped



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added custody filtering for enrollments, with Stratos and PDS options.
  - Enrollment records now display custody and repository host information.
  - Added repository-host details for each member’s space, including resolution sources when available.
  - Added an administrator query for retrieving repository-host resolutions.
- **UI Improvements**
  - Updated enrollment terminology to use “spaces.”
  - Added custody badges and a repository host section to member details.
- **Documentation**
  - Documented the new administrator queries and filtering options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->