### PR TITLE
MM-11: Make the feedgen index ephemeral

### DIFF
--- a/docker-compose.feedgen.yml
+++ b/docker-compose.feedgen.yml
@@ -71,4 +71,8 @@ services:
       start_period: 5s
 
 volumes:
+  # To upgrade an existing feedgen-data volume, start once with the old volume
+  # mounted at /app/legacy and FEEDGEN_SQLITE_PATH=/app/legacy/feedgen.sqlite.
+  # The service imports membership snapshots into feedgen-control. Stop it after
+  # the import. Before normal starts, remove FEEDGEN_SQLITE_PATH.
   feedgen-control:

--- a/docker-compose.feedgen.yml
+++ b/docker-compose.feedgen.yml
@@ -41,16 +41,11 @@ services:
       STRATOS_SERVICE_URL: http://stratos:3100
       STRATOS_SERVICE_DID: ${STRATOS_SERVICE_DID}
       FEEDGEN_STORAGE_BACKEND: sqlite
-      # Set an explicit path and mount storage to persist private feed data.
-      # FEEDGEN_SQLITE_PATH: /app/data/feedgen.sqlite
       FEEDGEN_FEEDS_FILE: /app/config/feeds.yaml
       FEEDGEN_SUBSCRIBE_ENROLLMENTS: 'true'
       FEEDGEN_PLC_URL: ${STRATOS_PLC_URL:-https://plc.directory}
     ulimits:
       core: 0
-    # Persistence is opt-in because the database contains private records.
-    # volumes:
-    #   - feedgen-data:/app/data
     volumes:
       - ./stratos-feedgen/feeds.local.yaml:/app/config/feeds.yaml:ro
     depends_on:
@@ -70,7 +65,3 @@ services:
       timeout: 10s
       retries: 3
       start_period: 5s
-
-# To retain data across restarts, uncomment this with the feedgen volume above.
-# volumes:
-#   feedgen-data:

--- a/docker-compose.feedgen.yml
+++ b/docker-compose.feedgen.yml
@@ -41,6 +41,9 @@ services:
       STRATOS_SERVICE_URL: http://stratos:3100
       STRATOS_SERVICE_DID: ${STRATOS_SERVICE_DID}
       FEEDGEN_STORAGE_BACKEND: sqlite
+      # The materialized record projection and its replay cursors stay in
+      # memory. Persist only the membership/control recovery snapshot.
+      FEEDGEN_MEMBERSHIP_SQLITE_PATH: /app/data/feedgen-membership.sqlite
       FEEDGEN_FEEDS_FILE: /app/config/feeds.yaml
       FEEDGEN_SUBSCRIBE_ENROLLMENTS: 'true'
       FEEDGEN_PLC_URL: ${STRATOS_PLC_URL:-https://plc.directory}
@@ -48,6 +51,7 @@ services:
       core: 0
     volumes:
       - ./stratos-feedgen/feeds.local.yaml:/app/config/feeds.yaml:ro
+      - feedgen-control:/app/data
     depends_on:
       stratos:
         condition: service_healthy
@@ -65,3 +69,6 @@ services:
       timeout: 10s
       retries: 3
       start_period: 5s
+
+volumes:
+  feedgen-control:

--- a/docker-compose.feedgen.yml
+++ b/docker-compose.feedgen.yml
@@ -41,12 +41,17 @@ services:
       STRATOS_SERVICE_URL: http://stratos:3100
       STRATOS_SERVICE_DID: ${STRATOS_SERVICE_DID}
       FEEDGEN_STORAGE_BACKEND: sqlite
-      FEEDGEN_SQLITE_PATH: /app/data/feedgen.sqlite
+      # Set an explicit path and mount storage to persist private feed data.
+      # FEEDGEN_SQLITE_PATH: /app/data/feedgen.sqlite
       FEEDGEN_FEEDS_FILE: /app/config/feeds.yaml
       FEEDGEN_SUBSCRIBE_ENROLLMENTS: 'true'
       FEEDGEN_PLC_URL: ${STRATOS_PLC_URL:-https://plc.directory}
+    ulimits:
+      core: 0
+    # Persistence is opt-in because the database contains private records.
+    # volumes:
+    #   - feedgen-data:/app/data
     volumes:
-      - feedgen-data:/app/data
       - ./stratos-feedgen/feeds.local.yaml:/app/config/feeds.yaml:ro
     depends_on:
       stratos:
@@ -66,5 +71,6 @@ services:
       retries: 3
       start_period: 5s
 
-volumes:
-  feedgen-data:
+# To retain data across restarts, uncomment this with the feedgen volume above.
+# volumes:
+#   feedgen-data:

--- a/docs/operator/examples/index.md
+++ b/docs/operator/examples/index.md
@@ -65,6 +65,13 @@ overlay on top of the base stack. The overlay adds a `feedgen` service (SQLite-b
 an ephemeral Cloudflare tunnel so the feedgen's `did:web` document is reachable over
 HTTPS.
 
+Feedgen uses an in-memory SQLite index by default. A restart rebuilds its post, boundary,
+enrollment, and cursor index from Stratos replay streams. The overlay sets the core-dump
+limit to zero because the process can hold private content. To persist the index, uncomment
+the documented `FEEDGEN_SQLITE_PATH` and `feedgen-data` volume entries in the overlay.
+That opt-in stores private records, boundaries, enrollments, and cursors, so protect the
+mounted storage as private content.
+
 A bare `docker compose -f docker-compose.yml -f docker-compose.feedgen.yml up -d` is not
 enough on its own: the feedgen's identity is derived from `FEEDGEN_HOST`
 (`FEEDGEN_SERVICE_DID=did:web:${FEEDGEN_HOST}`), and that host is the tunnel's ephemeral

--- a/docs/operator/examples/index.md
+++ b/docs/operator/examples/index.md
@@ -72,6 +72,9 @@ the documented `FEEDGEN_SQLITE_PATH` and `feedgen-data` volume entries in the ov
 That opt-in stores private records, boundaries, enrollments, and cursors, so protect the
 mounted storage as private content.
 
+Using `FEEDGEN_STORAGE_BACKEND=postgres` with `FEEDGEN_POSTGRES_URL` makes the same
+persistence choice in PostgreSQL. Protect that database as private content.
+
 A bare `docker compose -f docker-compose.yml -f docker-compose.feedgen.yml up -d` is not
 enough on its own: the feedgen's identity is derived from `FEEDGEN_HOST`
 (`FEEDGEN_SERVICE_DID=did:web:${FEEDGEN_HOST}`), and that host is the tunnel's ephemeral

--- a/docs/operator/examples/index.md
+++ b/docs/operator/examples/index.md
@@ -65,30 +65,44 @@ overlay on top of the base stack. The overlay adds a `feedgen` service (SQLite-b
 an ephemeral Cloudflare tunnel so the feedgen's `did:web` document is reachable over
 HTTPS.
 
-Feedgen uses an in-memory SQLite index by default. A restart rebuilds its posts,
-boundaries, enrollments, membership snapshots, and cursors through the custody-aware
-subscription and space-poller ingestion arms. The overlay sets the core-dump limit to
-zero because the process can hold private content. To persist the index, add a
-deployment-specific Compose override:
+Feedgen keeps its materialized record projection in memory by default: posts, post
+boundaries, actor subscription cursors, and PDS-custody cursors all rebuild after a
+restart. The overlay still mounts a small `feedgen-control` volume and sets
+`FEEDGEN_MEMBERSHIP_SQLITE_PATH=/app/data/feedgen-membership.sqlite`. That database holds
+only enrolled-actor and space-member snapshots, from which runtime components source their
+hot maps for fast lookup and recovery/reconciliation.
+
+Those durable snapshots are not an authorization grant. Before actor-subscription replayed
+records are admitted, Feedgen checks current membership with the authority; an unavailable
+or invalid answer fails closed and leaves the replay to retry. The overlay also sets the
+core-dump limit to zero because the process can hold private content.
+
+Feed reads are separately admission-gated. From process start, and again through every
+enrollment-stream reconnect and reconciliation, `zone.stratos.feedgen.getFeed` returns HTTP
+`503` `FeedNotReady`. It becomes available only after a complete current-authority
+reconciliation. A pass bounded by `FEEDGEN_RECONCILE_MAX_ACTORS` is partial and does not
+release that gate. Keep `FEEDGEN_SUBSCRIBE_ENROLLMENTS` enabled: setting it to `false` leaves
+feed reads unavailable, so it is not a static-feed or manual-soak serving mode.
+
+Persisting the private record projection is separately opt-in. Add a deployment-specific
+Compose override:
 
 ```yaml
 services:
   feedgen:
     environment:
       FEEDGEN_SQLITE_PATH: /app/data/feedgen.sqlite
-    volumes:
-      - feedgen-data:/app/data
-
-volumes:
-  feedgen-data:
 ```
 
-Layer that file after `docker-compose.feedgen.yml`. This opt-in stores private records,
-boundaries, enrollments, membership snapshots, and cursors, so protect the mounted
-storage as private content.
+Layer that file after `docker-compose.feedgen.yml`. The overlay's `feedgen-control` volume
+remains required; the opt-in record file additionally retains private posts, boundaries,
+and both replay cursors. Protect that volume as private content. It is also where the
+membership snapshots live, but those snapshots remain a recovery baseline rather than the
+authority for replay authorization.
 
-Using `FEEDGEN_STORAGE_BACKEND=postgres` with `FEEDGEN_POSTGRES_URL` makes the same
-persistence choice in PostgreSQL. Protect that database as private content.
+Using `FEEDGEN_STORAGE_BACKEND=postgres` with `FEEDGEN_POSTGRES_URL` persists both the
+record projection and membership snapshots in PostgreSQL. Protect that database as private
+content.
 
 A bare `docker compose -f docker-compose.yml -f docker-compose.feedgen.yml up -d` is not
 enough on its own: the feedgen's identity is derived from `FEEDGEN_HOST`

--- a/docs/operator/examples/index.md
+++ b/docs/operator/examples/index.md
@@ -65,12 +65,27 @@ overlay on top of the base stack. The overlay adds a `feedgen` service (SQLite-b
 an ephemeral Cloudflare tunnel so the feedgen's `did:web` document is reachable over
 HTTPS.
 
-Feedgen uses an in-memory SQLite index by default. A restart rebuilds its post, boundary,
-enrollment, and cursor index from Stratos replay streams. The overlay sets the core-dump
-limit to zero because the process can hold private content. To persist the index, uncomment
-the documented `FEEDGEN_SQLITE_PATH` and `feedgen-data` volume entries in the overlay.
-That opt-in stores private records, boundaries, enrollments, and cursors, so protect the
-mounted storage as private content.
+Feedgen uses an in-memory SQLite index by default. A restart rebuilds its posts,
+boundaries, enrollments, membership snapshots, and cursors through the custody-aware
+subscription and space-poller ingestion arms. The overlay sets the core-dump limit to
+zero because the process can hold private content. To persist the index, add a
+deployment-specific Compose override:
+
+```yaml
+services:
+  feedgen:
+    environment:
+      FEEDGEN_SQLITE_PATH: /app/data/feedgen.sqlite
+    volumes:
+      - feedgen-data:/app/data
+
+volumes:
+  feedgen-data:
+```
+
+Layer that file after `docker-compose.feedgen.yml`. This opt-in stores private records,
+boundaries, enrollments, membership snapshots, and cursors, so protect the mounted
+storage as private content.
 
 Using `FEEDGEN_STORAGE_BACKEND=postgres` with `FEEDGEN_POSTGRES_URL` makes the same
 persistence choice in PostgreSQL. Protect that database as private content.

--- a/stratos-feedgen/Dockerfile
+++ b/stratos-feedgen/Dockerfile
@@ -8,11 +8,13 @@
 #             -e FEEDGEN_SIGNING_KEY=<hex> \
 #             -e STRATOS_SERVICE_URL=https://stratos.example.com \
 #             -e STRATOS_SERVICE_DID=did:web:stratos.example.com \
-#             -e FEEDGEN_SQLITE_PATH=/app/data/feedgen.sqlite \
 #             -e FEEDGEN_FEEDS_FILE=/app/config/feeds.yaml \
 #             -v /path/to/feeds.yaml:/app/config/feeds.yaml:ro \
-#             -v feedgen-data:/app/data \
 #             stratos-feedgen
+#
+# Persistence is opt-in and retains private feed data:
+#             -e FEEDGEN_SQLITE_PATH=/app/data/feedgen.sqlite \
+#             -v feedgen-data:/app/data \
 
 # --- Build stage: install workspace deps and run esbuild bundle ---
 FROM node:24-alpine AS builder
@@ -58,7 +60,7 @@ RUN apk add --no-cache wget \
 # Bundled application (single ESM file + sourcemap).
 COPY --from=builder /app/stratos-feedgen/dist-bundle/ ./
 
-RUN mkdir -p /app/data /app/config && chown -R node:node /app/data /app/config
+RUN mkdir -p /app/config && chown -R node:node /app/config
 
 USER node
 

--- a/stratos-feedgen/Dockerfile
+++ b/stratos-feedgen/Dockerfile
@@ -19,6 +19,12 @@
 #
 # Persisting the private record projection is separately opt-in:
 #             -e FEEDGEN_SQLITE_PATH=/app/data/feedgen.sqlite
+#
+# To upgrade an existing feedgen-data volume, start once with:
+#             -e FEEDGEN_SQLITE_PATH=/app/legacy/feedgen.sqlite \
+#             -v <existing-feedgen-data-volume>:/app/legacy:ro
+# This imports membership snapshots into feedgen-control. Stop the container
+# after the import. Before normal starts, remove FEEDGEN_SQLITE_PATH.
 
 # --- Build stage: install workspace deps and run esbuild bundle ---
 FROM node:24-alpine AS builder

--- a/stratos-feedgen/Dockerfile
+++ b/stratos-feedgen/Dockerfile
@@ -8,13 +8,17 @@
 #             -e FEEDGEN_SIGNING_KEY=<hex> \
 #             -e STRATOS_SERVICE_URL=https://stratos.example.com \
 #             -e STRATOS_SERVICE_DID=did:web:stratos.example.com \
+#             -e FEEDGEN_MEMBERSHIP_SQLITE_PATH=/app/data/feedgen-membership.sqlite \
 #             -e FEEDGEN_FEEDS_FILE=/app/config/feeds.yaml \
+#             -v feedgen-control:/app/data \
 #             -v /path/to/feeds.yaml:/app/config/feeds.yaml:ro \
 #             stratos-feedgen
 #
-# Persistence is opt-in and retains private feed data:
-#             -e FEEDGEN_SQLITE_PATH=/app/data/feedgen.sqlite \
-#             -v feedgen-data:/app/data \
+# The record projection and its replay cursors stay in memory by default. The
+# mounted control database persists only the membership/recovery snapshot.
+#
+# Persisting the private record projection is separately opt-in:
+#             -e FEEDGEN_SQLITE_PATH=/app/data/feedgen.sqlite
 
 # --- Build stage: install workspace deps and run esbuild bundle ---
 FROM node:24-alpine AS builder
@@ -60,7 +64,7 @@ RUN apk add --no-cache wget \
 # Bundled application (single ESM file + sourcemap).
 COPY --from=builder /app/stratos-feedgen/dist-bundle/ ./
 
-RUN mkdir -p /app/config && chown -R node:node /app/config
+RUN mkdir -p /app/config /app/data && chown -R node:node /app/config /app/data
 
 USER node
 

--- a/stratos-feedgen/README.md
+++ b/stratos-feedgen/README.md
@@ -107,17 +107,17 @@ a terminal page awaits verification; capped pages retain their cursor.
 
 ### Storage choices
 
-| Concern                              | Choice                                                                                                      |
-| ------------------------------------ | ----------------------------------------------------------------------------------------------------------- |
-| Post / boundary / subscription index | SQLite in memory by default, or Postgres via the shared feedgen store                                       |
-| Foreign-repo cursor                  | `space_sync_cursor`, keyed by space URI and member DID                                                      |
-| Unverified foreign-repo delta        | `space_sync_stage`, held until terminal verification; pending terminal state is isolated from fresh runs     |
-| Membership snapshot                  | Separate SQLite store (durable path required with an in-memory record index) or Postgres                    |
-| Authorization leases and halt state  | In process; rebuilt from authoritative membership on boot                                                   |
-| Space credentials and DPoP keys      | In process; refreshed before expiry, never persisted                                                        |
-| Blob cache                           | S3 or filestore                                                                                              |
-| Feed configuration                   | Static — JSON/YAML file or env var                                                                           |
-| Viewer boundary cache                | In-process TTL + LRU (300 s default)                                                                         |
+| Concern                              | Choice                                                                                                   |
+| ------------------------------------ | -------------------------------------------------------------------------------------------------------- |
+| Post / boundary / subscription index | In-memory SQLite by default; file-backed SQLite or Postgres are opt-in                                   |
+| Foreign-repo cursor                  | `space_sync_cursor`, keyed by space URI and member DID                                                   |
+| Unverified foreign-repo delta        | `space_sync_stage`, held until terminal verification; pending terminal state is isolated from fresh runs |
+| Membership snapshot                  | Separate SQLite store (durable path required with an in-memory record index) or Postgres                 |
+| Authorization leases and halt state  | In process; rebuilt from authoritative membership on boot                                                |
+| Space credentials and DPoP keys      | In process; refreshed before expiry, never persisted                                                     |
+| Blob cache                           | S3 or filestore                                                                                          |
+| Feed configuration                   | Static — JSON/YAML file or env var                                                                       |
+| Viewer boundary cache                | In-process TTL + LRU (300 s default)                                                                     |
 
 ### Moderation labels
 
@@ -159,47 +159,51 @@ tests/
 
 ## Configuration
 
-| Env var                                       | Required    | Description                                                                                      |
-| --------------------------------------------- | ----------- | ------------------------------------------------------------------------------------------------ |
-| `FEEDGEN_SERVICE_DID`                         | yes         | Feed generator service DID                                                                       |
-| `FEEDGEN_PUBLIC_URL`                          | no          | Public base URL; derived from a `did:web` service DID when omitted                               |
-| `FEEDGEN_SIGNING_KEY`                         | yes         | Private secp256k1 service-signing key                                                            |
-| `STRATOS_SERVICE_URL`                         | yes         | Request base URL of the authority Stratos service                                                |
-| `STRATOS_PUBLIC_URL`                          | no          | Public Stratos origin used in DPoP `htu`; defaults to `STRATOS_SERVICE_URL`                      |
-| `STRATOS_SERVICE_DID`                         | yes         | DID of the authority Stratos service                                                             |
-| `FEEDGEN_PLC_URL`                             | no          | PLC directory used for commit-key resolution (default `https://plc.directory`)                   |
-| `FEEDGEN_STORAGE_BACKEND`                     | no          | `sqlite` (default) or `postgres`                                                                 |
-| `FEEDGEN_SQLITE_PATH`                         | no          | Record-index SQLite location; unset or empty uses `:memory:`                                     |
-| `FEEDGEN_MEMBERSHIP_SQLITE_PATH`              | conditional | Durable membership SQLite location; required with an in-memory record index                      |
-| `FEEDGEN_POSTGRES_URL`                        | conditional | Required for the Postgres backend                                                                |
-| `FEEDGEN_POSTGRES_SCHEMA`                     | no          | Postgres schema (default `public`)                                                               |
-| `FEEDGEN_SUBSCRIBE_ENROLLMENTS`               | no          | Set `false` to disable the Stratos subscription arm                                              |
-| `FEEDGEN_SPACE_SYNC_ENABLED`                  | no          | Enable the PDS-custody polling arm (default `true`)                                              |
-| `FEEDGEN_SPACE_SYNC_INTERVAL_MS`              | no          | Target interval between jittered passes (default `30000`)                                        |
-| `FEEDGEN_SPACE_MEMBERSHIP_PAGE_LIMIT`         | no          | Members requested per authority page, `1..1000` (default `100`)                                  |
-| `FEEDGEN_SPACE_MEMBERSHIP_REQUEST_TIMEOUT_MS` | no          | Timeout for membership listing and credential mint requests (default `60000`)                    |
-| `FEEDGEN_SPACE_SYNC_PAGE_LIMIT`               | no          | Ops requested per page, `1..1000` (default `1000`)                                               |
-| `FEEDGEN_SPACE_SYNC_MAX_PAGES`                | no          | Pages per member per pass (default `10`)                                                         |
-| `FEEDGEN_SPACE_SYNC_REQUEST_TIMEOUT_MS`       | no          | Timeout for one foreign-host request (default `10000`)                                           |
-| `FEEDGEN_SPACE_SYNC_MEMBER_BUDGET_MS`         | no          | Whole-member time budget per pass (default `60000`)                                              |
-| `FEEDGEN_SPACE_SYNC_MEMBER_CONCURRENCY`       | no          | Concurrent member syncs (default `8`)                                                            |
-| `FEEDGEN_SPACE_SYNC_MAX_RECORD_BYTES`         | no          | Maximum decoded record size (default `65536`)                                                    |
-| `FEEDGEN_SPACE_SYNC_MAX_RECORDS_PER_MEMBER`   | no          | Indexed-record cap per member and pass (default `1000`)                                          |
-| `FEEDGEN_SPACE_SYNC_ALLOW_HTTP_HOSTS`         | no          | Loopback `http://` only: `localhost`, `127/8`, `[::1]`; HTTPS always allowed                    |
-| `FEEDGEN_LOG_LEVEL`                           | no          | Pino level (default `info`)                                                                      |
-| `FEEDGEN_METRICS_TOKEN`                       | no          | Bearer token for `/metrics`; unset leaves the endpoint open                                      |
+| Env var                                       | Required    | Description                                                                    |
+| --------------------------------------------- | ----------- | ------------------------------------------------------------------------------ |
+| `FEEDGEN_SERVICE_DID`                         | yes         | Feed generator service DID                                                     |
+| `FEEDGEN_PUBLIC_URL`                          | no          | Public base URL; derived from a `did:web` service DID when omitted             |
+| `FEEDGEN_SIGNING_KEY`                         | yes         | Private secp256k1 service-signing key                                          |
+| `STRATOS_SERVICE_URL`                         | yes         | Request base URL of the authority Stratos service                              |
+| `STRATOS_PUBLIC_URL`                          | no          | Public Stratos origin used in DPoP `htu`; defaults to `STRATOS_SERVICE_URL`    |
+| `STRATOS_SERVICE_DID`                         | yes         | DID of the authority Stratos service                                           |
+| `FEEDGEN_PLC_URL`                             | no          | PLC directory used for commit-key resolution (default `https://plc.directory`) |
+| `FEEDGEN_STORAGE_BACKEND`                     | no          | `sqlite` (default) or `postgres`                                               |
+| `FEEDGEN_SQLITE_PATH`                         | no          | Record-index SQLite location; unset or empty uses `:memory:`                   |
+| `FEEDGEN_MEMBERSHIP_SQLITE_PATH`              | conditional | Durable membership SQLite location; required with an in-memory record index    |
+| `FEEDGEN_POSTGRES_URL`                        | conditional | Required for the Postgres backend                                              |
+| `FEEDGEN_POSTGRES_SCHEMA`                     | no          | Postgres schema (default `public`)                                             |
+| `FEEDGEN_SUBSCRIBE_ENROLLMENTS`               | no          | Set `false` to disable the Stratos subscription arm                            |
+| `FEEDGEN_SPACE_SYNC_ENABLED`                  | no          | Enable the PDS-custody polling arm (default `true`)                            |
+| `FEEDGEN_SPACE_SYNC_INTERVAL_MS`              | no          | Target interval between jittered passes (default `30000`)                      |
+| `FEEDGEN_SPACE_MEMBERSHIP_PAGE_LIMIT`         | no          | Members requested per authority page, `1..1000` (default `100`)                |
+| `FEEDGEN_SPACE_MEMBERSHIP_REQUEST_TIMEOUT_MS` | no          | Timeout for membership listing and credential mint requests (default `60000`)  |
+| `FEEDGEN_SPACE_SYNC_PAGE_LIMIT`               | no          | Ops requested per page, `1..1000` (default `1000`)                             |
+| `FEEDGEN_SPACE_SYNC_MAX_PAGES`                | no          | Pages per member per pass (default `10`)                                       |
+| `FEEDGEN_SPACE_SYNC_REQUEST_TIMEOUT_MS`       | no          | Timeout for one foreign-host request (default `10000`)                         |
+| `FEEDGEN_SPACE_SYNC_MEMBER_BUDGET_MS`         | no          | Whole-member time budget per pass (default `60000`)                            |
+| `FEEDGEN_SPACE_SYNC_MEMBER_CONCURRENCY`       | no          | Concurrent member syncs (default `8`)                                          |
+| `FEEDGEN_SPACE_SYNC_MAX_RECORD_BYTES`         | no          | Maximum decoded record size (default `65536`)                                  |
+| `FEEDGEN_SPACE_SYNC_MAX_RECORDS_PER_MEMBER`   | no          | Indexed-record cap per member and pass (default `1000`)                        |
+| `FEEDGEN_SPACE_SYNC_ALLOW_HTTP_HOSTS`         | no          | Loopback `http://` only: `localhost`, `127/8`, `[::1]`; HTTPS always allowed   |
+| `FEEDGEN_LOG_LEVEL`                           | no          | Pino level (default `info`)                                                    |
+| `FEEDGEN_METRICS_TOKEN`                       | no          | Bearer token for `/metrics`; unset leaves the endpoint open                    |
 
 ### Feed index durability
 
 SQLite uses `:memory:` for the record index by default. Feedgen loses its post, boundary,
-enrollment, and foreign-repo cursor index on restart, then rebuilds it from the Stratos
-replay streams. This keeps private feed content out of the container filesystem by default.
-The membership snapshot stays in its separate durable SQLite store. The Compose overlay also
-sets the core-dump limit to zero because process memory can contain private content.
+enrollment, and foreign-repo cursor index on restart, then rebuilds it through the
+custody-aware subscription and space-poller ingestion arms. This keeps private feed content
+out of the container filesystem by default. The membership snapshot stays in its separate
+durable SQLite store. The Compose overlay also sets the core-dump limit to zero because
+process memory can contain private content.
 
 To retain the index, set `FEEDGEN_SQLITE_PATH` to an explicit file path and mount durable
 storage for that path. This persists private records, boundaries, enrollments, and cursors;
 protect, encrypt, and manage that storage as private content.
+
+Selecting `FEEDGEN_STORAGE_BACKEND=postgres` and setting `FEEDGEN_POSTGRES_URL` is the
+equivalent persistent-storage decision. Treat that database as private content too.
 
 ## Observability
 
@@ -251,7 +255,9 @@ startup, stops the service stream, and drains the space scheduler. If the
 scheduler misses the deadline, shutdown aborts its active pass and still waits
 for every raw member call that can access the store. It then drains actor
 commit applies, closes the DB, and exits 0. Cursor writes are completed or
-restored before the store closes. A second signal exits 1 immediately.
+restored before the store closes. Persistent backends retain committed cursors;
+the default in-memory backend rebuilds them through replay on the next boot. A
+second signal exits 1 immediately.
 `unhandledRejection`/`uncaughtException` log the error and exit 1.
 
 ### Manual soak test

--- a/stratos-feedgen/README.md
+++ b/stratos-feedgen/README.md
@@ -15,7 +15,7 @@ flowchart TD
     FG([Feed Gen])
     Verify[Verify incoming JWT<br/>resolve user DID]
     BCache[Viewer boundaries cache<br/>TTL + LRU]
-    Index[(Post index<br/>uri, did, boundary,<br/>sortAt, recordJson)]
+    Index[(Record projection<br/>posts, boundaries,<br/>sync_cursor)]
     Hydrate[Stratos hydrateRecords<br/>service-auth]
     Blob[Feed Gen getBlob]
     S3[(S3 blob cache)]
@@ -23,12 +23,13 @@ flowchart TD
     ResolveEnr[Stratos enrollment and space APIs]
 
     SvcSub[Service-level subscribeRecords<br/>replays #enrollment events]
-    Enrolled[(enrolled_actor table)]
+    Enrolled[(enrolled_actor<br/>durable control snapshot)]
     ActorSub[Per-actor subscribeRecords<br/>did + domain=boundary]
     SpaceMembership[Space membership pass<br/>listRepos + custody partition]
     SpaceScheduler[Bounded space-sync scheduler]
     MemberHost[Member repo host<br/>listRepoOps + getRecord]
-    SpaceCursor[(space_sync_cursor<br/>space + member)]
+    Members[(space_member_snapshot<br/>durable control snapshot)]
+    SpaceCursor[(space_sync_cursor<br/>ephemeral record checkpoint)]
     SpaceStage[(space_sync_stage<br/>unverified delta)]
     Purger[Revocation and commit-failure purge]
 
@@ -48,6 +49,7 @@ flowchart TD
     ActorSub --> Index
     SpaceMembership -->|DPoP space credential| ResolveEnr
     SpaceMembership --> SpaceScheduler
+    SpaceMembership --> Members
     SpaceScheduler -->|DPoP space credential| MemberHost
     MemberHost --> SpaceStage
     SpaceStage -->|verified terminal commit| Index
@@ -70,7 +72,7 @@ flowchart TD
     class Client client
     class PDS pds
     class FG,Verify fg
-    class Index,Enrolled,SpaceCursor,SpaceStage store
+    class Index,Enrolled,Members,SpaceCursor,SpaceStage store
     class BCache,S3,Blob cache
     class Hydrate,ResolveEnr,StratosBlob,MemberHost upstream
     class SvcSub,ActorSub,SpaceMembership,SpaceScheduler,Purger worker
@@ -88,6 +90,12 @@ host's terminal commit verifies. Verified promotion applies staged updates and
 tombstones atomically to the index. A fresh run resets staged state only when
 a terminal page awaits verification; capped pages retain their cursor.
 
+For SQLite, the membership snapshots are held in a separate durable control
+database and loaded into memory at startup. They are recovery and
+reconciliation state, not authorization authority: replay admission checks the
+current authority before allowing an actor's historical records, and an
+unavailable or invalid answer fails closed so the replay can retry.
+
 ### Auth flow
 
 | Direction                    | Mechanism                                                                                 | Verification                                                                   |
@@ -96,7 +104,6 @@ a terminal page awaits verification; capped pages retain their cursor.
 | PDS → Feed Gen               | Bearer service-auth JWT (`iss=userDID`, `aud=feedgenDID`, `lxm=<endpoint>`, `exp<60s`)    | Feed gen resolves user DID, verifies signature via atproto verification method |
 | Feed Gen → Stratos           | Bearer service-auth JWT (`iss=feedgenDID`, `aud=stratosDID`, `lxm=<endpoint>`)            | Stratos `service` verifier resolves feed gen DID                               |
 | Feed Gen → Stratos (sync WS) | `Authorization: Bearer` header = same JWT shape, `lxm=zone.stratos.sync.subscribeRecords` | Stratos `subscribeAuth` verifier                                               |
-| Feed Gen → Stratos (space)   | DPoP-bound space credential for `listRepos`; mint uses a short-lived delegation JWT       | Stratos verifies the authority, credential scope, DPoP key, `htu`, and `ath`   |
 | Feed Gen → member repo host  | The same scoped credential plus a fresh DPoP presentation for each foreign-host request   | Member host verifies the space authority and request-bound DPoP proof          |
 
 ### Identity
@@ -107,17 +114,16 @@ a terminal page awaits verification; capped pages retain their cursor.
 
 ### Storage choices
 
-| Concern                              | Choice                                                                                                   |
-| ------------------------------------ | -------------------------------------------------------------------------------------------------------- |
-| Post / boundary / subscription index | In-memory SQLite by default; file-backed SQLite or Postgres are opt-in                                   |
-| Foreign-repo cursor                  | `space_sync_cursor`, keyed by space URI and member DID                                                   |
-| Unverified foreign-repo delta        | `space_sync_stage`, held until terminal verification; pending terminal state is isolated from fresh runs |
-| Membership snapshot                  | Separate SQLite store (durable path required with an in-memory record index) or Postgres                 |
-| Authorization leases and halt state  | In process; rebuilt from authoritative membership on boot                                                |
-| Space credentials and DPoP keys      | In process; refreshed before expiry, never persisted                                                     |
-| Blob cache                           | S3 or filestore                                                                                          |
-| Feed configuration                   | Static — JSON/YAML file or env var                                                                       |
-| Viewer boundary cache                | In-process TTL + LRU (300 s default)                                                                     |
+| Concern                                    | Choice                                                                                              |
+| ------------------------------------------ | --------------------------------------------------------------------------------------------------- |
+| Materialized record projection and cursors | `post`, `post_boundary`, `sync_cursor`, and `space_sync_cursor`; in-memory SQLite by default        |
+| Unverified foreign-repo delta              | `space_sync_stage`; held until terminal verification and isolated from a fresh pending-terminal run |
+| Durable membership/control snapshots       | `enrolled_actor` and `space_member_snapshot`; separate SQLite control DB, or Postgres storage       |
+| Replay authorization                       | Current authoritative membership check; snapshots are never permission grants                       |
+| Space credentials and DPoP keys            | In process; refreshed before expiry, never persisted                                                |
+| Blob cache                                 | S3 or filestore                                                                                     |
+| Feed configuration                         | Static — JSON/YAML file or env var                                                                  |
+| Viewer boundary cache                      | In-process TTL + LRU (300 s default)                                                                |
 
 ### Moderation labels
 
@@ -159,52 +165,79 @@ tests/
 
 ## Configuration
 
-| Env var                                       | Required    | Description                                                                    |
-| --------------------------------------------- | ----------- | ------------------------------------------------------------------------------ |
-| `FEEDGEN_SERVICE_DID`                         | yes         | Feed generator service DID                                                     |
-| `FEEDGEN_PUBLIC_URL`                          | no          | Public base URL; derived from a `did:web` service DID when omitted             |
-| `FEEDGEN_SIGNING_KEY`                         | yes         | Private secp256k1 service-signing key                                          |
-| `STRATOS_SERVICE_URL`                         | yes         | Request base URL of the authority Stratos service                              |
-| `STRATOS_PUBLIC_URL`                          | no          | Public Stratos origin used in DPoP `htu`; defaults to `STRATOS_SERVICE_URL`    |
-| `STRATOS_SERVICE_DID`                         | yes         | DID of the authority Stratos service                                           |
-| `FEEDGEN_PLC_URL`                             | no          | PLC directory used for commit-key resolution (default `https://plc.directory`) |
-| `FEEDGEN_STORAGE_BACKEND`                     | no          | `sqlite` (default) or `postgres`                                               |
-| `FEEDGEN_SQLITE_PATH`                         | no          | Record-index SQLite location; unset or empty uses `:memory:`                   |
-| `FEEDGEN_MEMBERSHIP_SQLITE_PATH`              | conditional | Durable membership SQLite location; required with an in-memory record index    |
-| `FEEDGEN_POSTGRES_URL`                        | conditional | Required for the Postgres backend                                              |
-| `FEEDGEN_POSTGRES_SCHEMA`                     | no          | Postgres schema (default `public`)                                             |
-| `FEEDGEN_SUBSCRIBE_ENROLLMENTS`               | no          | Set `false` to disable the Stratos subscription arm                            |
-| `FEEDGEN_SPACE_SYNC_ENABLED`                  | no          | Enable the PDS-custody polling arm (default `true`)                            |
-| `FEEDGEN_SPACE_SYNC_INTERVAL_MS`              | no          | Target interval between jittered passes (default `30000`)                      |
-| `FEEDGEN_SPACE_MEMBERSHIP_PAGE_LIMIT`         | no          | Members requested per authority page, `1..1000` (default `100`)                |
-| `FEEDGEN_SPACE_MEMBERSHIP_REQUEST_TIMEOUT_MS` | no          | Timeout for membership listing and credential mint requests (default `60000`)  |
-| `FEEDGEN_SPACE_SYNC_PAGE_LIMIT`               | no          | Ops requested per page, `1..1000` (default `1000`)                             |
-| `FEEDGEN_SPACE_SYNC_MAX_PAGES`                | no          | Pages per member per pass (default `10`)                                       |
-| `FEEDGEN_SPACE_SYNC_REQUEST_TIMEOUT_MS`       | no          | Timeout for one foreign-host request (default `10000`)                         |
-| `FEEDGEN_SPACE_SYNC_MEMBER_BUDGET_MS`         | no          | Whole-member time budget per pass (default `60000`)                            |
-| `FEEDGEN_SPACE_SYNC_MEMBER_CONCURRENCY`       | no          | Concurrent member syncs (default `8`)                                          |
-| `FEEDGEN_SPACE_SYNC_MAX_RECORD_BYTES`         | no          | Maximum decoded record size (default `65536`)                                  |
-| `FEEDGEN_SPACE_SYNC_MAX_RECORDS_PER_MEMBER`   | no          | Indexed-record cap per member and pass (default `1000`)                        |
-| `FEEDGEN_SPACE_SYNC_ALLOW_HTTP_HOSTS`         | no          | Loopback `http://` only: `localhost`, `127/8`, `[::1]`; HTTPS always allowed   |
-| `FEEDGEN_LOG_LEVEL`                           | no          | Pino level (default `info`)                                                    |
-| `FEEDGEN_METRICS_TOKEN`                       | no          | Bearer token for `/metrics`; unset leaves the endpoint open                    |
+| Env var                                       | Required    | Description                                                                     |
+| --------------------------------------------- | ----------- | ------------------------------------------------------------------------------- |
+| `FEEDGEN_SERVICE_DID`                         | yes         | Feed generator service DID                                                      |
+| `FEEDGEN_PUBLIC_URL`                          | no          | Public base URL; derived from a `did:web` service DID when omitted              |
+| `FEEDGEN_SIGNING_KEY`                         | yes         | Private secp256k1 service-signing key                                           |
+| `STRATOS_SERVICE_URL`                         | yes         | Request base URL of the authority Stratos service                               |
+| `STRATOS_PUBLIC_URL`                          | no          | Public Stratos origin used in DPoP `htu`; defaults to `STRATOS_SERVICE_URL`     |
+| `STRATOS_SERVICE_DID`                         | yes         | DID of the authority Stratos service                                            |
+| `FEEDGEN_PLC_URL`                             | no          | PLC directory used for commit-key resolution (default `https://plc.directory`)  |
+| `FEEDGEN_STORAGE_BACKEND`                     | no          | `sqlite` (default) or `postgres`                                                |
+| `FEEDGEN_SQLITE_PATH`                         | no          | Record projection SQLite location; unset or empty uses `:memory:`               |
+| `FEEDGEN_MEMBERSHIP_SQLITE_PATH`              | conditional | Durable SQLite control DB; required for `:memory:`, else a sibling file         |
+| `FEEDGEN_POSTGRES_URL`                        | conditional | Required for the Postgres backend                                               |
+| `FEEDGEN_POSTGRES_SCHEMA`                     | no          | Postgres schema (default `public`)                                              |
+| `FEEDGEN_SUBSCRIBE_ENROLLMENTS`               | no          | Set `false` to disable enrollment reconciliation; feed reads remain unavailable |
+| `FEEDGEN_SPACE_SYNC_ENABLED`                  | no          | Enable the PDS-custody polling arm (default `true`)                             |
+| `FEEDGEN_SPACE_SYNC_INTERVAL_MS`              | no          | Target interval between jittered passes (default `30000`)                       |
+| `FEEDGEN_SPACE_MEMBERSHIP_PAGE_LIMIT`         | no          | Members requested per authority page, `1..1000` (default `100`)                 |
+| `FEEDGEN_SPACE_MEMBERSHIP_REQUEST_TIMEOUT_MS` | no          | Timeout for membership listing and credential mint requests (default `60000`)   |
+| `FEEDGEN_SPACE_SYNC_PAGE_LIMIT`               | no          | Ops requested per page, `1..1000` (default `1000`)                              |
+| `FEEDGEN_SPACE_SYNC_MAX_PAGES`                | no          | Pages per member per pass (default `10`)                                        |
+| `FEEDGEN_SPACE_SYNC_REQUEST_TIMEOUT_MS`       | no          | Timeout for one foreign-host request (default `10000`)                          |
+| `FEEDGEN_SPACE_SYNC_MEMBER_BUDGET_MS`         | no          | Whole-member time budget per pass (default `60000`)                             |
+| `FEEDGEN_SPACE_SYNC_MEMBER_CONCURRENCY`       | no          | Concurrent member syncs (default `8`)                                           |
+| `FEEDGEN_SPACE_SYNC_MAX_RECORD_BYTES`         | no          | Maximum decoded record size (default `65536`)                                   |
+| `FEEDGEN_SPACE_SYNC_MAX_RECORDS_PER_MEMBER`   | no          | Indexed-record cap per member and pass (default `1000`)                         |
+| `FEEDGEN_SPACE_SYNC_ALLOW_HTTP_HOSTS`         | no          | Loopback `http://` only: `localhost`, `127/8`, `[::1]`; HTTPS always allowed    |
+| `FEEDGEN_LOG_LEVEL`                           | no          | Pino level (default `info`)                                                     |
+| `FEEDGEN_METRICS_TOKEN`                       | no          | Bearer token for `/metrics`; unset leaves the endpoint open                     |
 
-### Feed index durability
+### Storage durability
 
-SQLite uses `:memory:` for the record index by default. Feedgen loses cached posts,
-boundaries, enrollments, and foreign-repo cursors on restart, then rebuilds them through the
-custody-aware subscription and space-poller ingestion arms. This keeps private feed content
-out of the container filesystem by default. Membership snapshots remain in their separate
-durable SQLite store for restart recovery and fast in-memory lookup. The Compose overlay also
-sets the core-dump limit to zero because process memory can contain private content.
+SQLite separates the materialized record projection from durable membership/control state.
+`FEEDGEN_SQLITE_PATH` holds posts, post boundaries, `sync_cursor`, `space_sync_cursor`,
+`space_sync_stage`, and its pending-verification marker. It defaults to `:memory:`, so those
+records and cursors are discarded on restart and rebuilt through the custody-aware subscription
+and space-poller ingestion arms.
 
-To retain the record index, set `FEEDGEN_SQLITE_PATH` to an explicit file path and mount
-durable storage for that path. This persists private records, boundaries, enrollments, and
-cursors; protect, encrypt, and manage that storage as private content. Set
-`FEEDGEN_MEMBERSHIP_SQLITE_PATH` to durable storage for membership snapshots.
+`FEEDGEN_MEMBERSHIP_SQLITE_PATH` holds only `enrolled_actor` and
+`space_member_snapshot`. When the record projection is in memory, this must be an explicit
+non-memory file path. Runtime membership components source their hot maps from those
+snapshots for fast lookup and use them as a recovery/reconciliation baseline; they are not
+permission grants.
+Actor-subscription replay admission confirms current membership with the authority before
+accepting an actor's historical records. If the authority lookup is unavailable or invalid,
+the replay fails closed and retries rather than advancing its actor cursor.
 
-Selecting `FEEDGEN_STORAGE_BACKEND=postgres` and setting `FEEDGEN_POSTGRES_URL` is the
-equivalent persistent-storage decision. Treat that database as private content too.
+The Compose overlay mounts `/app/data` as `feedgen-control` and configures
+`/app/data/feedgen-membership.sqlite` for this purpose. The snapshot database still
+contains sensitive DIDs and boundary membership, so protect it appropriately, but it does
+not retain private records or replay cursors by default. The overlay also sets the core-dump
+limit to zero because process memory can contain private content.
+
+To retain the private record projection, set `FEEDGEN_SQLITE_PATH` to an explicit file path
+on durable storage. When it is a file and `FEEDGEN_MEMBERSHIP_SQLITE_PATH` is omitted,
+Feedgen derives a separate sibling membership database. Protect both files as private
+content.
+
+Selecting `FEEDGEN_STORAGE_BACKEND=postgres` and setting `FEEDGEN_POSTGRES_URL` persists
+the projection, cursors, and membership snapshots together. Treat that database as private
+content too.
+
+### Feed-read readiness
+
+Feed reads start fail closed. From process start, and again throughout every enrollment-stream
+reconnect and reconciliation, `zone.stratos.feedgen.getFeed` returns HTTP `503` with the
+XRPC error `FeedNotReady`. Reads become available only after a complete reconciliation against
+the current authority. A pass bounded by `FEEDGEN_RECONCILE_MAX_ACTORS` is deliberately
+partial and does not release the read gate.
+
+Keep `FEEDGEN_SUBSCRIBE_ENROLLMENTS` enabled for any serving deployment. Setting it to
+`false` leaves feed reads unavailable, so it is not a static-feed or manual-soak serving
+mode.
 
 ## Observability
 
@@ -246,7 +279,9 @@ itself (WP9); no blob cache exists yet.
 
 Returns `{ok, version, serviceStreamConnected, actorPoolSize}`. `ok` is
 independent of subscription state: with `FEEDGEN_SUBSCRIBE_ENROLLMENTS=false`
-the stream fields read `false`/`0` by design.
+the stream fields read `false`/`0` by design. `/health` is a liveness signal,
+not a feed-readiness signal: `getFeed` remains HTTP `503` `FeedNotReady` until
+the complete current-authority reconciliation releases its read gate.
 
 ### Shutdown semantics
 
@@ -256,15 +291,17 @@ startup, stops the service stream, and drains the space scheduler. If the
 scheduler misses the deadline, shutdown aborts its active pass and still waits
 for every raw member call that can access the store. It then drains actor
 commit applies, closes the DB, and exits 0. Cursor writes are completed or
-restored before the store closes. Persistent backends retain committed cursors;
-the default in-memory backend rebuilds them through replay on the next boot. A
-second signal exits 1 immediately.
+restored before the store closes. A file-backed record store or Postgres retains
+committed cursors; the default in-memory record projection rebuilds them through
+replay on the next boot. The separate membership/control SQLite database holds
+no record cursors. A second signal exits 1 immediately.
 `unhandledRejection`/`uncaughtException` log the error and exit 1.
 
 ### Manual soak test
 
-Run locally with sqlite, seeded posts, and `FEEDGEN_SUBSCRIBE_ENROLLMENTS=false`.
-Drive ~50 req/s for 5 minutes against `getFeed` with a static service JWT, e.g.
+Run locally with SQLite, seeded posts, and enrollment subscription enabled (the default).
+Wait for the complete current-authority reconciliation to release feed reads, then drive
+~50 req/s for 5 minutes against `getFeed` with a static service JWT, e.g.
 `autocannon -R 50 -d 300 -H "authorization=Bearer $JWT" "$BASE/xrpc/zone.stratos.feedgen.getFeed?feed=<id>"`.
 Record before/after RSS (`ps -o rss= -p <pid>`) and FD count
 (`ls /proc/<pid>/fd | wc -l`), and cross-check

--- a/stratos-feedgen/README.md
+++ b/stratos-feedgen/README.md
@@ -191,16 +191,17 @@ tests/
 
 ### Feed index durability
 
-SQLite uses `:memory:` for the record index by default. Feedgen loses its post, boundary,
-enrollment, and foreign-repo cursor index on restart, then rebuilds it through the
+SQLite uses `:memory:` for the record index by default. Feedgen loses cached posts,
+boundaries, enrollments, and foreign-repo cursors on restart, then rebuilds them through the
 custody-aware subscription and space-poller ingestion arms. This keeps private feed content
-out of the container filesystem by default. The membership snapshot stays in its separate
-durable SQLite store. The Compose overlay also sets the core-dump limit to zero because
-process memory can contain private content.
+out of the container filesystem by default. Membership snapshots remain in their separate
+durable SQLite store for restart recovery and fast in-memory lookup. The Compose overlay also
+sets the core-dump limit to zero because process memory can contain private content.
 
-To retain the index, set `FEEDGEN_SQLITE_PATH` to an explicit file path and mount durable
-storage for that path. This persists private records, boundaries, enrollments, and cursors;
-protect, encrypt, and manage that storage as private content.
+To retain the record index, set `FEEDGEN_SQLITE_PATH` to an explicit file path and mount
+durable storage for that path. This persists private records, boundaries, enrollments, and
+cursors; protect, encrypt, and manage that storage as private content. Set
+`FEEDGEN_MEMBERSHIP_SQLITE_PATH` to durable storage for membership snapshots.
 
 Selecting `FEEDGEN_STORAGE_BACKEND=postgres` and setting `FEEDGEN_POSTGRES_URL` is the
 equivalent persistent-storage decision. Treat that database as private content too.

--- a/stratos-feedgen/README.md
+++ b/stratos-feedgen/README.md
@@ -107,17 +107,17 @@ a terminal page awaits verification; capped pages retain their cursor.
 
 ### Storage choices
 
-| Concern                              | Choice                                                        |
-| ------------------------------------ | ------------------------------------------------------------- |
-| Post / boundary / subscription index | SQLite or Postgres via the shared feedgen store               |
-| Foreign-repo cursor                  | `space_sync_cursor`, keyed by space URI and member DID        |
-| Unverified foreign-repo delta        | `space_sync_stage`, promoted only after terminal verification |
-| Membership snapshot                  | SQLite/Postgres; replaced after a complete successful pass    |
-| Authorization leases and halt state  | In process; rebuilt from authoritative membership on boot     |
-| Space credentials and DPoP keys      | In process; refreshed before expiry, never persisted          |
-| Blob cache                           | S3 or filestore                                               |
-| Feed configuration                   | Static — JSON/YAML file or env var                            |
-| Viewer boundary cache                | In-process TTL + LRU (300 s default)                          |
+| Concern                              | Choice                                                                                                      |
+| ------------------------------------ | ----------------------------------------------------------------------------------------------------------- |
+| Post / boundary / subscription index | SQLite in memory by default, or Postgres via the shared feedgen store                                       |
+| Foreign-repo cursor                  | `space_sync_cursor`, keyed by space URI and member DID                                                      |
+| Unverified foreign-repo delta        | `space_sync_stage`, held until terminal verification; pending terminal state is isolated from fresh runs     |
+| Membership snapshot                  | Separate SQLite store (durable path required with an in-memory record index) or Postgres                    |
+| Authorization leases and halt state  | In process; rebuilt from authoritative membership on boot                                                   |
+| Space credentials and DPoP keys      | In process; refreshed before expiry, never persisted                                                        |
+| Blob cache                           | S3 or filestore                                                                                              |
+| Feed configuration                   | Static — JSON/YAML file or env var                                                                           |
+| Viewer boundary cache                | In-process TTL + LRU (300 s default)                                                                         |
 
 ### Moderation labels
 
@@ -159,34 +159,47 @@ tests/
 
 ## Configuration
 
-| Env var                                       | Required    | Description                                                                    |
-| --------------------------------------------- | ----------- | ------------------------------------------------------------------------------ |
-| `FEEDGEN_SERVICE_DID`                         | yes         | Feed generator service DID                                                     |
-| `FEEDGEN_PUBLIC_URL`                          | no          | Public base URL; derived from a `did:web` service DID when omitted             |
-| `FEEDGEN_SIGNING_KEY`                         | yes         | Private secp256k1 service-signing key                                          |
-| `STRATOS_SERVICE_URL`                         | yes         | Request base URL of the authority Stratos service                              |
-| `STRATOS_PUBLIC_URL`                          | no          | Public Stratos origin used in DPoP `htu`; defaults to `STRATOS_SERVICE_URL`    |
-| `STRATOS_SERVICE_DID`                         | yes         | DID of the authority Stratos service                                           |
-| `FEEDGEN_PLC_URL`                             | no          | PLC directory used for commit-key resolution (default `https://plc.directory`) |
-| `FEEDGEN_STORAGE_BACKEND`                     | no          | `sqlite` (default) or `postgres`                                               |
-| `FEEDGEN_SQLITE_PATH`                         | conditional | Required for the SQLite backend                                                |
-| `FEEDGEN_POSTGRES_URL`                        | conditional | Required for the Postgres backend                                              |
-| `FEEDGEN_POSTGRES_SCHEMA`                     | no          | Postgres schema (default `public`)                                             |
-| `FEEDGEN_SUBSCRIBE_ENROLLMENTS`               | no          | Set `false` to disable the Stratos subscription arm                            |
-| `FEEDGEN_SPACE_SYNC_ENABLED`                  | no          | Enable the PDS-custody polling arm (default `true`)                            |
-| `FEEDGEN_SPACE_SYNC_INTERVAL_MS`              | no          | Target interval between jittered passes (default `30000`)                      |
-| `FEEDGEN_SPACE_MEMBERSHIP_PAGE_LIMIT`         | no          | Members requested per authority page, `1..1000` (default `100`)                |
-| `FEEDGEN_SPACE_MEMBERSHIP_REQUEST_TIMEOUT_MS` | no          | Timeout for membership listing and credential mint requests (default `60000`)  |
-| `FEEDGEN_SPACE_SYNC_PAGE_LIMIT`               | no          | Ops requested per page, `1..1000` (default `1000`)                             |
-| `FEEDGEN_SPACE_SYNC_MAX_PAGES`                | no          | Pages per member per pass (default `10`)                                       |
-| `FEEDGEN_SPACE_SYNC_REQUEST_TIMEOUT_MS`       | no          | Timeout for one foreign-host request (default `10000`)                         |
-| `FEEDGEN_SPACE_SYNC_MEMBER_BUDGET_MS`         | no          | Whole-member time budget per pass (default `60000`)                            |
-| `FEEDGEN_SPACE_SYNC_MEMBER_CONCURRENCY`       | no          | Concurrent member syncs (default `8`)                                          |
-| `FEEDGEN_SPACE_SYNC_MAX_RECORD_BYTES`         | no          | Maximum decoded record size (default `65536`)                                  |
-| `FEEDGEN_SPACE_SYNC_MAX_RECORDS_PER_MEMBER`   | no          | Indexed-record cap per member and pass (default `1000`)                        |
-| `FEEDGEN_SPACE_SYNC_ALLOW_HTTP_HOSTS`         | no          | Loopback `http://` only: `localhost`, `127/8`, `[::1]`; HTTPS always allowed   |
-| `FEEDGEN_LOG_LEVEL`                           | no          | Pino level (default `info`)                                                    |
-| `FEEDGEN_METRICS_TOKEN`                       | no          | Bearer token for `/metrics`; unset leaves the endpoint open                    |
+| Env var                                       | Required    | Description                                                                                      |
+| --------------------------------------------- | ----------- | ------------------------------------------------------------------------------------------------ |
+| `FEEDGEN_SERVICE_DID`                         | yes         | Feed generator service DID                                                                       |
+| `FEEDGEN_PUBLIC_URL`                          | no          | Public base URL; derived from a `did:web` service DID when omitted                               |
+| `FEEDGEN_SIGNING_KEY`                         | yes         | Private secp256k1 service-signing key                                                            |
+| `STRATOS_SERVICE_URL`                         | yes         | Request base URL of the authority Stratos service                                                |
+| `STRATOS_PUBLIC_URL`                          | no          | Public Stratos origin used in DPoP `htu`; defaults to `STRATOS_SERVICE_URL`                      |
+| `STRATOS_SERVICE_DID`                         | yes         | DID of the authority Stratos service                                                             |
+| `FEEDGEN_PLC_URL`                             | no          | PLC directory used for commit-key resolution (default `https://plc.directory`)                   |
+| `FEEDGEN_STORAGE_BACKEND`                     | no          | `sqlite` (default) or `postgres`                                                                 |
+| `FEEDGEN_SQLITE_PATH`                         | no          | Record-index SQLite location; unset or empty uses `:memory:`                                     |
+| `FEEDGEN_MEMBERSHIP_SQLITE_PATH`              | conditional | Durable membership SQLite location; required with an in-memory record index                      |
+| `FEEDGEN_POSTGRES_URL`                        | conditional | Required for the Postgres backend                                                                |
+| `FEEDGEN_POSTGRES_SCHEMA`                     | no          | Postgres schema (default `public`)                                                               |
+| `FEEDGEN_SUBSCRIBE_ENROLLMENTS`               | no          | Set `false` to disable the Stratos subscription arm                                              |
+| `FEEDGEN_SPACE_SYNC_ENABLED`                  | no          | Enable the PDS-custody polling arm (default `true`)                                              |
+| `FEEDGEN_SPACE_SYNC_INTERVAL_MS`              | no          | Target interval between jittered passes (default `30000`)                                        |
+| `FEEDGEN_SPACE_MEMBERSHIP_PAGE_LIMIT`         | no          | Members requested per authority page, `1..1000` (default `100`)                                  |
+| `FEEDGEN_SPACE_MEMBERSHIP_REQUEST_TIMEOUT_MS` | no          | Timeout for membership listing and credential mint requests (default `60000`)                    |
+| `FEEDGEN_SPACE_SYNC_PAGE_LIMIT`               | no          | Ops requested per page, `1..1000` (default `1000`)                                               |
+| `FEEDGEN_SPACE_SYNC_MAX_PAGES`                | no          | Pages per member per pass (default `10`)                                                         |
+| `FEEDGEN_SPACE_SYNC_REQUEST_TIMEOUT_MS`       | no          | Timeout for one foreign-host request (default `10000`)                                           |
+| `FEEDGEN_SPACE_SYNC_MEMBER_BUDGET_MS`         | no          | Whole-member time budget per pass (default `60000`)                                              |
+| `FEEDGEN_SPACE_SYNC_MEMBER_CONCURRENCY`       | no          | Concurrent member syncs (default `8`)                                                            |
+| `FEEDGEN_SPACE_SYNC_MAX_RECORD_BYTES`         | no          | Maximum decoded record size (default `65536`)                                                    |
+| `FEEDGEN_SPACE_SYNC_MAX_RECORDS_PER_MEMBER`   | no          | Indexed-record cap per member and pass (default `1000`)                                          |
+| `FEEDGEN_SPACE_SYNC_ALLOW_HTTP_HOSTS`         | no          | Loopback `http://` only: `localhost`, `127/8`, `[::1]`; HTTPS always allowed                    |
+| `FEEDGEN_LOG_LEVEL`                           | no          | Pino level (default `info`)                                                                      |
+| `FEEDGEN_METRICS_TOKEN`                       | no          | Bearer token for `/metrics`; unset leaves the endpoint open                                      |
+
+### Feed index durability
+
+SQLite uses `:memory:` for the record index by default. Feedgen loses its post, boundary,
+enrollment, and foreign-repo cursor index on restart, then rebuilds it from the Stratos
+replay streams. This keeps private feed content out of the container filesystem by default.
+The membership snapshot stays in its separate durable SQLite store. The Compose overlay also
+sets the core-dump limit to zero because process memory can contain private content.
+
+To retain the index, set `FEEDGEN_SQLITE_PATH` to an explicit file path and mount durable
+storage for that path. This persists private records, boundaries, enrollments, and cursors;
+protect, encrypt, and manage that storage as private content.
 
 ## Observability
 

--- a/stratos-feedgen/src/config.ts
+++ b/stratos-feedgen/src/config.ts
@@ -31,7 +31,7 @@ export interface FeedgenConfig {
   feedgenAllowedLxms: readonly string[]
   /** Storage backend selection. */
   storageBackend: StorageBackend
-  /** Path to SQLite database file (used when `storageBackend === 'sqlite'`). */
+  /** SQLite location used when `storageBackend === 'sqlite'`. */
   sqlitePath?: string
   /**
    * Path to the SQLite database holding durable enrollment and space-membership
@@ -80,6 +80,7 @@ export interface FeedgenConfig {
 export type StorageBackend = 'sqlite' | 'postgres'
 
 export const DEFAULT_STORAGE_BACKEND: StorageBackend = 'sqlite'
+export const DEFAULT_SQLITE_PATH = ':memory:'
 export const DEFAULT_BOUNDARY_CACHE_TTL_MS = 300_000
 export const DEFAULT_BOUNDARY_CACHE_MAX = 10_000
 
@@ -221,13 +222,8 @@ export function loadFeedgenConfig(
 
 function loadStorageConfig(env: FeedgenEnv): StorageConfig {
   const storageBackend = parseStorageBackend(env['FEEDGEN_STORAGE_BACKEND'])
-  const sqlitePath = env['FEEDGEN_SQLITE_PATH']
+  const sqlitePath = nonEmpty(env['FEEDGEN_SQLITE_PATH']) ?? DEFAULT_SQLITE_PATH
   const postgresUrl = env['FEEDGEN_POSTGRES_URL']
-  if (storageBackend === 'sqlite' && !sqlitePath) {
-    throw new Error(
-      'Missing required env var FEEDGEN_SQLITE_PATH for sqlite backend',
-    )
-  }
   if (storageBackend === 'postgres' && !postgresUrl) {
     throw new Error(
       'Missing required env var FEEDGEN_POSTGRES_URL for postgres backend',
@@ -249,12 +245,9 @@ function loadStorageConfig(env: FeedgenEnv): StorageConfig {
 }
 
 function resolveMembershipSqlitePath(
-  sqlitePath: string | undefined,
+  sqlitePath: string,
   configuredPath: string | undefined,
 ): string {
-  if (!sqlitePath) {
-    throw new Error('sqlitePath is required for sqlite backend')
-  }
   if (sqlitePath === ':memory:' && !configuredPath) {
     throw new Error(
       'Missing required env var FEEDGEN_MEMBERSHIP_SQLITE_PATH when FEEDGEN_SQLITE_PATH is :memory:',

--- a/stratos-feedgen/src/db/sqlite.ts
+++ b/stratos-feedgen/src/db/sqlite.ts
@@ -1,4 +1,5 @@
 import { Client, createClient } from '@libsql/client'
+import { randomUUID } from 'node:crypto'
 import { resolve } from 'node:path'
 import { pathToFileURL } from 'node:url'
 import { and, asc, desc, eq, inArray, lt, or, sql } from 'drizzle-orm'
@@ -32,18 +33,25 @@ import {
 
 export type SqliteDb = LibSQLDatabase<typeof sqliteSchema> & {
   _client: Client
+  _memoryAnchor?: Client
   _initialized: Promise<void>
 }
 
 const LEGACY_MEMBERSHIP_IMPORT_KEY = 'legacy-record-store-imported'
 
 export function createSqliteDb(location: string): SqliteDb {
+  const url = sqliteClientUrl(location)
   const client = createClient({
-    url: sqliteClientUrl(location),
+    url,
   })
   const baseDb = drizzle({ client, schema: sqliteSchema })
   const db = baseDb as unknown as SqliteDb
   db._client = client
+  if (location === ':memory:') {
+    // Drizzle releases libSQL connections after transactions. Keep this
+    // connection open so the shared in-memory database survives that release.
+    db._memoryAnchor = createClient({ url })
+  }
   db._initialized = (async () => {
     try {
       await db.run(sql.raw('PRAGMA journal_mode = WAL'))
@@ -57,9 +65,9 @@ export function createSqliteDb(location: string): SqliteDb {
 }
 
 function sqliteClientUrl(location: string): string {
-  return location === ':memory:'
-    ? ':memory:'
-    : pathToFileURL(resolve(location)).href
+  if (location !== ':memory:') return pathToFileURL(resolve(location)).href
+  const uri = `file:feedgen-${randomUUID()}?mode=memory&cache=shared`
+  return `file:${encodeURIComponent(uri)}`
 }
 
 /** Migrate the materialized record index and its checkpointed sync state. */
@@ -934,8 +942,10 @@ export class SqliteFeedgenStore implements FeedgenStore {
 
   async close(): Promise<void> {
     this.recordDb._client.close()
+    this.recordDb._memoryAnchor?.close()
     if (this.membershipDb !== this.recordDb) {
       this.membershipDb._client.close()
+      this.membershipDb._memoryAnchor?.close()
     }
   }
 }

--- a/stratos-feedgen/tests/config.test.ts
+++ b/stratos-feedgen/tests/config.test.ts
@@ -9,6 +9,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import {
+  DEFAULT_SQLITE_PATH,
   DEFAULT_SPACE_MEMBERSHIP_PAGE_LIMIT,
   DEFAULT_SPACE_MEMBERSHIP_REQUEST_TIMEOUT_MS,
   DEFAULT_SPACE_SYNC_ALLOW_HTTP_ORIGINS,
@@ -18,6 +19,7 @@ import {
   DEFAULT_SPACE_SYNC_MAX_RECORD_BYTES,
   DEFAULT_SPACE_SYNC_MAX_RECORDS_PER_MEMBER,
   DEFAULT_SPACE_SYNC_MEMBER_BUDGET_MS,
+  DEFAULT_SPACE_SYNC_MEMBER_CONCURRENCY,
   DEFAULT_SPACE_SYNC_PAGE_LIMIT,
   DEFAULT_SPACE_SYNC_REQUEST_TIMEOUT_MS,
   MAX_SPACE_MEMBERSHIP_PAGE_LIMIT,
@@ -30,12 +32,27 @@ const baseEnv = {
   FEEDGEN_SIGNING_KEY: 'unused-by-this-test',
   STRATOS_SERVICE_URL: 'https://stratos.bebop.test',
   STRATOS_SERVICE_DID: 'did:web:stratos.bebop.test',
-  FEEDGEN_SQLITE_PATH: '/tmp/feedgen-bebop.sqlite',
+  FEEDGEN_MEMBERSHIP_SQLITE_PATH: '/tmp/feedgen-bebop-membership.sqlite',
 }
 
 describe('loadFeedgenConfig SQLite storage split', () => {
+  it('declares the in-memory record-index default', () => {
+    expect(DEFAULT_SQLITE_PATH).toBe(':memory:')
+  })
+
+  it('uses the in-memory record index when the path is unset or empty', () => {
+    expect(loadFeedgenConfig({ ...baseEnv }).sqlitePath).toBe(':memory:')
+    expect(
+      loadFeedgenConfig({ ...baseEnv, FEEDGEN_SQLITE_PATH: '' }).sqlitePath,
+    ).toBe(':memory:')
+  })
+
   it('derives a distinct sibling database for durable membership snapshots', () => {
-    const cfg = loadFeedgenConfig({ ...baseEnv })
+    const cfg = loadFeedgenConfig({
+      ...baseEnv,
+      FEEDGEN_SQLITE_PATH: '/tmp/feedgen-bebop.sqlite',
+      FEEDGEN_MEMBERSHIP_SQLITE_PATH: undefined,
+    })
 
     expect(cfg.sqlitePath).toBe('/tmp/feedgen-bebop.sqlite')
     expect(cfg.membershipSqlitePath).toBe(
@@ -57,6 +74,7 @@ describe('loadFeedgenConfig SQLite storage split', () => {
       loadFeedgenConfig({
         ...baseEnv,
         FEEDGEN_SQLITE_PATH: ':memory:',
+        FEEDGEN_MEMBERSHIP_SQLITE_PATH: undefined,
       }),
     ).toThrow(/FEEDGEN_MEMBERSHIP_SQLITE_PATH/)
 
@@ -89,7 +107,8 @@ describe('loadFeedgenConfig SQLite storage split', () => {
     expect(() =>
       loadFeedgenConfig({
         ...baseEnv,
-        FEEDGEN_MEMBERSHIP_SQLITE_PATH: baseEnv.FEEDGEN_SQLITE_PATH,
+        FEEDGEN_SQLITE_PATH: '/tmp/feedgen-bebop.sqlite',
+        FEEDGEN_MEMBERSHIP_SQLITE_PATH: '/tmp/feedgen-bebop.sqlite',
       }),
     ).toThrow(/must differ/)
 
@@ -138,6 +157,17 @@ describe('loadFeedgenConfig SQLite storage split', () => {
       rmSync(directory, { recursive: true, force: true })
     }
   })
+
+  it('still requires a Postgres URL for the Postgres backend', () => {
+    expect(() =>
+      loadFeedgenConfig({
+        ...baseEnv,
+        FEEDGEN_STORAGE_BACKEND: 'postgres',
+      }),
+    ).toThrow(
+      'Missing required env var FEEDGEN_POSTGRES_URL for postgres backend',
+    )
+  })
 })
 
 describe('loadFeedgenConfig space-sync defaults', () => {
@@ -171,7 +201,9 @@ describe('loadFeedgenConfig space-sync defaults', () => {
     expect(cfg.spaceSyncMemberBudgetMs).toBe(
       DEFAULT_SPACE_SYNC_MEMBER_BUDGET_MS,
     )
-    expect(cfg.spaceSyncMemberConcurrency).toBe(8)
+    expect(cfg.spaceSyncMemberConcurrency).toBe(
+      DEFAULT_SPACE_SYNC_MEMBER_CONCURRENCY,
+    )
     expect(cfg.spaceSyncMaxRecordBytes).toBe(
       DEFAULT_SPACE_SYNC_MAX_RECORD_BYTES,
     )

--- a/stratos-feedgen/tests/db/sqlite.test.ts
+++ b/stratos-feedgen/tests/db/sqlite.test.ts
@@ -71,13 +71,16 @@ describe('SQLite-specific behavior', () => {
 
   it('uses memory journal mode for an in-memory database', async () => {
     const db = createSqliteDb(':memory:')
-    await db._initialized
-    const result = await db.get<{ journal_mode: string }>(
-      sql`PRAGMA journal_mode`,
-    )
-    expect(result?.journal_mode).toBe('memory')
-    db._client.close()
-    db._memoryAnchor?.close()
+    const store = new SqliteFeedgenStore(db)
+    try {
+      await db._initialized
+      const result = await db.get<{ journal_mode: string }>(
+        sql`PRAGMA journal_mode`,
+      )
+      expect(result?.journal_mode).toBe('memory')
+    } finally {
+      await store.close()
+    }
   })
 
   it('creates no filesystem artifact for the generated in-memory URI', async () => {

--- a/stratos-feedgen/tests/db/sqlite.test.ts
+++ b/stratos-feedgen/tests/db/sqlite.test.ts
@@ -32,6 +32,16 @@ function sqliteConfig(recordPath: string, membershipPath: string) {
   })
 }
 
+function inMemorySqliteConfig(membershipPath: string) {
+  return loadFeedgenConfig({
+    FEEDGEN_SERVICE_DID: 'did:web:feedgen.bebop.test',
+    FEEDGEN_SIGNING_KEY: 'unused-by-this-test',
+    STRATOS_SERVICE_URL: 'https://stratos.bebop.test',
+    STRATOS_SERVICE_DID: 'did:web:stratos.bebop.test',
+    FEEDGEN_MEMBERSHIP_SQLITE_PATH: membershipPath,
+  })
+}
+
 async function listSqliteArtifacts(directory: string): Promise<string[]> {
   const entries = await readdir(directory, { withFileTypes: true })
   const artifacts = await Promise.all(
@@ -175,6 +185,60 @@ describe('SQLite-specific behavior', () => {
     )
     expect(await store.getCursor('did:plc:idempotent')).toBe(1)
     await store.close()
+  })
+
+  it('resets the in-memory record projection but keeps membership snapshots', async () => {
+    const membershipPath = await makeTempDbPath()
+    const did = 'did:plc:spikespiegel'
+    const spaceUri = `at://${did}/zone.stratos.space/bebop`
+    const indexedAt = '2024-01-01T00:00:00.000Z'
+    const postUri = `at://${did}/zone.stratos.feed.post/1`
+    const firstStore = await createFeedgenStore(
+      inMemorySqliteConfig(membershipPath),
+    )
+
+    await firstStore.upsertPost({
+      uri: postUri,
+      did,
+      cid: 'bafyrecord',
+      sortAt: indexedAt,
+      indexedAt,
+      record: { text: 'See you, space cowboy.' },
+      blobRefs: [],
+      boundaries: ['bounty-hunters'],
+    })
+    await firstStore.upsertCursor(did, 42, indexedAt)
+    await firstStore.upsertSpaceCursor(spaceUri, did, 'cursor-42', indexedAt)
+    await firstStore.upsertEnrolledActor({
+      did,
+      boundaries: ['bounty-hunters'],
+      enrolledAt: indexedAt,
+      lastSeenAt: indexedAt,
+    })
+    await firstStore.replaceSpaceMembers('bounty-hunters', [
+      { did, custody: 'pds', host: 'https://bebop.example' },
+    ])
+    await firstStore.close()
+
+    const restartedStore = await createFeedgenStore(
+      inMemorySqliteConfig(membershipPath),
+    )
+    try {
+      expect(await restartedStore.getPost(postUri)).toBeNull()
+      expect(await restartedStore.getCursor(did)).toBeNull()
+      expect(await restartedStore.getSpaceCursor(spaceUri, did)).toBeNull()
+      expect(await restartedStore.getEnrolledActor(did)).toEqual({
+        did,
+        boundaries: ['bounty-hunters'],
+        enrolledAt: indexedAt,
+        lastSeenAt: indexedAt,
+      })
+      expect(await restartedStore.listSpaceMembers('bounty-hunters')).toEqual([
+        { did, custody: 'pds', host: 'https://bebop.example' },
+      ])
+    } finally {
+      await restartedStore.close()
+    }
   })
 
   it('persists only membership snapshots when the record store resets', async () => {

--- a/stratos-feedgen/tests/db/sqlite.test.ts
+++ b/stratos-feedgen/tests/db/sqlite.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm } from 'node:fs/promises'
+import { mkdtemp, readFile, readdir, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { sql } from 'drizzle-orm'
@@ -13,6 +13,7 @@ import {
 import { describeStoreContract } from './contract.js'
 
 const tempDirs: string[] = []
+const SQLITE_HEADER = Buffer.from('SQLite format 3\0')
 
 async function makeTempDbPath(): Promise<string> {
   const dir = await mkdtemp(join(tmpdir(), 'feedgen-sqlite-'))
@@ -31,10 +32,31 @@ function sqliteConfig(recordPath: string, membershipPath: string) {
   })
 }
 
+async function listSqliteArtifacts(directory: string): Promise<string[]> {
+  const entries = await readdir(directory, { withFileTypes: true })
+  const artifacts = await Promise.all(
+    entries
+      .filter((entry) => entry.isFile())
+      .map(async (entry) => {
+        if (entry.name.endsWith('-journal') || entry.name.endsWith('-shm')) {
+          return entry.name
+        }
+        if (entry.name.endsWith('-wal')) return entry.name
+        const header = await readFile(join(directory, entry.name), {
+          encoding: null,
+          flag: 'r',
+        })
+        return header.subarray(0, SQLITE_HEADER.length).equals(SQLITE_HEADER)
+          ? entry.name
+          : undefined
+      }),
+  )
+  return artifacts.filter((name): name is string => name !== undefined).sort()
+}
+
 describeStoreContract('sqlite', {
   async build() {
-    const dbPath = await makeTempDbPath()
-    const db = createSqliteDb(dbPath)
+    const db = createSqliteDb(':memory:')
     await migrateSqliteDb(db)
     return new SqliteFeedgenStore(db)
   },
@@ -44,6 +66,84 @@ describe('SQLite-specific behavior', () => {
   afterAll(async () => {
     for (const dir of tempDirs) {
       await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('uses memory journal mode for an in-memory database', async () => {
+    const db = createSqliteDb(':memory:')
+    await db._initialized
+    const result = await db.get<{ journal_mode: string }>(
+      sql`PRAGMA journal_mode`,
+    )
+    expect(result?.journal_mode).toBe('memory')
+    db._client.close()
+    db._memoryAnchor?.close()
+  })
+
+  it('creates no filesystem artifact for the generated in-memory URI', async () => {
+    const before = await listSqliteArtifacts(process.cwd())
+    const db = createSqliteDb(':memory:')
+    const store = new SqliteFeedgenStore(db)
+    try {
+      await migrateSqliteDb(db)
+      await store.upsertCursor(
+        'did:plc:millythompson',
+        3,
+        '2024-01-01T00:00:00.000Z',
+      )
+    } finally {
+      await store.close()
+    }
+    expect(await listSqliteArtifacts(process.cwd())).toEqual(before)
+  })
+
+  it('keeps separate in-memory clients isolated', async () => {
+    const firstDb = createSqliteDb(':memory:')
+    const secondDb = createSqliteDb(':memory:')
+    await migrateSqliteDb(firstDb)
+    await migrateSqliteDb(secondDb)
+    const first = new SqliteFeedgenStore(firstDb)
+    const second = new SqliteFeedgenStore(secondDb)
+
+    try {
+      await first.upsertCursor(
+        'did:plc:linaminmay',
+        7,
+        '2024-01-01T00:00:00.000Z',
+      )
+      expect(await first.getCursor('did:plc:linaminmay')).toBe(7)
+      expect(await second.getCursor('did:plc:linaminmay')).toBeNull()
+    } finally {
+      await first.close()
+      await second.close()
+    }
+  })
+
+  it('keeps an in-memory schema after a transaction releases its connection', async () => {
+    const db = createSqliteDb(':memory:')
+    await migrateSqliteDb(db)
+    const store = new SqliteFeedgenStore(db)
+
+    try {
+      await store.upsertPost({
+        uri: 'at://did:plc:motokokusanagi/zone.stratos.feed.post/1',
+        did: 'did:plc:motokokusanagi',
+        cid: 'bafyreigh2akiscaildc',
+        sortAt: '2024-01-01T00:00:00.000Z',
+        indexedAt: '2024-01-01T00:00:00.000Z',
+        record: { $type: 'zone.stratos.feed.post' },
+        blobRefs: [],
+        boundaries: ['engineering'],
+      })
+
+      expect(
+        await store.getSpaceCursor(
+          'at://did:web:example.test/space/zone.stratos.space.feed/engineering',
+          'did:plc:motokokusanagi',
+        ),
+      ).toBeNull()
+    } finally {
+      await store.close()
     }
   })
 
@@ -207,5 +307,27 @@ describe('SQLite-specific behavior', () => {
       `),
     ).toEqual([])
     membershipDb._client.close()
+  })
+
+  it('persists an explicit file database across reopen', async () => {
+    const dbPath = await makeTempDbPath()
+    const firstDb = createSqliteDb(dbPath)
+    await migrateSqliteDb(firstDb)
+    const first = new SqliteFeedgenStore(firstDb)
+    await first.upsertCursor(
+      'did:plc:motokokusanagi',
+      9,
+      '2024-01-01T00:00:00.000Z',
+    )
+    await first.close()
+
+    const secondDb = createSqliteDb(dbPath)
+    await migrateSqliteDb(secondDb)
+    const second = new SqliteFeedgenStore(secondDb)
+    try {
+      expect(await second.getCursor('did:plc:motokokusanagi')).toBe(9)
+    } finally {
+      await second.close()
+    }
   })
 })

--- a/stratos-feedgen/tests/db/sqlite.test.ts
+++ b/stratos-feedgen/tests/db/sqlite.test.ts
@@ -107,12 +107,12 @@ describe('SQLite-specific behavior', () => {
 
     try {
       await first.upsertCursor(
-        'did:plc:linaminmay',
+        'did:plc:fayevalentine',
         7,
         '2024-01-01T00:00:00.000Z',
       )
-      expect(await first.getCursor('did:plc:linaminmay')).toBe(7)
-      expect(await second.getCursor('did:plc:linaminmay')).toBeNull()
+      expect(await first.getCursor('did:plc:fayevalentine')).toBe(7)
+      expect(await second.getCursor('did:plc:fayevalentine')).toBeNull()
     } finally {
       await first.close()
       await second.close()

--- a/stratos-feedgen/tests/db/sqlite.test.ts
+++ b/stratos-feedgen/tests/db/sqlite.test.ts
@@ -300,6 +300,72 @@ describe('SQLite-specific behavior', () => {
     await restartedStore.close()
   })
 
+  it('keeps unverified space sync state in the record database', async () => {
+    const recordPath = await makeTempDbPath()
+    const membershipPath = await makeTempDbPath()
+    const store = await createFeedgenStore(
+      sqliteConfig(recordPath, membershipPath),
+    )
+    const did = 'did:plc:spikespiegel'
+    const spaceUri = `at://${did}/zone.stratos.space/bebop`
+    const postUri = `at://${did}/zone.stratos.feed.post/staged`
+    const indexedAt = '2024-01-01T00:00:00.000Z'
+
+    try {
+      await store.stageSpaceSyncPage({
+        spaceUri,
+        did,
+        boundary: 'bounty-hunters',
+        mutations: [{ kind: 'delete', uri: postUri }],
+        nextCursor: 'cursor-1',
+        updatedAt: indexedAt,
+      })
+      await store.stageSpaceSyncPage({
+        spaceUri,
+        did,
+        boundary: 'bounty-hunters',
+        mutations: [],
+        updatedAt: indexedAt,
+      })
+
+      expect(await store.getSpaceCursor(spaceUri, did)).toBe('cursor-1')
+    } finally {
+      await store.close()
+    }
+
+    const recordDb = createSqliteDb(recordPath)
+    const membershipDb = createSqliteDb(membershipPath)
+    try {
+      expect(
+        await recordDb.all<{ uri: string }>(sql`
+          SELECT uri
+          FROM space_sync_stage
+        `),
+      ).toEqual([{ uri: postUri }])
+      expect(
+        await recordDb.all<{ did: string }>(sql`
+          SELECT did
+          FROM space_sync_pending_verification
+        `),
+      ).toEqual([{ did }])
+      expect(
+        await membershipDb.all<{ name: string }>(sql`
+          SELECT name
+          FROM sqlite_master
+          WHERE type = 'table'
+            AND name IN (
+              'space_sync_cursor',
+              'space_sync_pending_verification',
+              'space_sync_stage'
+            )
+        `),
+      ).toEqual([])
+    } finally {
+      recordDb._client.close()
+      membershipDb._client.close()
+    }
+  })
+
   it('imports legacy membership snapshots once without moving cursors', async () => {
     const legacyPath = await makeTempDbPath()
     const membershipPath = await makeTempDbPath()

--- a/test/docker-compose.test.yml
+++ b/test/docker-compose.test.yml
@@ -149,7 +149,6 @@ services:
       FEEDGEN_SIGNING_KEY: 097ce261481a889a756db476dceb6cc57596541c264675e9712c7252cfd1183c
       FEEDGEN_PUBLIC_URL: http://localhost:3302
       FEEDGEN_PORT: 3302
-      FEEDGEN_SQLITE_PATH: /app/config/browser-e2e.sqlite
       FEEDGEN_FEEDS_JSON: '{"feeds":[{"id":"swordsmith","boundary":"${STRATOS_SERVICE_DID:-did:web:127.0.0.1%3A3100}/swordsmith"},{"id":"aekea","boundary":"${STRATOS_SERVICE_DID:-did:web:127.0.0.1%3A3100}/aekea"}]}'
       STRATOS_SERVICE_URL: http://localhost:3100
       STRATOS_PUBLIC_URL: ${STRATOS_PUBLIC_URL:-http://127.0.0.1:3100}

--- a/test/docker-compose.test.yml
+++ b/test/docker-compose.test.yml
@@ -149,6 +149,7 @@ services:
       FEEDGEN_SIGNING_KEY: 097ce261481a889a756db476dceb6cc57596541c264675e9712c7252cfd1183c
       FEEDGEN_PUBLIC_URL: http://localhost:3302
       FEEDGEN_PORT: 3302
+      FEEDGEN_MEMBERSHIP_SQLITE_PATH: /app/data/feedgen-membership.sqlite
       FEEDGEN_FEEDS_JSON: '{"feeds":[{"id":"swordsmith","boundary":"${STRATOS_SERVICE_DID:-did:web:127.0.0.1%3A3100}/swordsmith"},{"id":"aekea","boundary":"${STRATOS_SERVICE_DID:-did:web:127.0.0.1%3A3100}/aekea"}]}'
       STRATOS_SERVICE_URL: http://localhost:3100
       STRATOS_PUBLIC_URL: ${STRATOS_PUBLIC_URL:-http://127.0.0.1:3100}

--- a/test/scripts/lib/feedgen.ts
+++ b/test/scripts/lib/feedgen.ts
@@ -93,9 +93,7 @@ export class FeedgenHarness {
         TEMP: this.childTmpDir,
         TMP: this.childTmpDir,
         TMPDIR: this.childTmpDir,
-        FEEDGEN_MEMBERSHIP_SQLITE_PATH: membershipSqlitePath(
-          this.childTmpDir,
-        ),
+        FEEDGEN_MEMBERSHIP_SQLITE_PATH: membershipSqlitePath(this.childTmpDir),
         STRATOS_SERVICE_URL: STRATOS_URL,
         STRATOS_PUBLIC_URL: STRATOS_URL,
         STRATOS_SERVICE_DID: SERVICE_DID,

--- a/test/scripts/lib/feedgen.ts
+++ b/test/scripts/lib/feedgen.ts
@@ -37,6 +37,7 @@ export interface FeedgenStartOptions {
 }
 
 interface SqliteArtifactSnapshot {
+  childTmpDir: ReadonlySet<string>
   feedgenCwd: ReadonlySet<string>
 }
 
@@ -58,7 +59,10 @@ export class FeedgenHarness {
 
   static async create(): Promise<FeedgenHarness> {
     const childTmpDir = await Deno.makeTempDir({ prefix: 'feedgen-e2e-tmp-' })
-    return new FeedgenHarness(childTmpDir, await snapshotSqliteArtifacts())
+    return new FeedgenHarness(
+      childTmpDir,
+      await snapshotSqliteArtifacts(childTmpDir),
+    )
   }
 
   async start(options: FeedgenStartOptions): Promise<void> {
@@ -81,7 +85,6 @@ export class FeedgenHarness {
         FEEDGEN_PUBLIC_URL: url,
         FEEDGEN_PORT: String(options.port),
         FEEDGEN_FEEDS_JSON: JSON.stringify({ feeds }),
-        FEEDGEN_SQLITE_PATH: `${this.childTmpDir}/feedgen-${startId}.sqlite`,
         TEMP: this.childTmpDir,
         TMP: this.childTmpDir,
         TMPDIR: this.childTmpDir,
@@ -191,7 +194,7 @@ export class FeedgenHarness {
   async cleanup(): Promise<void> {
     await this.stop()
     try {
-      await assertNoNewSqliteArtifacts(this.beforeArtifacts)
+      await assertNoNewSqliteArtifacts(this.beforeArtifacts, this.childTmpDir)
     } finally {
       await Deno.remove(this.childTmpDir, { recursive: true })
     }
@@ -256,22 +259,29 @@ function parseLogLine(line: string): Readonly<Record<string, unknown>> {
   return {}
 }
 
-async function snapshotSqliteArtifacts(): Promise<SqliteArtifactSnapshot> {
+async function snapshotSqliteArtifacts(
+  childTmpDir: string,
+): Promise<SqliteArtifactSnapshot> {
   return {
+    childTmpDir: await listSqliteArtifacts(childTmpDir),
     feedgenCwd: await listSqliteArtifacts(FEEDGEN_CWD),
   }
 }
 
 async function assertNoNewSqliteArtifacts(
   before: SqliteArtifactSnapshot,
+  childTmpDir: string,
 ): Promise<void> {
-  const after = await snapshotSqliteArtifacts()
-  const created = [...after.feedgenCwd].filter(
-    (path) => !before.feedgenCwd.has(path),
-  )
+  const after = await snapshotSqliteArtifacts(childTmpDir)
+  const created = [
+    ...new Set([
+      ...[...after.childTmpDir].filter((path) => !before.childTmpDir.has(path)),
+      ...[...after.feedgenCwd].filter((path) => !before.feedgenCwd.has(path)),
+    ]),
+  ]
   assert(
     created.length === 0,
-    'feedgen SQLite stays inside its temporary test directory',
+    'default SQLite creates no filesystem artifacts',
     created.join(', '),
   )
 }

--- a/test/scripts/lib/feedgen.ts
+++ b/test/scripts/lib/feedgen.ts
@@ -84,7 +84,7 @@ export class FeedgenHarness {
       stdout: 'piped',
       stderr: 'piped',
       env: {
-        ...withoutInheritedSqlitePath(),
+        ...withoutInheritedSqlitePaths(),
         FEEDGEN_SERVICE_DID: FEEDGEN_DID,
         FEEDGEN_SIGNING_KEY,
         FEEDGEN_PUBLIC_URL: url,
@@ -93,6 +93,9 @@ export class FeedgenHarness {
         TEMP: this.childTmpDir,
         TMP: this.childTmpDir,
         TMPDIR: this.childTmpDir,
+        FEEDGEN_MEMBERSHIP_SQLITE_PATH: membershipSqlitePath(
+          this.childTmpDir,
+        ),
         STRATOS_SERVICE_URL: STRATOS_URL,
         STRATOS_PUBLIC_URL: STRATOS_URL,
         STRATOS_SERVICE_DID: SERVICE_DID,
@@ -230,9 +233,10 @@ export async function buildFeedgen(): Promise<boolean> {
   return result.success
 }
 
-function withoutInheritedSqlitePath(): Record<string, string> {
+function withoutInheritedSqlitePaths(): Record<string, string> {
   const env = Deno.env.toObject()
   delete env['FEEDGEN_SQLITE_PATH']
+  delete env['FEEDGEN_MEMBERSHIP_SQLITE_PATH']
   return env
 }
 
@@ -282,17 +286,27 @@ async function assertNoNewSqliteArtifacts(
   childTmpDir: string,
 ): Promise<void> {
   const after = await snapshotSqliteArtifacts(childTmpDir)
+  const controlPath = membershipSqlitePath(childTmpDir)
+  const allowedControlArtifacts = new Set([
+    controlPath,
+    ...SQLITE_SIDECAR_SUFFIXES.map((suffix) => `${controlPath}${suffix}`),
+  ])
   const created = [
-    ...new Set([
-      ...[...after.childTmpDir].filter((path) => !before.childTmpDir.has(path)),
-      ...[...after.feedgenCwd].filter((path) => !before.feedgenCwd.has(path)),
-    ]),
+    ...[...after.childTmpDir].filter(
+      (path) =>
+        !before.childTmpDir.has(path) && !allowedControlArtifacts.has(path),
+    ),
+    ...[...after.feedgenCwd].filter((path) => !before.feedgenCwd.has(path)),
   ]
   assert(
     created.length === 0,
-    'default SQLite creates no filesystem artifacts',
+    'default record SQLite creates no filesystem artifacts',
     created.join(', '),
   )
+}
+
+function membershipSqlitePath(childTmpDir: string): string {
+  return `${childTmpDir}/feedgen-membership.sqlite`
 }
 
 async function listSqliteArtifacts(directory: string): Promise<Set<string>> {

--- a/test/scripts/lib/feedgen.ts
+++ b/test/scripts/lib/feedgen.ts
@@ -9,6 +9,11 @@ const MAX_LOG_LINES = 500
 export const FEEDGEN_DID = 'did:web:feedgen.test'
 export const FEEDGEN_SIGNING_KEY =
   '097ce261481a889a756db476dceb6cc57596541c264675e9712c7252cfd1183c'
+export const SPACE_COMMIT_TAMPER_MODULE = new URL(
+  './tamper-space-commit.mjs',
+  import.meta.url,
+).href
+
 export interface FeedDefinition {
   id: string
   boundary: string
@@ -185,6 +190,10 @@ export class FeedgenHarness {
         .map((event) => event.line)
         .join('\n')}`,
     )
+  }
+
+  countLogs(predicate: (event: FeedgenLogEvent) => boolean): number {
+    return this.logs.filter(predicate).length
   }
 
   recentLogLines(limit = 20): string[] {

--- a/test/scripts/lib/tamper-space-commit.mjs
+++ b/test/scripts/lib/tamper-space-commit.mjs
@@ -21,7 +21,7 @@ globalThis.fetch = async (input, init) => {
     return response
   }
 
-  const body = await response.json()
+  const body = await response.clone().json()
   if (!isRecord(body) || !isRecord(body.commit) || !isRecord(body.commit.mac)) {
     return response
   }

--- a/test/scripts/lib/tamper-space-commit.mjs
+++ b/test/scripts/lib/tamper-space-commit.mjs
@@ -1,0 +1,47 @@
+const targetRepo = process.env.FEEDGEN_E2E_TAMPER_COMMIT_REPO
+const targetSpace = process.env.FEEDGEN_E2E_TAMPER_COMMIT_SPACE
+
+if (!targetRepo || !targetSpace) {
+  throw new Error('Missing the E2E commit tamper target')
+}
+
+const originalFetch = globalThis.fetch
+
+globalThis.fetch = async (input, init) => {
+  const response = await originalFetch(input, init)
+  const url = new URL(
+    typeof input === 'string' || input instanceof URL ? input : input.url,
+  )
+  if (
+    url.pathname !== '/xrpc/com.atproto.space.listRepoOps' ||
+    url.searchParams.get('repo') !== targetRepo ||
+    url.searchParams.get('space') !== targetSpace ||
+    !response.ok
+  ) {
+    return response
+  }
+
+  const body = await response.json()
+  if (!isRecord(body) || !isRecord(body.commit) || !isRecord(body.commit.mac)) {
+    return response
+  }
+  const mac = body.commit.mac.$bytes
+  if (typeof mac !== 'string' || mac.length === 0) {
+    throw new Error('The PDS response has no signed commit MAC')
+  }
+
+  body.commit.mac = {
+    $bytes: `${mac[0] === 'A' ? 'B' : 'A'}${mac.slice(1)}`,
+  }
+  const headers = new Headers(response.headers)
+  headers.delete('content-length')
+  return new Response(JSON.stringify(body), {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  })
+}
+
+function isRecord(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}

--- a/test/scripts/test-feedgen.ts
+++ b/test/scripts/test-feedgen.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env -S deno run -A
 
 import { DOMAINS } from './lib/config.ts'
+import { adminGetBoundaries, adminSetBoundaries } from './lib/admin.ts'
 import { buildFeedgen, FEEDGEN_DID, FeedgenHarness } from './lib/feedgen.ts'
 import { assert, fail, finish, pass, section } from './lib/log.ts'
 import { createSession, getServiceAuth } from './lib/pds.ts'
@@ -64,8 +65,9 @@ async function waitForPost(
   token: string,
   feed: string,
   uri: string,
+  timeoutMs = 30_000,
 ): Promise<PostView | null> {
-  const deadline = Date.now() + 30_000
+  const deadline = Date.now() + timeoutMs
   while (Date.now() < deadline) {
     const { status, body } = await getFeed(token, feed)
     const post = (body as unknown as GetFeedBody).feed?.find(
@@ -77,14 +79,37 @@ async function waitForPost(
   return null
 }
 
+async function waitForFeedReadiness(
+  token: string,
+  feed: string,
+  timeoutMs = 30_000,
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    const { status } = await getFeed(token, feed)
+    if (status === 200) return true
+    if (status !== 503) return false
+    await new Promise((resolve) => setTimeout(resolve, 500))
+  }
+  return false
+}
+
 async function run(): Promise<void> {
   section('Phase 4f: Feedgen — describeFeed & getFeed')
   const state = await loadState()
   const rei = state.users.rei
   const sakura = state.users.sakura
   const kaoruko = state.users.kaoruko
-  if (!rei?.enrolled || !sakura?.enrolled || !kaoruko?.enrolled) {
-    fail('Users rei, sakura, kaoruko must be enrolled — run earlier phases')
+  const adminSessionCookie = state.adminSessionCookie
+  if (
+    !rei?.enrolled ||
+    !sakura?.enrolled ||
+    !kaoruko?.enrolled ||
+    !adminSessionCookie
+  ) {
+    fail(
+      'Users rei, sakura, kaoruko and an admin session must be available — run earlier phases',
+    )
     finish()
   }
   if (!(await buildFeedgen())) {
@@ -103,6 +128,7 @@ async function run(): Promise<void> {
       await feedgen.start({ port: FEEDGEN_PORT })
       await assertFeedgenWarmup(feedgen, 'restart')
       await verifyReplay(feedgen, replay)
+      await verifyReplayAuthorization(feedgen, replay, adminSessionCookie)
     }
   } finally {
     await feedgen.cleanup()
@@ -256,6 +282,82 @@ async function verifyReplay(
     post?.author.did === replay.authorDid,
     'same viewer sees the same author after replay',
   )
+}
+
+async function verifyReplayAuthorization(
+  feedgen: FeedgenHarness,
+  replay: ReplayCheck,
+  adminSessionCookie: string,
+): Promise<void> {
+  section('Replay admission uses current author membership')
+  const originalBoundaries = await adminGetBoundaries(
+    replay.authorDid,
+    adminSessionCookie,
+  )
+  assert(
+    originalBoundaries?.includes(DOMAINS.swordsmith),
+    'author holds swordsmith before the replay-authorization check',
+    originalBoundaries?.join(', '),
+  )
+  if (!originalBoundaries?.includes(DOMAINS.swordsmith)) return
+
+  await feedgen.stop()
+  let boundariesChanged = false
+  try {
+    const change = await adminSetBoundaries(
+      replay.authorDid,
+      [DOMAINS.aekea],
+      adminSessionCookie,
+    )
+    boundariesChanged = change.status === 200
+    assert(
+      boundariesChanged,
+      'admin moves the author from swordsmith to aekea while feedgen is stopped',
+      `status=${change.status}`,
+    )
+    if (!boundariesChanged) return
+
+    await feedgen.start({ port: FEEDGEN_PORT })
+    await assertFeedgenWarmup(feedgen, 'stale-membership replay')
+    if (!(await feedgen.waitForHealth(FEEDGEN_PORT, 30_000))) {
+      fail('feedgen /health did not become ready for replay authorization')
+      return
+    }
+    const token = await mintViewerJwt(
+      replay.viewer.handle,
+      replay.viewer.password,
+    )
+    const feedReady = await waitForFeedReadiness(token, 'swordsmith')
+    assert(
+      feedReady,
+      'feed reads become ready before replay authorization is evaluated',
+    )
+    if (!feedReady) return
+    const resurrected = await waitForPost(
+      token,
+      'swordsmith',
+      replay.uri,
+      15_000,
+    )
+    assert(
+      resurrected === null,
+      'a historical swordsmith post is denied after the author loses swordsmith',
+      resurrected?.uri,
+    )
+  } finally {
+    if (boundariesChanged) {
+      const restore = await adminSetBoundaries(
+        replay.authorDid,
+        originalBoundaries,
+        adminSessionCookie,
+      )
+      assert(
+        restore.status === 200,
+        'admin restores the author boundaries after replay authorization',
+        `status=${restore.status}`,
+      )
+    }
+  }
 }
 
 run().catch((err) => {

--- a/test/scripts/test-feedgen.ts
+++ b/test/scripts/test-feedgen.ts
@@ -1,27 +1,12 @@
 #!/usr/bin/env -S deno run -A
-// Feedgen E2E — boundary-scoped hydrated feeds over the real service stack.
-//
-// Builds and launches the feedgen from its workspace package against the
-// running Stratos, then asserts the zone.stratos.feedgen.* lexicon contract:
-// describeFeed lists the configured feeds, getFeed returns hydrated postViews
-// only to viewers holding the feed's boundary, and the declared UnknownFeed /
-// BoundaryMismatch errors and the service-auth requirement are enforced.
-//
-// The feedgen's identity (did:web:feedgen.test) is declared to Stratos via
-// STRATOS_SERVICE_ENROLLMENTS in the compose files, with an inline did:key so
-// Stratos verifies its JWTs without resolving the non-resolvable did:web.
 
-import { DOMAINS, SERVICE_DID, STRATOS_URL, TEST_ROOT } from './lib/config.ts'
-import { loadState } from './lib/state.ts'
+import { DOMAINS } from './lib/config.ts'
+import { buildFeedgen, FEEDGEN_DID, FeedgenHarness } from './lib/feedgen.ts'
+import { assert, fail, finish, pass, section } from './lib/log.ts'
 import { createSession, getServiceAuth } from './lib/pds.ts'
+import { loadState } from './lib/state.ts'
 import { createRecord } from './lib/stratos.ts'
-import { assert, fail, finish, info, pass, section } from './lib/log.ts'
 
-const FEEDGEN_DID = 'did:web:feedgen.test'
-// Private key for the did:key declared in STRATOS_SERVICE_ENROLLMENTS
-// (docker-compose.test.yml / docker-compose.e2e.yml). Test-only material.
-const FEEDGEN_SIGNING_KEY =
-  '097ce261481a889a756db476dceb6cc57596541c264675e9712c7252cfd1183c'
 const FEEDGEN_PORT = 3300
 const FEEDGEN_URL = `http://127.0.0.1:${FEEDGEN_PORT}`
 const GET_FEED_LXM = 'zone.stratos.feedgen.getFeed'
@@ -36,7 +21,6 @@ interface PostView {
 }
 
 interface GetFeedBody {
-  cursor?: string
   feed: Array<{ post: PostView }>
 }
 
@@ -45,62 +29,11 @@ interface DescribeFeedBody {
   feeds: Array<{ id: string; boundary: string }>
 }
 
-async function buildFeedgen(): Promise<boolean> {
-  // Run the esbuild bundle, not the tsc build. The tsc dist keeps the bare
-  // stratos-core import, which resolves to workspace TS source that plain
-  // node cannot load. The bundle is the artifact the Docker image ships.
-  info('bundling stratos-feedgen (production esbuild bundle)')
-  const result = await new Deno.Command('pnpm', {
-    args: ['--filter', '@northskysocial/stratos-feedgen', 'bundle'],
-    cwd: `${TEST_ROOT}/..`,
-    stdout: 'inherit',
-    stderr: 'inherit',
-  }).output()
-  return result.success
-}
-
-function startFeedgen(sqlitePath: string): Deno.ChildProcess {
-  const feedsJson = JSON.stringify({
-    feeds: [
-      { id: 'swordsmith', boundary: DOMAINS.swordsmith },
-      { id: 'aekea', boundary: DOMAINS.aekea },
-    ],
-  })
-  return new Deno.Command('node', {
-    args: ['dist-bundle/main.mjs'],
-    cwd: `${TEST_ROOT}/../stratos-feedgen`,
-    env: {
-      FEEDGEN_SERVICE_DID: FEEDGEN_DID,
-      FEEDGEN_SIGNING_KEY,
-      FEEDGEN_PUBLIC_URL: FEEDGEN_URL,
-      FEEDGEN_PORT: String(FEEDGEN_PORT),
-      FEEDGEN_SQLITE_PATH: sqlitePath,
-      FEEDGEN_FEEDS_JSON: feedsJson,
-      STRATOS_SERVICE_URL: STRATOS_URL,
-      // Set this explicitly. `Deno.Command` merges the parent environment, and
-      // `.env` carries a placeholder STRATOS_PUBLIC_URL that would otherwise
-      // win and break every DPoP proof's `htu`.
-      STRATOS_PUBLIC_URL: STRATOS_URL,
-      STRATOS_SERVICE_DID: SERVICE_DID,
-    },
-    stdout: 'inherit',
-    stderr: 'inherit',
-  }).spawn()
-}
-
-async function waitForHealth(timeoutMs: number): Promise<boolean> {
-  const deadline = Date.now() + timeoutMs
-  while (Date.now() < deadline) {
-    try {
-      const res = await fetch(`${FEEDGEN_URL}/health`)
-      const body = (await res.json()) as { ok?: boolean }
-      if (res.ok && body.ok === true) return true
-    } catch {
-      // not up yet
-    }
-    await new Promise((r) => setTimeout(r, 500))
-  }
-  return false
+interface ReplayCheck {
+  authorDid: string
+  cid: string
+  uri: string
+  viewer: { did: string; handle: string; password: string }
 }
 
 async function mintViewerJwt(
@@ -115,177 +48,213 @@ async function getFeed(
   token: string | null,
   feed: string,
 ): Promise<{ status: number; body: Record<string, unknown> }> {
-  const params = new URLSearchParams({ feed })
   const headers: Record<string, string> = {}
   if (token) headers['Authorization'] = `Bearer ${token}`
   const res = await fetch(
-    `${FEEDGEN_URL}/xrpc/zone.stratos.feedgen.getFeed?${params}`,
+    `${FEEDGEN_URL}/xrpc/zone.stratos.feedgen.getFeed?${new URLSearchParams({ feed })}`,
     { headers },
   )
-  const body = (await res.json().catch(() => ({}))) as Record<string, unknown>
-  return { status: res.status, body }
+  return {
+    status: res.status,
+    body: (await res.json().catch(() => ({}))) as Record<string, unknown>,
+  }
 }
 
-/** Poll getFeed until the given post uri appears (indexing is async). */
 async function waitForPost(
   token: string,
   feed: string,
   uri: string,
-  timeoutMs: number,
 ): Promise<PostView | null> {
-  const deadline = Date.now() + timeoutMs
+  const deadline = Date.now() + 30_000
   while (Date.now() < deadline) {
     const { status, body } = await getFeed(token, feed)
-    if (status === 200) {
-      const found = (body as unknown as GetFeedBody).feed?.find(
-        (item) => item.post?.uri === uri,
-      )
-      if (found) return found.post
-    }
-    await new Promise((r) => setTimeout(r, 500))
+    const post = (body as unknown as GetFeedBody).feed?.find(
+      (item) => item.post?.uri === uri,
+    )?.post
+    if (status === 200 && post) return post
+    await new Promise((resolve) => setTimeout(resolve, 500))
   }
   return null
 }
 
-interface FeedgenUsers {
-  rei: { did: string; handle: string; password: string }
-  sakura: { handle: string; password: string }
-  kaoruko: { handle: string; password: string }
-}
-
-async function run() {
+async function run(): Promise<void> {
   section('Phase 4f: Feedgen — describeFeed & getFeed')
-
   const state = await loadState()
-  const rei = state.users.rei // author, swordsmith
-  const sakura = state.users.sakura // shares swordsmith
-  const kaoruko = state.users.kaoruko // aekea only
+  const rei = state.users.rei
+  const sakura = state.users.sakura
+  const kaoruko = state.users.kaoruko
   if (!rei?.enrolled || !sakura?.enrolled || !kaoruko?.enrolled) {
     fail('Users rei, sakura, kaoruko must be enrolled — run earlier phases')
     finish()
   }
-
   if (!(await buildFeedgen())) {
     fail('stratos-feedgen bundle')
     finish()
   }
   pass('stratos-feedgen bundled')
 
-  const tmpDir = await Deno.makeTempDir({ prefix: 'feedgen-e2e-' })
-  const feedgen = startFeedgen(`${tmpDir}/feedgen.sqlite`)
-
-  // finish() calls Deno.exit, which skips finally blocks. Early aborts in
-  // exerciseFeedgen therefore return instead, so the child process and the
-  // temp dir are cleaned up before the summary runs.
+  const feedgen = await FeedgenHarness.create()
   try {
-    await exerciseFeedgen({ rei, sakura, kaoruko })
-  } finally {
-    info('stopping feedgen')
-    try {
-      feedgen.kill('SIGTERM')
-      await feedgen.status
-    } catch {
-      // already exited
+    await feedgen.start({ port: FEEDGEN_PORT })
+    await assertFeedgenWarmup(feedgen, 'initial')
+    const replay = await exerciseFeedgen(feedgen, { rei, sakura, kaoruko })
+    if (replay) {
+      await feedgen.stop()
+      await feedgen.start({ port: FEEDGEN_PORT })
+      await assertFeedgenWarmup(feedgen, 'restart')
+      await verifyReplay(feedgen, replay)
     }
-    await Deno.remove(tmpDir, { recursive: true }).catch(() => {})
+  } finally {
+    await feedgen.cleanup()
   }
-
   finish()
 }
 
-async function exerciseFeedgen({ rei, sakura, kaoruko }: FeedgenUsers) {
-  if (!(await waitForHealth(30_000))) {
+async function assertFeedgenWarmup(
+  feedgen: FeedgenHarness,
+  phase: string,
+): Promise<void> {
+  const warmup = await feedgen.waitForWarmup(30_000)
+  assert(
+    warmup.attempted === 2,
+    `${phase} credential warm-up attempts both configured boundaries`,
+    String(warmup.attempted),
+  )
+  assert(
+    warmup.acquired === 2,
+    `${phase} credential warm-up acquires both configured boundaries`,
+    String(warmup.acquired),
+  )
+  assert(
+    warmup.failed === 0,
+    `${phase} credential warm-up has no failed boundary`,
+    String(warmup.failed),
+  )
+}
+
+async function exerciseFeedgen(
+  feedgen: FeedgenHarness,
+  users: {
+    rei: { did: string; handle: string; password: string }
+    sakura: { did: string; handle: string; password: string }
+    kaoruko: { handle: string; password: string }
+  },
+): Promise<ReplayCheck | null> {
+  if (!(await feedgen.waitForHealth(FEEDGEN_PORT, 30_000))) {
     fail('feedgen /health did not become ready within 30s')
-    return
+    return null
   }
   pass('feedgen healthy', FEEDGEN_URL)
 
-  section('Fresh boundary-scoped post to index')
   const text = 'Totosai reforges Tessaiga at the swordsmith village'
-  let createdUri = ''
-  let createdCid = ''
+  let created: { uri: string; cid: string }
   try {
-    const created = await createRecord(rei.did, COLLECTION, {
+    created = await createRecord(users.rei.did, COLLECTION, {
       $type: COLLECTION,
       text,
       boundary: { values: [{ value: DOMAINS.swordsmith }] },
       createdAt: new Date().toISOString(),
     })
-    createdUri = created.uri
-    createdCid = created.cid
     pass('createRecord as rei (swordsmith boundary)', created.uri)
   } catch (err) {
     fail('createRecord as rei (swordsmith boundary)', String(err))
-    return
+    return null
   }
 
-  section('describeFeed lists the configured feeds (unauthenticated)')
   const describeRes = await fetch(
     `${FEEDGEN_URL}/xrpc/zone.stratos.feedgen.describeFeed`,
   )
   assert(describeRes.status === 200, 'describeFeed responds 200')
   const describe = (await describeRes.json()) as DescribeFeedBody
-  assert(
-    describe.did === FEEDGEN_DID,
-    'describeFeed.did is the feedgen DID',
-    describe.did,
-  )
-  for (const id of ['swordsmith', 'aekea']) {
-    const entry = describe.feeds?.find((f) => f.id === id)
+  assert(describe.did === FEEDGEN_DID, 'describeFeed.did is the feedgen DID')
+  for (const id of ['swordsmith', 'aekea'] as const) {
+    const entry = describe.feeds.find((feed) => feed.id === id)
     assert(
-      entry !== undefined && entry.boundary === DOMAINS[id as 'swordsmith'],
+      entry?.boundary === DOMAINS[id],
       `describeFeed lists feed "${id}" with its boundary`,
       entry?.boundary,
     )
   }
 
-  section('getFeed returns the hydrated post to a boundary member')
-  const sakuraJwt = await mintViewerJwt(sakura.handle, sakura.password)
-  const post = await waitForPost(sakuraJwt, 'swordsmith', createdUri, 30_000)
+  const sakuraJwt = await mintViewerJwt(
+    users.sakura.handle,
+    users.sakura.password,
+  )
+  const post = await waitForPost(sakuraJwt, 'swordsmith', created.uri)
   assert(
     post !== null,
     'shared-boundary viewer sees the fresh post',
-    createdUri,
+    created.uri,
   )
   if (post) {
-    assert(post.cid === createdCid, 'postView.cid matches the create', post.cid)
     assert(
-      post.author?.did === rei.did,
-      'postView.author.did is the author',
-      post.author?.did,
+      post.cid === created.cid,
+      'postView.cid matches the create',
+      post.cid,
     )
     assert(
-      post.record?.['text'] === text,
+      post.author.did === users.rei.did,
+      'postView.author.did is the author',
+    )
+    assert(
+      post.record['text'] === text,
       'postView.record is the hydrated record body',
     )
     assert(
       !Number.isNaN(Date.parse(post.indexedAt)),
       'postView.indexedAt is a datetime',
-      post.indexedAt,
     )
   }
 
-  section('Declared errors: BoundaryMismatch and UnknownFeed')
-  const kaorukoJwt = await mintViewerJwt(kaoruko.handle, kaoruko.password)
+  const kaorukoJwt = await mintViewerJwt(
+    users.kaoruko.handle,
+    users.kaoruko.password,
+  )
   const mismatch = await getFeed(kaorukoJwt, 'swordsmith')
   assert(
     mismatch.status === 400 && mismatch.body['error'] === 'BoundaryMismatch',
     'viewer without the boundary gets BoundaryMismatch',
-    `status=${mismatch.status} error=${mismatch.body['error']}`,
   )
   const unknown = await getFeed(sakuraJwt, 'yorozuya')
   assert(
     unknown.status === 400 && unknown.body['error'] === 'UnknownFeed',
     'unconfigured feed id gets UnknownFeed',
-    `status=${unknown.status} error=${unknown.body['error']}`,
+  )
+  const anonymous = await getFeed(null, 'swordsmith')
+  assert(
+    anonymous.status === 401,
+    'unauthenticated getFeed is rejected with 401',
   )
 
-  section('getFeed requires service-auth')
-  const anon = await getFeed(null, 'swordsmith')
+  return post
+    ? {
+        authorDid: users.rei.did,
+        cid: created.cid,
+        uri: created.uri,
+        viewer: users.sakura,
+      }
+    : null
+}
+
+async function verifyReplay(
+  feedgen: FeedgenHarness,
+  replay: ReplayCheck,
+): Promise<void> {
+  section('Restart replay rebuilds the in-memory feed index')
+  if (!(await feedgen.waitForHealth(FEEDGEN_PORT, 30_000))) {
+    fail('restarted feedgen /health did not become ready within 30s')
+    return
+  }
+  const token = await mintViewerJwt(
+    replay.viewer.handle,
+    replay.viewer.password,
+  )
+  const post = await waitForPost(token, 'swordsmith', replay.uri)
+  assert(post?.uri === replay.uri, 'same viewer sees the same URI after replay')
+  assert(post?.cid === replay.cid, 'same viewer sees the same CID after replay')
   assert(
-    anon.status === 401,
-    'unauthenticated getFeed is rejected with 401',
-    `status=${anon.status}`,
+    post?.author.did === replay.authorDid,
+    'same viewer sees the same author after replay',
   )
 }
 

--- a/test/scripts/test-feedgen.ts
+++ b/test/scripts/test-feedgen.ts
@@ -37,6 +37,11 @@ interface ReplayCheck {
   viewer: { did: string; handle: string; password: string }
 }
 
+interface FeedPostPoll {
+  post: PostView | null
+  status: number | null
+}
+
 async function mintViewerJwt(
   handle: string,
   password: string,
@@ -66,17 +71,19 @@ async function waitForPost(
   feed: string,
   uri: string,
   timeoutMs = 30_000,
-): Promise<PostView | null> {
+): Promise<FeedPostPoll> {
   const deadline = Date.now() + timeoutMs
+  let status: number | null = null
   while (Date.now() < deadline) {
-    const { status, body } = await getFeed(token, feed)
-    const post = (body as unknown as GetFeedBody).feed?.find(
+    const response = await getFeed(token, feed)
+    status = response.status
+    const post = (response.body as unknown as GetFeedBody).feed?.find(
       (item) => item.post?.uri === uri,
     )?.post
-    if (status === 200 && post) return post
+    if (status === 200 && post) return { status, post }
     await new Promise((resolve) => setTimeout(resolve, 500))
   }
-  return null
+  return { status, post: null }
 }
 
 async function waitForFeedReadiness(
@@ -206,7 +213,7 @@ async function exerciseFeedgen(
     users.sakura.handle,
     users.sakura.password,
   )
-  const post = await waitForPost(sakuraJwt, 'swordsmith', created.uri)
+  const { post } = await waitForPost(sakuraJwt, 'swordsmith', created.uri)
   assert(
     post !== null,
     'shared-boundary viewer sees the fresh post',
@@ -275,7 +282,7 @@ async function verifyReplay(
     replay.viewer.handle,
     replay.viewer.password,
   )
-  const post = await waitForPost(token, 'swordsmith', replay.uri)
+  const { post } = await waitForPost(token, 'swordsmith', replay.uri)
   assert(post?.uri === replay.uri, 'same viewer sees the same URI after replay')
   assert(post?.cid === replay.cid, 'same viewer sees the same CID after replay')
   assert(
@@ -340,9 +347,9 @@ async function verifyReplayAuthorization(
       15_000,
     )
     assert(
-      resurrected === null,
+      resurrected.status === 200 && resurrected.post === null,
       'a historical swordsmith post is denied after the author loses swordsmith',
-      resurrected?.uri,
+      `status=${resurrected.status} uri=${resurrected.post?.uri}`,
     )
   } finally {
     if (boundariesChanged) {

--- a/test/scripts/test-mixed-mode.ts
+++ b/test/scripts/test-mixed-mode.ts
@@ -822,11 +822,6 @@ async function run(): Promise<void> {
       `${describeFeedState(quarantinedFeedState.response)}\n${describeFeedgenLogs(feedgen)}`,
     )
 
-    const passesBeforeRestart = feedgen.countLogs(isSpaceSyncPass)
-    const membershipsBeforeRestart = feedgen.countLogs(
-      isSwordsmithMembershipPass,
-    )
-    const memberSyncsBeforeRestart = feedgen.countLogs(isMemberSpaceSync)
     await feedgen.stop()
     await feedgen.start(feedgenStartOptions())
     await assertFeedgenWarmup(feedgen, 'cold-restart mixed-mode')
@@ -837,7 +832,7 @@ async function run(): Promise<void> {
     const restartMembershipPass = await feedgen.waitForLog(
       isSwordsmithMembershipPass,
       30_000,
-      membershipsBeforeRestart + 1,
+      1,
     )
     assert(
       restartMembershipPass.fields['memberCount'] === 1 &&
@@ -845,11 +840,7 @@ async function run(): Promise<void> {
         restartMembershipPass.fields['removed'] === 0,
       'the cold restart rebuilds the swordsmith PDS poll target',
     )
-    const restartPass = await feedgen.waitForLog(
-      isSpaceSyncPass,
-      30_000,
-      passesBeforeRestart + 1,
-    )
+    const restartPass = await feedgen.waitForLog(isSpaceSyncPass, 30_000, 1)
     assert(
       restartPass.fields['targets'] === 1 &&
         restartPass.fields['succeeded'] === 1 &&
@@ -861,7 +852,7 @@ async function run(): Promise<void> {
     const restartMemberSync = await feedgen.waitForLog(
       isMemberSpaceSync,
       30_000,
-      memberSyncsBeforeRestart + 1,
+      1,
     )
     assert(
       typeof restartMemberSync.fields['recordsIndexed'] === 'number' &&

--- a/test/scripts/test-mixed-mode.ts
+++ b/test/scripts/test-mixed-mode.ts
@@ -32,6 +32,7 @@ import {
   FEEDGEN_SIGNING_KEY,
   FeedgenHarness,
   type FeedgenStartOptions,
+  SPACE_COMMIT_TAMPER_MODULE,
 } from './lib/feedgen.ts'
 import { assert, fail, finish, pass, section } from './lib/log.ts'
 import {
@@ -116,11 +117,13 @@ interface FeedPostsResult {
   response: GetFeedResponse
 }
 
-function feedgenStartOptions(): FeedgenStartOptions {
+function feedgenStartOptions(
+  additionalEnv: Record<string, string> = {},
+): FeedgenStartOptions {
   return {
     port: FEEDGEN_PORT,
     feeds: MIXED_MODE_FEEDS,
-    env: SPACE_SYNC_ENV,
+    env: { ...SPACE_SYNC_ENV, ...additionalEnv },
   }
 }
 
@@ -417,6 +420,12 @@ async function run(): Promise<void> {
       fixture.hostile.did.startsWith('did:plc:'),
     'the invite-backed spaces PDS account APIs created did:plc fixtures',
   )
+
+  const isMemberSpaceSync = (event: {
+    fields: Readonly<Record<string, unknown>>
+  }): boolean =>
+    event.fields['msg'] === 'space member sync completed' &&
+    event.fields['did'] === fixture.member.did
 
   const space = spaceUriFor('swordsmith')
   const dnsRemediation = `republish ${DNS_DECLARATION_NAME} TXT as did=${SPACE_DECLARATION_AUTHORITY_DID}`
@@ -761,6 +770,120 @@ async function run(): Promise<void> {
       deniedSwordsmithFeed.status === 400 &&
         deniedSwordsmithFeed.body.error === 'BoundaryMismatch',
       'a viewer without swordsmith cannot access either custody record',
+    )
+
+    await feedgen.stop()
+    await feedgen.start(
+      feedgenStartOptions({
+        NODE_OPTIONS: `--import=${SPACE_COMMIT_TAMPER_MODULE}`,
+        FEEDGEN_E2E_TAMPER_COMMIT_REPO: fixture.member.did,
+        FEEDGEN_E2E_TAMPER_COMMIT_SPACE: space,
+      }),
+    )
+    await assertFeedgenWarmup(feedgen, 'quarantine mixed-mode')
+    assert(
+      await feedgen.waitForHealth(FEEDGEN_PORT, 30_000),
+      'the feedgen under a tampered PDS response is healthy',
+    )
+    const verificationFailure = await feedgen.waitForLog(
+      (event) => event.fields['msg'] === 'space commit verification failed',
+      30_000,
+    )
+    const failedTarget = verificationFailure.fields['target'] as
+      | Record<string, unknown>
+      | undefined
+    assert(
+      verificationFailure.fields['reason'] === 'mac-mismatch' &&
+        failedTarget?.['spaceUri'] === space &&
+        failedTarget['boundary'] === DOMAINS.swordsmith &&
+        failedTarget['did'] === fixture.member.did &&
+        failedTarget['host'] === PDS_SPACES_URL,
+      'the live feedgen quarantines the tampered PDS commit',
+    )
+    const haltedPass = await feedgen.waitForLog(
+      (event) => isSpaceSyncPass(event) && event.fields['halted'] === 1,
+      30_000,
+    )
+    assert(
+      haltedPass.fields['targets'] === 1 &&
+        haltedPass.fields['succeeded'] === 0 &&
+        haltedPass.fields['failed'] === 0,
+      'the live feedgen skips the quarantined PDS target on its next pass',
+    )
+    const quarantinedFeedState = await waitForFeedPost(
+      viewerToken,
+      'swordsmith',
+      memberPost.uri,
+      (found) => !found,
+    )
+    assert(
+      quarantinedFeedState.matches,
+      'commit quarantine removes the PDS-custody post from the boundary feed',
+      `${describeFeedState(quarantinedFeedState.response)}\n${describeFeedgenLogs(feedgen)}`,
+    )
+
+    const passesBeforeRestart = feedgen.countLogs(isSpaceSyncPass)
+    const membershipsBeforeRestart = feedgen.countLogs(
+      isSwordsmithMembershipPass,
+    )
+    const memberSyncsBeforeRestart = feedgen.countLogs(isMemberSpaceSync)
+    await feedgen.stop()
+    await feedgen.start(feedgenStartOptions())
+    await assertFeedgenWarmup(feedgen, 'cold-restart mixed-mode')
+    assert(
+      await feedgen.waitForHealth(FEEDGEN_PORT, 30_000),
+      'cold-restarted mixed-mode feedgen is healthy',
+    )
+    const restartMembershipPass = await feedgen.waitForLog(
+      isSwordsmithMembershipPass,
+      30_000,
+      membershipsBeforeRestart + 1,
+    )
+    assert(
+      restartMembershipPass.fields['memberCount'] === 1 &&
+        restartMembershipPass.fields['skippedNoHost'] === 0 &&
+        restartMembershipPass.fields['removed'] === 0,
+      'the cold restart rebuilds the swordsmith PDS poll target',
+    )
+    const restartPass = await feedgen.waitForLog(
+      isSpaceSyncPass,
+      30_000,
+      passesBeforeRestart + 1,
+    )
+    assert(
+      restartPass.fields['targets'] === 1 &&
+        restartPass.fields['succeeded'] === 1 &&
+        restartPass.fields['failed'] === 0 &&
+        restartPass.fields['abandoned'] === 0 &&
+        restartPass.fields['halted'] === 0,
+      'the cold restart syncs the rebuilt PDS poll target',
+    )
+    const restartMemberSync = await feedgen.waitForLog(
+      isMemberSpaceSync,
+      30_000,
+      memberSyncsBeforeRestart + 1,
+    )
+    assert(
+      typeof restartMemberSync.fields['recordsIndexed'] === 'number' &&
+        restartMemberSync.fields['recordsIndexed'] > 0,
+      'the cold restart reindexes the PDS member records',
+      JSON.stringify(restartMemberSync.fields),
+    )
+    const restartViewerToken = await getServiceAuth(
+      viewerSession.accessJwt,
+      FEEDGEN_DID,
+      GET_FEED_LXM,
+    )
+    const restartFeedState = await waitForFeedPost(
+      restartViewerToken,
+      'swordsmith',
+      memberPost.uri,
+      (found) => found,
+    )
+    assert(
+      restartFeedState.matches,
+      'the cold restart retains the PDS-custody post in its boundary feed',
+      `${describeFeedState(restartFeedState.response)}\n${describeFeedgenLogs(feedgen)}`,
     )
 
     const removal = await adminSetBoundaries(


### PR DESCRIPTION
## Summary

- Use an in-memory SQLite feed index by default so private feed data is ephemeral.
- Keep the shared in-memory libSQL database alive across released transaction connections.
- Make file-backed persistence an explicit operator choice in configuration and Compose examples.
- Disable core dumps in the Compose example and document the private-data durability tradeoff.

## Stack

- Depends on #171
- Final package in the mixed-mode stack

## Verification

The reconstructed full stack passes:

- `pnpm format:check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` — 197 files passed, 2,484 tests passed, 32 skipped



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Feed Generator record projections and replay cursors now use in-memory storage by default.
  * Membership and recovery data can be persisted separately through SQLite or PostgreSQL.
  * Feed reads remain unavailable until enrollment reconciliation completes.
  * Replay authorization now fails closed when membership data is unavailable.

* **Documentation**
  * Updated deployment, storage, readiness, health, shutdown, and load-testing guidance.

* **Bug Fixes**
  * Improved in-memory database reliability and preserved membership data across record projection resets.
  * Added validation for replay, commit integrity, quarantine, and cold-restart scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->