### PR TITLE
MM-11 prereq: replay authorization and membership storage

### DIFF
--- a/stratos-feedgen/src/api/feed/getFeed.ts
+++ b/stratos-feedgen/src/api/feed/getFeed.ts
@@ -1,9 +1,13 @@
-import type { Server as XrpcServer } from '@atproto/xrpc-server'
+import {
+  NotEnoughResourcesError,
+  type Server as XrpcServer,
+} from '@atproto/xrpc-server'
 import type { FeedgenStore, IndexedPost } from '../../db/index.js'
 import { decodeCursor, encodeCursor } from '../../db/index.js'
 import type { EnrollmentManager } from '../../enrollment/index.js'
 import type { FeedRegistry } from '../../feeds/index.js'
 import { NSID } from '../../lexicon/index.js'
+import type { FeedReadiness } from '../../readiness.js'
 import {
   BoundaryMismatchError,
   UnknownFeedError,
@@ -20,6 +24,8 @@ export interface GetFeedDeps {
   store: Pick<FeedgenStore, 'listPostsByBoundary'>
   enrollmentManager: Pick<EnrollmentManager, 'getBoundaries'>
   verifier: FeedRequestVerifier
+  /** Omitted means the caller has no replay-readiness requirement. */
+  readiness?: FeedReadiness
 }
 
 export interface PostView {
@@ -47,6 +53,13 @@ export function registerGetFeedHandler(
   server.method(NSID.getFeed, {
     auth: toXrpcAuthVerifier(deps.verifier),
     handler: async ({ params, auth }) => {
+      if (deps.readiness !== undefined && !deps.readiness.isReady()) {
+        throw new NotEnoughResourcesError(
+          'Feed is unavailable while authorization state is reconciling',
+          'FeedNotReady',
+        )
+      }
+
       const { viewerDid } = auth.credentials
       const feedId = params['feed'] as string
       const limit = clampLimit(params['limit'])

--- a/stratos-feedgen/src/api/feed/getFeed.ts
+++ b/stratos-feedgen/src/api/feed/getFeed.ts
@@ -53,12 +53,7 @@ export function registerGetFeedHandler(
   server.method(NSID.getFeed, {
     auth: toXrpcAuthVerifier(deps.verifier),
     handler: async ({ params, auth }) => {
-      if (deps.readiness !== undefined && !deps.readiness.isReady()) {
-        throw new NotEnoughResourcesError(
-          'Feed is unavailable while authorization state is reconciling',
-          'FeedNotReady',
-        )
-      }
+      assertReadiness(deps.readiness)
 
       const { viewerDid } = auth.credentials
       const feedId = params['feed'] as string
@@ -70,6 +65,7 @@ export function registerGetFeedHandler(
 
       const viewerBoundaries =
         await deps.enrollmentManager.getBoundaries(viewerDid)
+      assertReadiness(deps.readiness)
       if (!viewerBoundaries.includes(feed.boundary)) {
         throw new BoundaryMismatchError(feed.boundary)
       }
@@ -79,6 +75,7 @@ export function registerGetFeedHandler(
         limit,
         cursor: normalizeCursor(cursor),
       })
+      assertReadiness(deps.readiness)
 
       return {
         encoding: 'application/json',
@@ -89,6 +86,14 @@ export function registerGetFeedHandler(
       }
     },
   })
+}
+
+function assertReadiness(readiness: FeedReadiness | undefined): void {
+  if (readiness === undefined || readiness.isReady()) return
+  throw new NotEnoughResourcesError(
+    'Feed is unavailable while authorization state is reconciling',
+    'FeedNotReady',
+  )
 }
 
 function clampLimit(raw: unknown): number {

--- a/stratos-feedgen/src/bin/main.ts
+++ b/stratos-feedgen/src/bin/main.ts
@@ -37,6 +37,7 @@ import {
 } from '../space-sync/index.js'
 import {
   ActorPool,
+  CurrentMembershipReplayAuthorizer,
   intersectsBoundaries,
   ServiceStream,
   SubscriptionIndexer,
@@ -132,8 +133,14 @@ async function main(): Promise<void> {
   logger.info({ port }, 'stratos-feedgen listening')
 
   const configuredBoundaries = new Set(feeds.list().map((f) => f.boundary))
+  const replayAuthorizer = new CurrentMembershipReplayAuthorizer({
+    store,
+    client: upstream,
+    configuredBoundaries,
+  })
   const indexer = new SubscriptionIndexer(store, {
     onPostIndexed: () => metrics.indexPostsTotal.inc(),
+    replayAuthorizer,
   })
 
   // Best-effort warm-up: a boundary this feedgen has no membership for yet

--- a/stratos-feedgen/src/bin/main.ts
+++ b/stratos-feedgen/src/bin/main.ts
@@ -23,6 +23,7 @@ import {
   reconcileEnrollments,
 } from '../purge/index.js'
 import { SpaceMutationFence } from '../mutation-fence.js'
+import { FeedReadinessGate } from '../readiness.js'
 import { createFeedgenServer } from '../server.js'
 import { SpaceCredentialManager } from '../space-credential/index.js'
 import {
@@ -107,6 +108,9 @@ async function main(): Promise<void> {
   const store = await createFeedgenStore(cfg)
   shutdownDeps.store = store
   const spaceMutationFence = new SpaceMutationFence()
+  // Never serve the local projection until the enrollment stream has opened
+  // and a complete current-authority reconciliation has finished.
+  const feedReadiness = new FeedReadinessGate()
 
   const verifier = createFeedRequestVerifier({
     feedgenDid: cfg.feedgenServiceDid,
@@ -126,6 +130,7 @@ async function main(): Promise<void> {
     metrics,
     metricsToken: cfg.metricsToken,
     subscriptionStatus,
+    feedReadiness,
   })
 
   const httpServer = await server.listen(port)
@@ -134,7 +139,6 @@ async function main(): Promise<void> {
 
   const configuredBoundaries = new Set(feeds.list().map((f) => f.boundary))
   const replayAuthorizer = new CurrentMembershipReplayAuthorizer({
-    store,
     client: upstream,
     configuredBoundaries,
   })
@@ -198,6 +202,7 @@ async function main(): Promise<void> {
       metrics,
       shutdownDeps,
       spaceMutationFence,
+      feedReadiness,
     })
     // Shutdown awaits this barrier before it closes the store. The swallow
     // keeps a startup failure out of the panic path; main's catch reports it.
@@ -317,6 +322,7 @@ interface StartSubscriptionDeps {
   metrics: FeedgenMetrics
   shutdownDeps: ShutdownDeps
   spaceMutationFence: SpaceMutationFence
+  feedReadiness: FeedReadinessGate
 }
 
 /**
@@ -331,7 +337,7 @@ async function startSubscription(deps: StartSubscriptionDeps): Promise<{
 }> {
   const { cfg, upstream, store, indexer, enrollmentManager, logger, metrics } =
     deps
-  const { configuredBoundaries, spaceMutationFence } = deps
+  const { configuredBoundaries, spaceMutationFence, feedReadiness } = deps
 
   const pool = new ActorPool(
     {
@@ -372,7 +378,8 @@ async function startSubscription(deps: StartSubscriptionDeps): Promise<{
   // via batching so upstream resolves don't fan out unbounded on large
   // tenants.
   const runReconcile = async (): Promise<void> => {
-    await reconcileEnrollments(
+    const generation = feedReadiness.beginReconciliation()
+    const summary = await reconcileEnrollments(
       {
         store,
         purger,
@@ -390,6 +397,13 @@ async function startSubscription(deps: StartSubscriptionDeps): Promise<{
         maxActors: parseIntEnv(process.env['FEEDGEN_RECONCILE_MAX_ACTORS']),
       },
     )
+    const released = feedReadiness.completeReconciliation(generation, summary)
+    if (!released && (summary.errors > 0 || summary.truncated)) {
+      logger.warn(
+        { ...summary },
+        'feed remains unavailable until enrollment reconciliation is complete',
+      )
+    }
   }
   await runReconcile()
   const triggerReconcile = createReconcileScheduler(runReconcile, (err) => {
@@ -454,8 +468,10 @@ async function startSubscription(deps: StartSubscriptionDeps): Promise<{
     {
       stratosServiceUrl: cfg.stratosServiceUrl,
       mintToken: () => upstream.mintServiceAuthToken(),
-      onReconnectScheduled: () =>
-        metrics.reconnectsTotal.inc({ kind: 'service' }),
+      onReconnectScheduled: () => {
+        feedReadiness.markUnavailable()
+        metrics.reconnectsTotal.inc({ kind: 'service' })
+      },
     },
     {
       onEnroll: async (did, boundaries) => {
@@ -482,6 +498,7 @@ async function startSubscription(deps: StartSubscriptionDeps): Promise<{
       // The scheduler coalesces, so a healthy boot pays one bounded extra
       // run.
       onSessionEstablished: () => {
+        feedReadiness.markSessionEstablished()
         triggerReconcile()
       },
     },

--- a/stratos-feedgen/src/config.ts
+++ b/stratos-feedgen/src/config.ts
@@ -31,6 +31,11 @@ export interface FeedgenConfig {
   storageBackend: StorageBackend
   /** Path to SQLite database file (used when `storageBackend === 'sqlite'`). */
   sqlitePath?: string
+  /**
+   * Path to the SQLite database holding durable enrollment and space-membership
+   * snapshots. This must differ from `sqlitePath`.
+   */
+  membershipSqlitePath?: string
   /** Postgres connection URL (used when `storageBackend === 'postgres'`). */
   postgresUrl?: string
   /** Optional Postgres schema name. Defaults to `public` when omitted. */
@@ -107,25 +112,19 @@ export interface FeedgenEnv {
   [key: string]: string | undefined
 }
 
+type StorageConfig = Pick<
+  FeedgenConfig,
+  | 'storageBackend'
+  | 'sqlitePath'
+  | 'membershipSqlitePath'
+  | 'postgresUrl'
+  | 'postgresSchema'
+>
+
 export function loadFeedgenConfig(
   env: FeedgenEnv = process.env,
 ): FeedgenConfig {
-  const storageBackend = parseStorageBackend(env['FEEDGEN_STORAGE_BACKEND'])
-  const sqlitePath = env['FEEDGEN_SQLITE_PATH']
-  const postgresUrl = env['FEEDGEN_POSTGRES_URL']
-  const postgresSchema = env['FEEDGEN_POSTGRES_SCHEMA']
-
-  if (storageBackend === 'sqlite' && !sqlitePath) {
-    throw new Error(
-      'Missing required env var FEEDGEN_SQLITE_PATH for sqlite backend',
-    )
-  }
-  if (storageBackend === 'postgres' && !postgresUrl) {
-    throw new Error(
-      'Missing required env var FEEDGEN_POSTGRES_URL for postgres backend',
-    )
-  }
-
+  const storage = loadStorageConfig(env)
   const feedgenServiceDid = requireEnv(env, 'FEEDGEN_SERVICE_DID')
 
   return {
@@ -144,10 +143,7 @@ export function loadFeedgenConfig(
     stratosServiceDid: requireEnv(env, 'STRATOS_SERVICE_DID'),
     feedgenPlcUrl: trimTrailingSlash(env['FEEDGEN_PLC_URL'] ?? DEFAULT_PLC_URL),
     feedgenAllowedLxms: DEFAULT_ALLOWED_LXMS,
-    storageBackend,
-    sqlitePath,
-    postgresUrl,
-    postgresSchema,
+    ...storage,
     boundaryCacheTtlMs: parsePositiveInt(
       env['FEEDGEN_BOUNDARY_CACHE_TTL_MS'],
       'FEEDGEN_BOUNDARY_CACHE_TTL_MS',
@@ -219,6 +215,59 @@ export function loadFeedgenConfig(
       env['FEEDGEN_SPACE_SYNC_ALLOW_HTTP_HOSTS'],
     ),
   }
+}
+
+function loadStorageConfig(env: FeedgenEnv): StorageConfig {
+  const storageBackend = parseStorageBackend(env['FEEDGEN_STORAGE_BACKEND'])
+  const sqlitePath = env['FEEDGEN_SQLITE_PATH']
+  const postgresUrl = env['FEEDGEN_POSTGRES_URL']
+  if (storageBackend === 'sqlite' && !sqlitePath) {
+    throw new Error(
+      'Missing required env var FEEDGEN_SQLITE_PATH for sqlite backend',
+    )
+  }
+  if (storageBackend === 'postgres' && !postgresUrl) {
+    throw new Error(
+      'Missing required env var FEEDGEN_POSTGRES_URL for postgres backend',
+    )
+  }
+  return {
+    storageBackend,
+    sqlitePath,
+    membershipSqlitePath:
+      storageBackend === 'sqlite'
+        ? resolveMembershipSqlitePath(
+            sqlitePath,
+            nonEmpty(env['FEEDGEN_MEMBERSHIP_SQLITE_PATH']),
+          )
+        : undefined,
+    postgresUrl,
+    postgresSchema: env['FEEDGEN_POSTGRES_SCHEMA'],
+  }
+}
+
+function resolveMembershipSqlitePath(
+  sqlitePath: string | undefined,
+  configuredPath: string | undefined,
+): string {
+  if (!sqlitePath) {
+    throw new Error('sqlitePath is required for sqlite backend')
+  }
+  if (sqlitePath === ':memory:' && !configuredPath) {
+    throw new Error(
+      'Missing required env var FEEDGEN_MEMBERSHIP_SQLITE_PATH when FEEDGEN_SQLITE_PATH is :memory:',
+    )
+  }
+  const membershipPath = configuredPath ?? `${sqlitePath}.membership`
+  if (membershipPath === ':memory:') {
+    throw new Error('FEEDGEN_MEMBERSHIP_SQLITE_PATH must be a file path')
+  }
+  if (membershipPath === sqlitePath) {
+    throw new Error(
+      'FEEDGEN_MEMBERSHIP_SQLITE_PATH must differ from FEEDGEN_SQLITE_PATH',
+    )
+  }
+  return membershipPath
 }
 
 /** Treat an empty env var the same as an unset one. */

--- a/stratos-feedgen/src/config.ts
+++ b/stratos-feedgen/src/config.ts
@@ -1,4 +1,6 @@
 import { isIP } from 'node:net'
+import { lstatSync, realpathSync, statSync } from 'node:fs'
+import { basename, dirname, join, resolve } from 'node:path'
 import { parseCommaList } from '@northskysocial/stratos-core'
 
 /**
@@ -259,15 +261,69 @@ function resolveMembershipSqlitePath(
     )
   }
   const membershipPath = configuredPath ?? `${sqlitePath}.membership`
-  if (membershipPath === ':memory:') {
+  if (membershipPath.startsWith(':memory:')) {
     throw new Error('FEEDGEN_MEMBERSHIP_SQLITE_PATH must be a file path')
   }
-  if (membershipPath === sqlitePath) {
+  if (sqlitePath !== ':memory:') {
+    assertDistinctSqlitePaths(sqlitePath, membershipPath)
+  }
+  return membershipPath
+}
+
+/**
+ * Reject two spellings that resolve to the same SQLite file. Keeping cursor
+ * state out of durable control storage depends on these files being distinct.
+ */
+export function assertDistinctSqlitePaths(
+  recordPath: string,
+  membershipPath: string,
+): void {
+  if (
+    canonicalSqlitePath(recordPath) === canonicalSqlitePath(membershipPath) ||
+    sameExistingFile(recordPath, membershipPath)
+  ) {
     throw new Error(
       'FEEDGEN_MEMBERSHIP_SQLITE_PATH must differ from FEEDGEN_SQLITE_PATH',
     )
   }
-  return membershipPath
+}
+
+function sameExistingFile(left: string, right: string): boolean {
+  try {
+    const leftStat = statSync(left)
+    const rightStat = statSync(right)
+    return leftStat.dev === rightStat.dev && leftStat.ino === rightStat.ino
+  } catch (err) {
+    if ((err as { code?: string }).code === 'ENOENT') return false
+    throw err
+  }
+}
+
+function canonicalSqlitePath(location: string): string {
+  const absolute = resolve(location)
+  const missingSegments: string[] = []
+  let existingPath = absolute
+  for (;;) {
+    try {
+      // A leaf symlink can become an alias after startup. Reject it rather
+      // than accepting a path whose durable/ephemeral identity can change.
+      if (
+        missingSegments.length === 0 &&
+        lstatSync(existingPath).isSymbolicLink()
+      ) {
+        throw new Error(
+          `SQLite storage path must not be a symbolic link: ${location}`,
+        )
+      }
+      return join(realpathSync.native(existingPath), ...missingSegments)
+    } catch (err) {
+      if ((err as { code?: string }).code !== 'ENOENT') throw err
+      const parent = dirname(existingPath)
+      if (parent === existingPath) return absolute
+      missingSegments.unshift(basename(existingPath))
+      existingPath = parent
+    }
+  }
 }
 
 /** Treat an empty env var the same as an unset one. */

--- a/stratos-feedgen/src/db/index.ts
+++ b/stratos-feedgen/src/db/index.ts
@@ -1,4 +1,4 @@
-import type { FeedgenConfig } from '../config.js'
+import { assertDistinctSqlitePaths, type FeedgenConfig } from '../config.js'
 import { createPgDb, migratePgDb, PgFeedgenStore } from './postgres.js'
 import {
   createSqliteDb,
@@ -23,8 +23,11 @@ export async function createFeedgenStore(
     if (!cfg.membershipSqlitePath) {
       throw new Error('membershipSqlitePath is required for sqlite backend')
     }
-    if (cfg.membershipSqlitePath === cfg.sqlitePath) {
-      throw new Error('membershipSqlitePath must differ from sqlitePath')
+    if (cfg.membershipSqlitePath.startsWith(':memory:')) {
+      throw new Error('membershipSqlitePath must be a file path')
+    }
+    if (cfg.sqlitePath !== ':memory:') {
+      assertDistinctSqlitePaths(cfg.sqlitePath, cfg.membershipSqlitePath)
     }
     const recordDb = createSqliteDb(cfg.sqlitePath)
     const membershipDb = createSqliteDb(cfg.membershipSqlitePath)

--- a/stratos-feedgen/src/db/index.ts
+++ b/stratos-feedgen/src/db/index.ts
@@ -2,7 +2,9 @@ import type { FeedgenConfig } from '../config.js'
 import { createPgDb, migratePgDb, PgFeedgenStore } from './postgres.js'
 import {
   createSqliteDb,
-  migrateSqliteDb,
+  importLegacyMembershipSnapshots,
+  migrateMembershipSqliteDb,
+  migrateRecordSqliteDb,
   SqliteFeedgenStore,
 } from './sqlite.js'
 import type { FeedgenStore } from './types.js'
@@ -18,9 +20,20 @@ export async function createFeedgenStore(
     if (!cfg.sqlitePath) {
       throw new Error('sqlitePath is required for sqlite backend')
     }
-    const db = createSqliteDb(cfg.sqlitePath)
-    await migrateSqliteDb(db)
-    return new SqliteFeedgenStore(db)
+    if (!cfg.membershipSqlitePath) {
+      throw new Error('membershipSqlitePath is required for sqlite backend')
+    }
+    if (cfg.membershipSqlitePath === cfg.sqlitePath) {
+      throw new Error('membershipSqlitePath must differ from sqlitePath')
+    }
+    const recordDb = createSqliteDb(cfg.sqlitePath)
+    const membershipDb = createSqliteDb(cfg.membershipSqlitePath)
+    await Promise.all([
+      migrateRecordSqliteDb(recordDb),
+      migrateMembershipSqliteDb(membershipDb),
+    ])
+    await importLegacyMembershipSnapshots(recordDb, membershipDb)
+    return new SqliteFeedgenStore(recordDb, membershipDb)
   }
   if (!cfg.postgresUrl) {
     throw new Error('postgresUrl is required for postgres backend')

--- a/stratos-feedgen/src/db/sqlite.ts
+++ b/stratos-feedgen/src/db/sqlite.ts
@@ -1,4 +1,6 @@
 import { Client, createClient } from '@libsql/client'
+import { resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
 import { and, asc, desc, eq, inArray, lt, or, sql } from 'drizzle-orm'
 import { drizzle, LibSQLDatabase } from 'drizzle-orm/libsql'
 import {
@@ -37,7 +39,7 @@ const LEGACY_MEMBERSHIP_IMPORT_KEY = 'legacy-record-store-imported'
 
 export function createSqliteDb(location: string): SqliteDb {
   const client = createClient({
-    url: location === ':memory:' ? ':memory:' : `file:${location}`,
+    url: sqliteClientUrl(location),
   })
   const baseDb = drizzle({ client, schema: sqliteSchema })
   const db = baseDb as unknown as SqliteDb
@@ -52,6 +54,12 @@ export function createSqliteDb(location: string): SqliteDb {
     await db.run(sql.raw('PRAGMA foreign_keys = ON'))
   })()
   return db
+}
+
+function sqliteClientUrl(location: string): string {
+  return location === ':memory:'
+    ? ':memory:'
+    : pathToFileURL(resolve(location)).href
 }
 
 /** Migrate the materialized record index and the cursors that checkpoint it. */

--- a/stratos-feedgen/src/db/sqlite.ts
+++ b/stratos-feedgen/src/db/sqlite.ts
@@ -33,6 +33,8 @@ export type SqliteDb = LibSQLDatabase<typeof sqliteSchema> & {
   _initialized: Promise<void>
 }
 
+const LEGACY_MEMBERSHIP_IMPORT_KEY = 'legacy-record-store-imported'
+
 export function createSqliteDb(location: string): SqliteDb {
   const client = createClient({
     url: location === ':memory:' ? ':memory:' : `file:${location}`,
@@ -52,7 +54,8 @@ export function createSqliteDb(location: string): SqliteDb {
   return db
 }
 
-export async function migrateSqliteDb(db: SqliteDb): Promise<void> {
+/** Migrate the materialized record index and the cursors that checkpoint it. */
+export async function migrateRecordSqliteDb(db: SqliteDb): Promise<void> {
   await db._initialized
   await db.run(sql`
     CREATE TABLE IF NOT EXISTS post (
@@ -88,20 +91,25 @@ export async function migrateSqliteDb(db: SqliteDb): Promise<void> {
     )
   `)
   await db.run(sql`
-    CREATE TABLE IF NOT EXISTS enrolled_actor (
-      did TEXT PRIMARY KEY,
-      boundariesJson TEXT NOT NULL,
-      enrolledAt TEXT NOT NULL,
-      lastSeenAt TEXT NOT NULL
-    )
-  `)
-  await db.run(sql`
     CREATE TABLE IF NOT EXISTS space_sync_cursor (
       spaceUri TEXT NOT NULL,
       did TEXT NOT NULL,
       cursor TEXT NOT NULL,
       updatedAt TEXT NOT NULL,
       PRIMARY KEY (spaceUri, did)
+    )
+  `)
+}
+
+/** Migrate durable enrollment and completed space-membership snapshots. */
+export async function migrateMembershipSqliteDb(db: SqliteDb): Promise<void> {
+  await db._initialized
+  await db.run(sql`
+    CREATE TABLE IF NOT EXISTS enrolled_actor (
+      did TEXT PRIMARY KEY,
+      boundariesJson TEXT NOT NULL,
+      enrolledAt TEXT NOT NULL,
+      lastSeenAt TEXT NOT NULL
     )
   `)
   await db.run(sql`
@@ -135,13 +143,95 @@ export async function migrateSqliteDb(db: SqliteDb): Promise<void> {
       PRIMARY KEY (boundary, did)
     )
   `)
+  await db.run(sql`
+    CREATE TABLE IF NOT EXISTS feedgen_membership_metadata (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL
+    )
+  `)
+}
+
+/**
+ * Carry forward membership baselines from a legacy one-file store exactly
+ * once. Cursors are intentionally not copied: they remain co-durable with
+ * the materialized records in the record store.
+ */
+export async function importLegacyMembershipSnapshots(
+  recordDb: SqliteDb,
+  membershipDb: SqliteDb,
+): Promise<void> {
+  if (recordDb === membershipDb) return
+  const marker = await membershipDb.all<{ value: string }>(sql`
+    SELECT value
+    FROM feedgen_membership_metadata
+    WHERE key = ${LEGACY_MEMBERSHIP_IMPORT_KEY}
+  `)
+  if (marker.length > 0) return
+
+  const [hasEnrolledActors, hasSpaceMembers] = await Promise.all([
+    sqliteTableExists(recordDb, 'enrolled_actor'),
+    sqliteTableExists(recordDb, 'space_member_snapshot'),
+  ])
+  const [actors, members] = await Promise.all([
+    hasEnrolledActors
+      ? recordDb.select().from(enrolledActorTbl)
+      : Promise.resolve([]),
+    hasSpaceMembers
+      ? recordDb.select().from(spaceMemberSnapshotTbl)
+      : Promise.resolve([]),
+  ])
+
+  await membershipDb.transaction(async (tx) => {
+    if (actors.length > 0) {
+      await tx.insert(enrolledActorTbl).values(actors).onConflictDoNothing()
+    }
+    for (
+      let offset = 0;
+      offset < members.length;
+      offset += SPACE_MEMBER_INSERT_CHUNK_SIZE
+    ) {
+      await tx
+        .insert(spaceMemberSnapshotTbl)
+        .values(members.slice(offset, offset + SPACE_MEMBER_INSERT_CHUNK_SIZE))
+        .onConflictDoNothing()
+    }
+    await tx.run(sql`
+      INSERT INTO feedgen_membership_metadata (key, value)
+      VALUES (${LEGACY_MEMBERSHIP_IMPORT_KEY}, '1')
+      ON CONFLICT(key) DO NOTHING
+    `)
+  })
+}
+
+/**
+ * Backwards-compatible all-in-one migration for direct store construction.
+ * Production opens the record and membership databases independently.
+ */
+export async function migrateSqliteDb(db: SqliteDb): Promise<void> {
+  await migrateRecordSqliteDb(db)
+  await migrateMembershipSqliteDb(db)
+}
+
+async function sqliteTableExists(
+  db: SqliteDb,
+  table: string,
+): Promise<boolean> {
+  const rows = await db.all<{ name: string }>(sql`
+    SELECT name
+    FROM sqlite_master
+    WHERE type = 'table' AND name = ${table}
+  `)
+  return rows.length > 0
 }
 
 export class SqliteFeedgenStore implements FeedgenStore {
-  constructor(private readonly db: SqliteDb) {}
+  constructor(
+    private readonly recordDb: SqliteDb,
+    private readonly membershipDb: SqliteDb = recordDb,
+  ) {}
 
   async upsertPost(input: PostUpsert): Promise<void> {
-    await this.db.transaction(async (tx) => {
+    await this.recordDb.transaction(async (tx) => {
       await tx
         .insert(postTbl)
         .values({
@@ -177,12 +267,12 @@ export class SqliteFeedgenStore implements FeedgenStore {
   }
 
   async deletePost(uri: string): Promise<void> {
-    await this.db.delete(postTbl).where(eq(postTbl.uri, uri))
+    await this.recordDb.delete(postTbl).where(eq(postTbl.uri, uri))
   }
 
   async deletePostsByDid(did: string): Promise<number> {
     // FK ON DELETE CASCADE removes the matching post_boundary rows.
-    const res = await this.db.delete(postTbl).where(eq(postTbl.did, did))
+    const res = await this.recordDb.delete(postTbl).where(eq(postTbl.did, did))
     return res.rowsAffected
   }
 
@@ -190,7 +280,7 @@ export class SqliteFeedgenStore implements FeedgenStore {
     did: string,
     boundary: string,
   ): Promise<number> {
-    return this.db.transaction(async (tx) => {
+    return this.recordDb.transaction(async (tx) => {
       // Delete posts for which the removed boundary is the last one. Testing
       // for that boundary before deletion keeps pre-existing boundaryless
       // posts out of scope without materializing every URI into SQL binds.
@@ -233,7 +323,7 @@ export class SqliteFeedgenStore implements FeedgenStore {
     shouldCommit: () => boolean,
   ): Promise<GuardedBoundaryDeleteResult> {
     try {
-      return await this.db.transaction(async (tx) => {
+      return await this.recordDb.transaction(async (tx) => {
         const cursorDelete = await tx
           .delete(spaceSyncCursorTbl)
           .where(
@@ -302,7 +392,7 @@ export class SqliteFeedgenStore implements FeedgenStore {
     // FK ON DELETE CASCADE removes every boundary row for matching posts.
     // Keep the selection in SQL so a large space never becomes an unbounded
     // application-side URI list or exceeds the backend's bind limit.
-    const res = await this.db.delete(postTbl).where(sql`EXISTS (
+    const res = await this.recordDb.delete(postTbl).where(sql`EXISTS (
       SELECT 1 FROM post_boundary scoped
       WHERE scoped.uri = ${postTbl.uri}
         AND scoped.boundary = ${boundary}
@@ -311,14 +401,14 @@ export class SqliteFeedgenStore implements FeedgenStore {
   }
 
   async deleteCursor(did: string): Promise<number> {
-    const res = await this.db
+    const res = await this.recordDb
       .delete(syncCursorTbl)
       .where(eq(syncCursorTbl.did, did))
     return res.rowsAffected
   }
 
   async deleteSpaceCursor(spaceUri: string, did: string): Promise<number> {
-    const res = await this.db
+    const res = await this.recordDb
       .delete(spaceSyncCursorTbl)
       .where(
         and(
@@ -330,14 +420,14 @@ export class SqliteFeedgenStore implements FeedgenStore {
   }
 
   async deleteSpaceCursors(did: string): Promise<number> {
-    const res = await this.db
+    const res = await this.recordDb
       .delete(spaceSyncCursorTbl)
       .where(eq(spaceSyncCursorTbl.did, did))
     return res.rowsAffected
   }
 
   async deleteSpaceCursorsBySpace(spaceUri: string): Promise<number> {
-    const res = await this.db
+    const res = await this.recordDb
       .delete(spaceSyncCursorTbl)
       .where(eq(spaceSyncCursorTbl.spaceUri, spaceUri))
     return res.rowsAffected
@@ -611,13 +701,13 @@ export class SqliteFeedgenStore implements FeedgenStore {
   }
 
   async getPost(uri: string): Promise<IndexedPost | null> {
-    const rows = await this.db
+    const rows = await this.recordDb
       .select()
       .from(postTbl)
       .where(eq(postTbl.uri, uri))
       .limit(1)
     if (rows.length === 0) return null
-    const boundaries = await this.db
+    const boundaries = await this.recordDb
       .select({ boundary: postBoundaryTbl.boundary })
       .from(postBoundaryTbl)
       .where(eq(postBoundaryTbl.uri, uri))
@@ -638,7 +728,7 @@ export class SqliteFeedgenStore implements FeedgenStore {
           ),
         )
       : undefined
-    const rows = await this.db
+    const rows = await this.recordDb
       .select({
         uri: postTbl.uri,
         did: postTbl.did,
@@ -676,7 +766,7 @@ export class SqliteFeedgenStore implements FeedgenStore {
     uris: string[],
   ): Promise<Map<string, string[]>> {
     if (uris.length === 0) return new Map()
-    const rows = await this.db
+    const rows = await this.recordDb
       .select({
         uri: postBoundaryTbl.uri,
         boundary: postBoundaryTbl.boundary,
@@ -697,7 +787,7 @@ export class SqliteFeedgenStore implements FeedgenStore {
     seq: number,
     updatedAt: string,
   ): Promise<void> {
-    await this.db
+    await this.recordDb
       .insert(syncCursorTbl)
       .values({ did, seq, updatedAt })
       .onConflictDoUpdate({
@@ -707,7 +797,7 @@ export class SqliteFeedgenStore implements FeedgenStore {
   }
 
   async getCursor(did: string): Promise<number | null> {
-    const rows = await this.db
+    const rows = await this.recordDb
       .select({ seq: syncCursorTbl.seq })
       .from(syncCursorTbl)
       .where(eq(syncCursorTbl.did, did))
@@ -721,7 +811,7 @@ export class SqliteFeedgenStore implements FeedgenStore {
     cursor: string,
     updatedAt: string,
   ): Promise<void> {
-    await this.db
+    await this.recordDb
       .insert(spaceSyncCursorTbl)
       .values({ spaceUri, did, cursor, updatedAt })
       .onConflictDoUpdate({
@@ -731,7 +821,7 @@ export class SqliteFeedgenStore implements FeedgenStore {
   }
 
   async getSpaceCursor(spaceUri: string, did: string): Promise<string | null> {
-    const rows = await this.db
+    const rows = await this.recordDb
       .select({ cursor: spaceSyncCursorTbl.cursor })
       .from(spaceSyncCursorTbl)
       .where(
@@ -745,7 +835,7 @@ export class SqliteFeedgenStore implements FeedgenStore {
   }
 
   async listSpaceMembers(boundary: string): Promise<SpaceMemberSnapshot[]> {
-    const rows = await this.db
+    const rows = await this.membershipDb
       .select({
         did: spaceMemberSnapshotTbl.did,
         custody: spaceMemberSnapshotTbl.custody,
@@ -768,7 +858,7 @@ export class SqliteFeedgenStore implements FeedgenStore {
     const uniqueMembers = [
       ...new Map(members.map((member) => [member.did, member])).values(),
     ]
-    await this.db.transaction(async (tx) => {
+    await this.membershipDb.transaction(async (tx) => {
       await tx
         .delete(spaceMemberSnapshotTbl)
         .where(eq(spaceMemberSnapshotTbl.boundary, boundary))
@@ -795,7 +885,7 @@ export class SqliteFeedgenStore implements FeedgenStore {
 
   async upsertEnrolledActor(input: EnrolledActorUpsert): Promise<void> {
     const boundariesJson = JSON.stringify(input.boundaries)
-    await this.db
+    await this.membershipDb
       .insert(enrolledActorTbl)
       .values({
         did: input.did,
@@ -814,7 +904,7 @@ export class SqliteFeedgenStore implements FeedgenStore {
   }
 
   async getEnrolledActor(did: string): Promise<EnrolledActor | null> {
-    const rows = await this.db
+    const rows = await this.membershipDb
       .select()
       .from(enrolledActorTbl)
       .where(eq(enrolledActorTbl.did, did))
@@ -824,16 +914,21 @@ export class SqliteFeedgenStore implements FeedgenStore {
   }
 
   async listEnrolledActors(): Promise<EnrolledActor[]> {
-    const rows = await this.db.select().from(enrolledActorTbl)
+    const rows = await this.membershipDb.select().from(enrolledActorTbl)
     return rows.map(rowToEnrolledActor)
   }
 
   async deleteEnrolledActor(did: string): Promise<void> {
-    await this.db.delete(enrolledActorTbl).where(eq(enrolledActorTbl.did, did))
+    await this.membershipDb
+      .delete(enrolledActorTbl)
+      .where(eq(enrolledActorTbl.did, did))
   }
 
   async close(): Promise<void> {
-    this.db._client.close()
+    this.recordDb._client.close()
+    if (this.membershipDb !== this.recordDb) {
+      this.membershipDb._client.close()
+    }
   }
 }
 

--- a/stratos-feedgen/src/db/sqlite.ts
+++ b/stratos-feedgen/src/db/sqlite.ts
@@ -62,7 +62,7 @@ function sqliteClientUrl(location: string): string {
     : pathToFileURL(resolve(location)).href
 }
 
-/** Migrate the materialized record index and the cursors that checkpoint it. */
+/** Migrate the materialized record index and its checkpointed sync state. */
 export async function migrateRecordSqliteDb(db: SqliteDb): Promise<void> {
   await db._initialized
   await db.run(sql`
@@ -107,19 +107,6 @@ export async function migrateRecordSqliteDb(db: SqliteDb): Promise<void> {
       PRIMARY KEY (spaceUri, did)
     )
   `)
-}
-
-/** Migrate durable enrollment and completed space-membership snapshots. */
-export async function migrateMembershipSqliteDb(db: SqliteDb): Promise<void> {
-  await db._initialized
-  await db.run(sql`
-    CREATE TABLE IF NOT EXISTS enrolled_actor (
-      did TEXT PRIMARY KEY,
-      boundariesJson TEXT NOT NULL,
-      enrolledAt TEXT NOT NULL,
-      lastSeenAt TEXT NOT NULL
-    )
-  `)
   await db.run(sql`
     CREATE TABLE IF NOT EXISTS space_sync_stage (
       spaceUri TEXT NOT NULL,
@@ -140,6 +127,19 @@ export async function migrateMembershipSqliteDb(db: SqliteDb): Promise<void> {
       spaceUri TEXT NOT NULL,
       did TEXT NOT NULL,
       PRIMARY KEY (spaceUri, did)
+    )
+  `)
+}
+
+/** Migrate durable enrollment and completed space-membership snapshots. */
+export async function migrateMembershipSqliteDb(db: SqliteDb): Promise<void> {
+  await db._initialized
+  await db.run(sql`
+    CREATE TABLE IF NOT EXISTS enrolled_actor (
+      did TEXT PRIMARY KEY,
+      boundariesJson TEXT NOT NULL,
+      enrolledAt TEXT NOT NULL,
+      lastSeenAt TEXT NOT NULL
     )
   `)
   await db.run(sql`
@@ -442,7 +442,7 @@ export class SqliteFeedgenStore implements FeedgenStore {
   }
 
   async stageSpaceSyncPage(input: SpaceSyncStagePage): Promise<void> {
-    await this.db.transaction(async (tx) => {
+    await this.recordDb.transaction(async (tx) => {
       for (const mutation of input.mutations) {
         if (mutation.kind === 'delete') {
           await tx
@@ -534,7 +534,7 @@ export class SqliteFeedgenStore implements FeedgenStore {
   }
 
   async promoteSpaceSyncStage(spaceUri: string, did: string): Promise<void> {
-    await this.db.transaction(async (tx) => {
+    await this.recordDb.transaction(async (tx) => {
       const stages = await tx
         .select()
         .from(spaceSyncStageTbl)
@@ -603,7 +603,7 @@ export class SqliteFeedgenStore implements FeedgenStore {
     spaceUri: string,
     did: string,
   ): Promise<boolean> {
-    return this.db.transaction(async (tx) => {
+    return this.recordDb.transaction(async (tx) => {
       const pending = await tx
         .delete(spaceSyncPendingVerificationTbl)
         .where(
@@ -634,7 +634,7 @@ export class SqliteFeedgenStore implements FeedgenStore {
   }
 
   async resetSpaceSyncState(spaceUri: string, did: string): Promise<void> {
-    await this.db.transaction(async (tx) => {
+    await this.recordDb.transaction(async (tx) => {
       await tx
         .delete(spaceSyncPendingVerificationTbl)
         .where(
@@ -663,7 +663,7 @@ export class SqliteFeedgenStore implements FeedgenStore {
   }
 
   async deleteSpaceSyncStage(spaceUri: string, did: string): Promise<number> {
-    return this.db.transaction(async (tx) => {
+    return this.recordDb.transaction(async (tx) => {
       const deleted = await tx
         .delete(spaceSyncStageTbl)
         .where(
@@ -685,7 +685,7 @@ export class SqliteFeedgenStore implements FeedgenStore {
   }
 
   async deleteSpaceSyncStages(did: string): Promise<number> {
-    return this.db.transaction(async (tx) => {
+    return this.recordDb.transaction(async (tx) => {
       const deleted = await tx
         .delete(spaceSyncStageTbl)
         .where(eq(spaceSyncStageTbl.did, did))
@@ -697,7 +697,7 @@ export class SqliteFeedgenStore implements FeedgenStore {
   }
 
   async deleteSpaceSyncStagesBySpace(spaceUri: string): Promise<number> {
-    return this.db.transaction(async (tx) => {
+    return this.recordDb.transaction(async (tx) => {
       const deleted = await tx
         .delete(spaceSyncStageTbl)
         .where(eq(spaceSyncStageTbl.spaceUri, spaceUri))

--- a/stratos-feedgen/src/db/types.ts
+++ b/stratos-feedgen/src/db/types.ts
@@ -91,7 +91,11 @@ export interface GuardedBoundaryDeleteResult {
   spaceCursors: number
 }
 
-export interface FeedgenStore {
+/**
+ * Ephemeral materialized feed state. Sync cursors belong here because a
+ * cursor is only valid while the records it checkpoints are available.
+ */
+export interface FeedgenRecordStore {
   // posts
   upsertPost: (input: PostUpsert) => Promise<void>
   deletePost: (uri: string) => Promise<void>
@@ -158,7 +162,13 @@ export interface FeedgenStore {
     updatedAt: string,
   ) => Promise<void>
   getSpaceCursor: (spaceUri: string, did: string) => Promise<string | null>
+}
 
+/**
+ * Durable enrollment and membership snapshots. Runtime consumers keep their
+ * own hot maps; this store supplies restart and reconciliation baselines.
+ */
+export interface FeedgenMembershipStore {
   // completed space membership snapshots
   listSpaceMembers: (boundary: string) => Promise<SpaceMemberSnapshot[]>
   replaceSpaceMembers: (
@@ -171,7 +181,11 @@ export interface FeedgenStore {
   getEnrolledActor: (did: string) => Promise<EnrolledActor | null>
   listEnrolledActors: () => Promise<EnrolledActor[]>
   deleteEnrolledActor: (did: string) => Promise<void>
+}
 
+/** The production store combines record and membership storage lifecycles. */
+export interface FeedgenStore
+  extends FeedgenRecordStore, FeedgenMembershipStore {
   close: () => Promise<void>
 }
 

--- a/stratos-feedgen/src/purge/reconcile.ts
+++ b/stratos-feedgen/src/purge/reconcile.ts
@@ -28,6 +28,10 @@ export interface ReconcileOptions {
 }
 
 export interface ReconcileSummary {
+  /** Actors present in the persisted snapshot before any optional cap. */
+  total: number
+  /** Whether `maxActors` left part of that snapshot unchecked. */
+  truncated: boolean
   /** Actors examined this run. */
   examined: number
   /** Actors fully purged because they are no longer enrolled. */
@@ -86,6 +90,8 @@ export async function reconcileEnrollments(
   const actors = maxActors > 0 ? all.slice(0, maxActors) : all
 
   const summary: ReconcileSummary = {
+    total: all.length,
+    truncated: actors.length < all.length,
     examined: 0,
     unenrolled: 0,
     shrunk: 0,

--- a/stratos-feedgen/src/readiness.ts
+++ b/stratos-feedgen/src/readiness.ts
@@ -28,6 +28,7 @@ export class FeedReadinessGate implements FeedReadiness {
 
   markUnavailable(): void {
     this.ready = false
+    this.hasAuthoritativeSession = false
     this.generation++
   }
 
@@ -36,8 +37,8 @@ export class FeedReadinessGate implements FeedReadiness {
    * allowed to release reads, so invalidate any prior result first.
    */
   markSessionEstablished(): void {
-    this.hasAuthoritativeSession = true
     this.markUnavailable()
+    this.hasAuthoritativeSession = true
   }
 
   /** Mark reads unavailable and return the generation this run must satisfy. */

--- a/stratos-feedgen/src/readiness.ts
+++ b/stratos-feedgen/src/readiness.ts
@@ -1,0 +1,68 @@
+/**
+ * Read-side admission control for projections whose authorization state must
+ * be reconciled before they can be safely served.
+ */
+export interface FeedReadiness {
+  isReady: () => boolean
+}
+
+export interface ReconciliationOutcome {
+  errors: number
+  truncated: boolean
+}
+
+/**
+ * Starts unavailable so callers must explicitly release reads after an
+ * authoritative stream session and complete reconciliation. The generation
+ * fence prevents an older reconciliation from reopening reads after a newer
+ * disconnect or session transition.
+ */
+export class FeedReadinessGate implements FeedReadiness {
+  private ready = false
+  private generation = 0
+  private hasAuthoritativeSession = false
+
+  isReady(): boolean {
+    return this.ready
+  }
+
+  markUnavailable(): void {
+    this.ready = false
+    this.generation++
+  }
+
+  /**
+   * A service stream opened. Its follow-up reconciliation is the first one
+   * allowed to release reads, so invalidate any prior result first.
+   */
+  markSessionEstablished(): void {
+    this.hasAuthoritativeSession = true
+    this.markUnavailable()
+  }
+
+  /** Mark reads unavailable and return the generation this run must satisfy. */
+  beginReconciliation(): number {
+    this.ready = false
+    return this.generation
+  }
+
+  /**
+   * Release reads only when the run covers every persisted actor, has no
+   * authority errors, follows a service session, and is not superseded.
+   */
+  completeReconciliation(
+    generation: number,
+    outcome: ReconciliationOutcome,
+  ): boolean {
+    if (
+      !this.hasAuthoritativeSession ||
+      generation !== this.generation ||
+      outcome.errors > 0 ||
+      outcome.truncated
+    ) {
+      return false
+    }
+    this.ready = true
+    return true
+  }
+}

--- a/stratos-feedgen/src/server.ts
+++ b/stratos-feedgen/src/server.ts
@@ -13,6 +13,7 @@ import {
 } from './api/index.js'
 import { FEEDGEN_LEXICONS } from './lexicon/index.js'
 import type { FeedgenMetrics, SubscriptionStatus } from './metrics.js'
+import type { FeedReadiness } from './readiness.js'
 import {
   getRequestContext,
   requestIdMiddleware,
@@ -41,6 +42,8 @@ export interface FeedgenServerDeps {
   metricsToken?: string
   /** Late-bound subscription state reported by `/health`. */
   subscriptionStatus?: SubscriptionStatus
+  /** Optional fail-closed gate for projections pending authorization replay. */
+  feedReadiness?: FeedReadiness
 }
 
 export interface FeedgenHttpServer {
@@ -64,6 +67,7 @@ export function createFeedgenServer(
     store: deps.store,
     enrollmentManager: deps.enrollmentManager,
     verifier: deps.verifier,
+    readiness: deps.feedReadiness,
   })
 
   registerDescribeFeedHandler(xrpc, {

--- a/stratos-feedgen/src/subscription/index.ts
+++ b/stratos-feedgen/src/subscription/index.ts
@@ -1,4 +1,5 @@
 export * from './service-stream.js'
 export * from './indexer.js'
+export * from './replay-authorizer.js'
 export * from './actor-syncer.js'
 export * from './actor-pool.js'

--- a/stratos-feedgen/src/subscription/indexer.ts
+++ b/stratos-feedgen/src/subscription/indexer.ts
@@ -1,5 +1,6 @@
 import { extractBoundaries } from '@northskysocial/stratos-core'
 import type { BlobRef, FeedgenStore } from '../db/index.js'
+import type { ReplayAuthorizer } from './replay-authorizer.js'
 
 export const STRATOS_POST_COLLECTION = 'zone.stratos.feed.post'
 
@@ -27,11 +28,26 @@ export interface SubscriptionIndexerHooks {
   onPostIndexed?: () => void
 }
 
+export interface SubscriptionIndexerOptions extends SubscriptionIndexerHooks {
+  /**
+   * Optional while older callers are migrated. When present, replayed post
+   * boundaries are narrowed to the actor's current authorization before
+   * persistence.
+   */
+  replayAuthorizer?: ReplayAuthorizer
+}
+
 export class SubscriptionIndexer {
+  private readonly hooks: SubscriptionIndexerHooks
+  private readonly replayAuthorizer?: ReplayAuthorizer
+
   constructor(
     private store: FeedgenStore,
-    private hooks?: SubscriptionIndexerHooks,
-  ) {}
+    options: SubscriptionIndexerOptions = {},
+  ) {
+    this.hooks = options
+    this.replayAuthorizer = options.replayAuthorizer
+  }
 
   /**
    * Apply a single decoded commit to the store. All ops belonging to the
@@ -53,7 +69,17 @@ export class SubscriptionIndexer {
       if (op.record['$type'] !== STRATOS_POST_COLLECTION) continue
       const uri = `at://${did}/${path}`
       const sortAt = pickSortAt(op.record, time)
-      const boundaries = extractBoundaries(op.record)
+      const recordBoundaries = extractBoundaries(op.record)
+      const boundaries = this.replayAuthorizer
+        ? await this.replayAuthorizer.authorize(did, recordBoundaries)
+        : recordBoundaries
+      // An authorizer's empty result is a current-authority denial. Deleting
+      // any historical copy makes replay fail closed; the commit can then
+      // advance without reintroducing the forbidden record.
+      if (this.replayAuthorizer && boundaries.length === 0) {
+        await this.store.deletePost(uri)
+        continue
+      }
       const blobRefs = extractBlobRefs(op.record)
       await this.store.upsertPost({
         uri,
@@ -65,7 +91,7 @@ export class SubscriptionIndexer {
         blobRefs,
         boundaries,
       })
-      this.hooks?.onPostIndexed?.()
+      this.hooks.onPostIndexed?.()
     }
     await this.store.upsertCursor(did, seq, time)
   }

--- a/stratos-feedgen/src/subscription/replay-authorizer.ts
+++ b/stratos-feedgen/src/subscription/replay-authorizer.ts
@@ -17,11 +17,14 @@ export interface ReplayAuthorizer {
 }
 
 export interface CurrentMembershipReplayAuthorizerOptions {
-  /** Locally maintained enrollment snapshots. */
-  store: Pick<FeedgenStore, 'getEnrolledActor'>
   /**
-   * Deliberately the upstream client rather than EnrollmentManager: a
-   * disagreement with the local snapshot must bypass its TTL cache.
+   * Retained only for source compatibility with existing construction sites.
+   * Replay authorization never reads persisted membership snapshots.
+   */
+  store?: Pick<FeedgenStore, 'getEnrolledActor'>
+  /**
+   * Deliberately the upstream client rather than EnrollmentManager: every
+   * replay admission must bypass its TTL cache and resolve current authority.
    */
   client: Pick<UpstreamStratosClient, 'resolveEnrollments'>
   /** Boundaries this feed generator is configured to serve. */
@@ -30,18 +33,14 @@ export interface CurrentMembershipReplayAuthorizerOptions {
 
 /**
  * Authorizes records replayed from an actor subscription against the actor's
- * current enrollment. The first admission for each actor resolves authority
- * directly, so an unchanged on-disk snapshot cannot re-authorize old data.
- * Later admissions use that answer until the local snapshot changes.
+ * current enrollment. Every admission resolves authority directly, so a
+ * retained local snapshot or prior response cannot re-authorize old data.
  */
 export class CurrentMembershipReplayAuthorizer implements ReplayAuthorizer {
-  private readonly store: Pick<FeedgenStore, 'getEnrolledActor'>
   private readonly client: Pick<UpstreamStratosClient, 'resolveEnrollments'>
   private readonly configuredBoundaries: ReadonlySet<string>
-  private readonly authorityByDid = new Map<string, KnownAuthority>()
 
   constructor(opts: CurrentMembershipReplayAuthorizerOptions) {
-    this.store = opts.store
     this.client = opts.client
     this.configuredBoundaries = new Set(opts.configuredBoundaries)
   }
@@ -50,74 +49,21 @@ export class CurrentMembershipReplayAuthorizer implements ReplayAuthorizer {
     did: string,
     recordBoundaries: readonly string[],
   ): Promise<string[]> {
-    const requested = configuredRecordBoundaries(
-      recordBoundaries,
-      this.configuredBoundaries,
-    )
-    if (requested.length === 0) return []
-
-    const enrolledActor = await this.store.getEnrolledActor(did)
-    const snapshot: LocalMembershipSnapshot = {
-      present: enrolledActor !== null,
-      boundaries: configuredRecordBoundaries(
-        enrolledActor?.boundaries ?? [],
-        this.configuredBoundaries,
-      ),
-    }
-    const authority = await this.getCurrentAuthority(did, snapshot)
-    return requested.filter((boundary) => authority.boundaries.has(boundary))
-  }
-
-  private async getCurrentAuthority(
-    did: string,
-    snapshot: LocalMembershipSnapshot,
-  ): Promise<KnownAuthority> {
-    const known = this.authorityByDid.get(did)
-    if (known) {
-      // Keep a direct answer when the persisted snapshot is stale. A later
-      // snapshot is meaningful only if it differs from both the state we
-      // originally checked and the authority result we retained.
-      if (sameSnapshot(snapshot, known.snapshot)) {
-        return known
-      }
-      if (snapshotConfirmsAuthority(snapshot, known)) {
-        known.snapshot = snapshot
-        return known
-      }
-    }
-
     const resolved = await this.client.resolveEnrollments(did)
     assertValidResolution(did, resolved)
-    const authority: KnownAuthority = {
-      snapshot,
-      enrolled: resolved.enrolled,
-      boundaries: new Set(
-        resolved.enrolled
-          ? configuredRecordBoundaries(
-              resolved.boundaries,
-              this.configuredBoundaries,
-            )
-          : [],
+    if (!resolved.enrolled) return []
+
+    const authority = new Set(
+      configuredRecordBoundaries(
+        resolved.boundaries,
+        this.configuredBoundaries,
       ),
-    }
-    this.authorityByDid.set(did, authority)
-    return authority
+    )
+    return configuredRecordBoundaries(
+      recordBoundaries,
+      this.configuredBoundaries,
+    ).filter((boundary) => authority.has(boundary))
   }
-}
-
-interface KnownAuthority {
-  /** Local snapshot in effect when this direct authority answer was obtained. */
-  snapshot: LocalMembershipSnapshot
-  /** Whether the direct authority result says the actor remains enrolled. */
-  enrolled: boolean
-  /** Authoritative current configured-boundary membership. */
-  boundaries: ReadonlySet<string>
-}
-
-interface LocalMembershipSnapshot {
-  /** Absence is different from an enrolled actor with no configured boundaries. */
-  present: boolean
-  boundaries: string[]
 }
 
 function configuredRecordBoundaries(
@@ -132,36 +78,6 @@ function configuredRecordBoundaries(
     result.push(boundary)
   }
   return result
-}
-
-function sameBoundaries(
-  left: Iterable<string>,
-  right: Iterable<string>,
-): boolean {
-  const leftSet = new Set(left)
-  const rightSet = new Set(right)
-  if (leftSet.size !== rightSet.size) return false
-  return [...leftSet].every((boundary) => rightSet.has(boundary))
-}
-
-function sameSnapshot(
-  left: LocalMembershipSnapshot,
-  right: LocalMembershipSnapshot,
-): boolean {
-  return (
-    left.present === right.present &&
-    sameBoundaries(left.boundaries, right.boundaries)
-  )
-}
-
-function snapshotConfirmsAuthority(
-  snapshot: LocalMembershipSnapshot,
-  authority: KnownAuthority,
-): boolean {
-  return (
-    snapshot.present === authority.enrolled &&
-    sameBoundaries(snapshot.boundaries, authority.boundaries)
-  )
 }
 
 function assertValidResolution(

--- a/stratos-feedgen/src/subscription/replay-authorizer.ts
+++ b/stratos-feedgen/src/subscription/replay-authorizer.ts
@@ -1,0 +1,187 @@
+import { StratosError } from '@northskysocial/stratos-core'
+import type { FeedgenStore } from '../db/index.js'
+import type {
+  ResolveEnrollmentsResult,
+  UpstreamStratosClient,
+} from '../upstream/index.js'
+
+/**
+ * Decides which boundaries on a replayed actor-owned record can enter the
+ * local feed index. Returning no boundaries is a safe denial, not a failure.
+ */
+export interface ReplayAuthorizer {
+  authorize: (
+    did: string,
+    recordBoundaries: readonly string[],
+  ) => Promise<string[]>
+}
+
+export interface CurrentMembershipReplayAuthorizerOptions {
+  /** Locally maintained enrollment snapshots. */
+  store: Pick<FeedgenStore, 'getEnrolledActor'>
+  /**
+   * Deliberately the upstream client rather than EnrollmentManager: a
+   * disagreement with the local snapshot must bypass its TTL cache.
+   */
+  client: Pick<UpstreamStratosClient, 'resolveEnrollments'>
+  /** Boundaries this feed generator is configured to serve. */
+  configuredBoundaries: Iterable<string>
+}
+
+/**
+ * Authorizes records replayed from an actor subscription against the actor's
+ * current enrollment. The first admission for each actor resolves authority
+ * directly, so an unchanged on-disk snapshot cannot re-authorize old data.
+ * Later admissions use that answer until the local snapshot changes.
+ */
+export class CurrentMembershipReplayAuthorizer implements ReplayAuthorizer {
+  private readonly store: Pick<FeedgenStore, 'getEnrolledActor'>
+  private readonly client: Pick<UpstreamStratosClient, 'resolveEnrollments'>
+  private readonly configuredBoundaries: ReadonlySet<string>
+  private readonly authorityByDid = new Map<string, KnownAuthority>()
+
+  constructor(opts: CurrentMembershipReplayAuthorizerOptions) {
+    this.store = opts.store
+    this.client = opts.client
+    this.configuredBoundaries = new Set(opts.configuredBoundaries)
+  }
+
+  async authorize(
+    did: string,
+    recordBoundaries: readonly string[],
+  ): Promise<string[]> {
+    const requested = configuredRecordBoundaries(
+      recordBoundaries,
+      this.configuredBoundaries,
+    )
+    if (requested.length === 0) return []
+
+    const enrolledActor = await this.store.getEnrolledActor(did)
+    const snapshot: LocalMembershipSnapshot = {
+      present: enrolledActor !== null,
+      boundaries: configuredRecordBoundaries(
+        enrolledActor?.boundaries ?? [],
+        this.configuredBoundaries,
+      ),
+    }
+    const authority = await this.getCurrentAuthority(did, snapshot)
+    return requested.filter((boundary) => authority.boundaries.has(boundary))
+  }
+
+  private async getCurrentAuthority(
+    did: string,
+    snapshot: LocalMembershipSnapshot,
+  ): Promise<KnownAuthority> {
+    const known = this.authorityByDid.get(did)
+    if (known) {
+      // Keep a direct answer when the persisted snapshot is stale. A later
+      // snapshot is meaningful only if it differs from both the state we
+      // originally checked and the authority result we retained.
+      if (sameSnapshot(snapshot, known.snapshot)) {
+        return known
+      }
+      if (snapshotConfirmsAuthority(snapshot, known)) {
+        known.snapshot = snapshot
+        return known
+      }
+    }
+
+    const resolved = await this.client.resolveEnrollments(did)
+    assertValidResolution(did, resolved)
+    const authority: KnownAuthority = {
+      snapshot,
+      enrolled: resolved.enrolled,
+      boundaries: new Set(
+        resolved.enrolled
+          ? configuredRecordBoundaries(
+              resolved.boundaries,
+              this.configuredBoundaries,
+            )
+          : [],
+      ),
+    }
+    this.authorityByDid.set(did, authority)
+    return authority
+  }
+}
+
+interface KnownAuthority {
+  /** Local snapshot in effect when this direct authority answer was obtained. */
+  snapshot: LocalMembershipSnapshot
+  /** Whether the direct authority result says the actor remains enrolled. */
+  enrolled: boolean
+  /** Authoritative current configured-boundary membership. */
+  boundaries: ReadonlySet<string>
+}
+
+interface LocalMembershipSnapshot {
+  /** Absence is different from an enrolled actor with no configured boundaries. */
+  present: boolean
+  boundaries: string[]
+}
+
+function configuredRecordBoundaries(
+  recordBoundaries: readonly string[],
+  configuredBoundaries: ReadonlySet<string>,
+): string[] {
+  const result: string[] = []
+  const seen = new Set<string>()
+  for (const boundary of recordBoundaries) {
+    if (!configuredBoundaries.has(boundary) || seen.has(boundary)) continue
+    seen.add(boundary)
+    result.push(boundary)
+  }
+  return result
+}
+
+function sameBoundaries(
+  left: Iterable<string>,
+  right: Iterable<string>,
+): boolean {
+  const leftSet = new Set(left)
+  const rightSet = new Set(right)
+  if (leftSet.size !== rightSet.size) return false
+  return [...leftSet].every((boundary) => rightSet.has(boundary))
+}
+
+function sameSnapshot(
+  left: LocalMembershipSnapshot,
+  right: LocalMembershipSnapshot,
+): boolean {
+  return (
+    left.present === right.present &&
+    sameBoundaries(left.boundaries, right.boundaries)
+  )
+}
+
+function snapshotConfirmsAuthority(
+  snapshot: LocalMembershipSnapshot,
+  authority: KnownAuthority,
+): boolean {
+  return (
+    snapshot.present === authority.enrolled &&
+    sameBoundaries(snapshot.boundaries, authority.boundaries)
+  )
+}
+
+function assertValidResolution(
+  expectedDid: string,
+  resolution: unknown,
+): asserts resolution is ResolveEnrollmentsResult {
+  const raw =
+    resolution !== null && typeof resolution === 'object'
+      ? (resolution as Record<string, unknown>)
+      : undefined
+  const boundaries = raw?.['boundaries']
+  if (
+    raw?.['did'] !== expectedDid ||
+    typeof raw['enrolled'] !== 'boolean' ||
+    !Array.isArray(boundaries) ||
+    !boundaries.every((boundary: unknown) => typeof boundary === 'string')
+  ) {
+    throw new StratosError(
+      `invalid enrollment resolution for ${expectedDid}`,
+      'ACTOR_REPLAY_AUTHORITY_INVALID',
+    )
+  }
+}

--- a/stratos-feedgen/src/upstream/client.ts
+++ b/stratos-feedgen/src/upstream/client.ts
@@ -149,6 +149,7 @@ export class UpstreamStratosClient {
     const lxm = LXM.resolveEnrollments
     const res = await this.fetchImpl(url, {
       method: 'GET',
+      signal: AbortSignal.timeout(this.requestTimeoutMs),
       headers: {
         authorization: `Bearer ${await this.mintFor(lxm)}`,
         accept: 'application/json',

--- a/stratos-feedgen/tests/api-getFeed.test.ts
+++ b/stratos-feedgen/tests/api-getFeed.test.ts
@@ -167,6 +167,25 @@ describe('zone.stratos.feedgen.getFeed', () => {
     expect(ctx.listPosts).not.toHaveBeenCalled()
   })
 
+  it('fails closed if readiness changes during a feed read', async () => {
+    const readiness = {
+      isReady: vi
+        .fn<() => boolean>()
+        .mockReturnValueOnce(true)
+        .mockReturnValueOnce(true)
+        .mockReturnValueOnce(false),
+    }
+    ctx = await startServer({ readiness })
+
+    const res = await fetch(
+      `${ctx.baseUrl}/xrpc/zone.stratos.feedgen.getFeed?feed=eng-feed`,
+      { headers: { authorization: 'Bearer test-token' } },
+    )
+
+    expect(res.status).toBe(503)
+    expect(ctx.listPosts).toHaveBeenCalledOnce()
+  })
+
   it('returns hydrated feedViewPosts with cursor', async () => {
     const posts = [
       makePost(

--- a/stratos-feedgen/tests/api-getFeed.test.ts
+++ b/stratos-feedgen/tests/api-getFeed.test.ts
@@ -31,6 +31,7 @@ async function startServer(opts?: {
   viewerBoundaries?: string[]
   posts?: IndexedPost[]
   nextCursor?: string
+  readiness?: { isReady(): boolean }
   /** Override verifier to simulate auth failure or alternative viewer DIDs. */
   verifier?: FeedRequestVerifier
 }): Promise<TestServerCtx> {
@@ -79,6 +80,7 @@ async function startServer(opts?: {
       typeof createFeedgenServer
     >[0]['enrollmentManager'],
     verifier,
+    feedReadiness: opts?.readiness,
   })
 
   const httpServer = await server.listen(0, '127.0.0.1')
@@ -139,6 +141,30 @@ describe('zone.stratos.feedgen.getFeed', () => {
       limit: 50,
       cursor: undefined,
     })
+  })
+
+  it('fails closed while replay authorization is not ready', async () => {
+    ctx = await startServer({
+      readiness: { isReady: () => false },
+      posts: [
+        makePost(
+          'at://did:plc:fayevalentine/zone.stratos.feed.post/1',
+          FAYE_DID,
+          '2025-01-01T00:00:00.000Z',
+        ),
+      ],
+    })
+
+    const res = await fetch(
+      `${ctx.baseUrl}/xrpc/zone.stratos.feedgen.getFeed?feed=eng-feed`,
+      { headers: { authorization: 'Bearer test-token' } },
+    )
+
+    expect(res.status).toBe(503)
+    const body = (await res.json()) as { error: string; message: string }
+    expect(body.error).toBe('FeedNotReady')
+    expect(ctx.resolveBoundaries).not.toHaveBeenCalled()
+    expect(ctx.listPosts).not.toHaveBeenCalled()
   })
 
   it('returns hydrated feedViewPosts with cursor', async () => {

--- a/stratos-feedgen/tests/config.test.ts
+++ b/stratos-feedgen/tests/config.test.ts
@@ -1,3 +1,12 @@
+import {
+  linkSync,
+  mkdtempSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import {
   DEFAULT_SPACE_MEMBERSHIP_PAGE_LIMIT,
@@ -59,6 +68,14 @@ describe('loadFeedgenConfig SQLite storage split', () => {
       }),
     ).toThrow(/must be a file path/)
 
+    expect(() =>
+      loadFeedgenConfig({
+        ...baseEnv,
+        FEEDGEN_SQLITE_PATH: ':memory:',
+        FEEDGEN_MEMBERSHIP_SQLITE_PATH: ':memory:?cache=shared',
+      }),
+    ).toThrow(/must be a file path/)
+
     expect(
       loadFeedgenConfig({
         ...baseEnv,
@@ -75,6 +92,50 @@ describe('loadFeedgenConfig SQLite storage split', () => {
         FEEDGEN_MEMBERSHIP_SQLITE_PATH: baseEnv.FEEDGEN_SQLITE_PATH,
       }),
     ).toThrow(/must differ/)
+
+    expect(() =>
+      loadFeedgenConfig({
+        ...baseEnv,
+        FEEDGEN_MEMBERSHIP_SQLITE_PATH: '/tmp/./feedgen-bebop.sqlite',
+      }),
+    ).toThrow(/must differ/)
+  })
+
+  it('rejects a membership database symlink', () => {
+    const directory = mkdtempSync(join(tmpdir(), 'feedgen-config-'))
+    const recordPath = join(directory, 'record.sqlite')
+    const membershipPath = join(directory, 'membership.sqlite')
+    try {
+      symlinkSync(recordPath, membershipPath)
+      expect(() =>
+        loadFeedgenConfig({
+          ...baseEnv,
+          FEEDGEN_SQLITE_PATH: recordPath,
+          FEEDGEN_MEMBERSHIP_SQLITE_PATH: membershipPath,
+        }),
+      ).toThrow(/symbolic link/)
+    } finally {
+      rmSync(directory, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects membership and record hard links to the same file', () => {
+    const directory = mkdtempSync(join(tmpdir(), 'feedgen-config-'))
+    const recordPath = join(directory, 'record.sqlite')
+    const membershipPath = join(directory, 'membership.sqlite')
+    try {
+      writeFileSync(recordPath, '')
+      linkSync(recordPath, membershipPath)
+      expect(() =>
+        loadFeedgenConfig({
+          ...baseEnv,
+          FEEDGEN_SQLITE_PATH: recordPath,
+          FEEDGEN_MEMBERSHIP_SQLITE_PATH: membershipPath,
+        }),
+      ).toThrow(/must differ/)
+    } finally {
+      rmSync(directory, { recursive: true, force: true })
+    }
   })
 })
 

--- a/stratos-feedgen/tests/config.test.ts
+++ b/stratos-feedgen/tests/config.test.ts
@@ -96,6 +96,7 @@ describe('loadFeedgenConfig SQLite storage split', () => {
     expect(() =>
       loadFeedgenConfig({
         ...baseEnv,
+        FEEDGEN_SQLITE_PATH: '/tmp/feedgen-bebop.sqlite',
         FEEDGEN_MEMBERSHIP_SQLITE_PATH: '/tmp/./feedgen-bebop.sqlite',
       }),
     ).toThrow(/must differ/)

--- a/stratos-feedgen/tests/config.test.ts
+++ b/stratos-feedgen/tests/config.test.ts
@@ -24,6 +24,60 @@ const baseEnv = {
   FEEDGEN_SQLITE_PATH: '/tmp/feedgen-bebop.sqlite',
 }
 
+describe('loadFeedgenConfig SQLite storage split', () => {
+  it('derives a distinct sibling database for durable membership snapshots', () => {
+    const cfg = loadFeedgenConfig({ ...baseEnv })
+
+    expect(cfg.sqlitePath).toBe('/tmp/feedgen-bebop.sqlite')
+    expect(cfg.membershipSqlitePath).toBe(
+      '/tmp/feedgen-bebop.sqlite.membership',
+    )
+  })
+
+  it('keeps an explicitly configured membership database path', () => {
+    const cfg = loadFeedgenConfig({
+      ...baseEnv,
+      FEEDGEN_MEMBERSHIP_SQLITE_PATH: '/var/lib/feedgen/membership.sqlite',
+    })
+
+    expect(cfg.membershipSqlitePath).toBe('/var/lib/feedgen/membership.sqlite')
+  })
+
+  it('requires an explicit disk membership path for an in-memory record index', () => {
+    expect(() =>
+      loadFeedgenConfig({
+        ...baseEnv,
+        FEEDGEN_SQLITE_PATH: ':memory:',
+      }),
+    ).toThrow(/FEEDGEN_MEMBERSHIP_SQLITE_PATH/)
+
+    expect(() =>
+      loadFeedgenConfig({
+        ...baseEnv,
+        FEEDGEN_SQLITE_PATH: ':memory:',
+        FEEDGEN_MEMBERSHIP_SQLITE_PATH: ':memory:',
+      }),
+    ).toThrow(/must be a file path/)
+
+    expect(
+      loadFeedgenConfig({
+        ...baseEnv,
+        FEEDGEN_SQLITE_PATH: ':memory:',
+        FEEDGEN_MEMBERSHIP_SQLITE_PATH: '/var/lib/feedgen/membership.sqlite',
+      }).membershipSqlitePath,
+    ).toBe('/var/lib/feedgen/membership.sqlite')
+  })
+
+  it('rejects a membership database that aliases the record database', () => {
+    expect(() =>
+      loadFeedgenConfig({
+        ...baseEnv,
+        FEEDGEN_MEMBERSHIP_SQLITE_PATH: baseEnv.FEEDGEN_SQLITE_PATH,
+      }),
+    ).toThrow(/must differ/)
+  })
+})
+
 describe('loadFeedgenConfig space-sync defaults', () => {
   it('leaves request-timeout headroom above worst-case default host resolution', () => {
     const resolverWorkers = 10

--- a/stratos-feedgen/tests/db/sqlite.test.ts
+++ b/stratos-feedgen/tests/db/sqlite.test.ts
@@ -3,7 +3,9 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { sql } from 'drizzle-orm'
 import { afterAll, describe, expect, it } from 'vitest'
+import { loadFeedgenConfig } from '../../src/config.js'
 import {
+  createFeedgenStore,
   createSqliteDb,
   migrateSqliteDb,
   SqliteFeedgenStore,
@@ -16,6 +18,17 @@ async function makeTempDbPath(): Promise<string> {
   const dir = await mkdtemp(join(tmpdir(), 'feedgen-sqlite-'))
   tempDirs.push(dir)
   return join(dir, 'feedgen.sqlite')
+}
+
+function sqliteConfig(recordPath: string, membershipPath: string) {
+  return loadFeedgenConfig({
+    FEEDGEN_SERVICE_DID: 'did:web:feedgen.bebop.test',
+    FEEDGEN_SIGNING_KEY: 'unused-by-this-test',
+    STRATOS_SERVICE_URL: 'https://stratos.bebop.test',
+    STRATOS_SERVICE_DID: 'did:web:stratos.bebop.test',
+    FEEDGEN_SQLITE_PATH: recordPath,
+    FEEDGEN_MEMBERSHIP_SQLITE_PATH: membershipPath,
+  })
 }
 
 describeStoreContract('sqlite', {
@@ -59,5 +72,140 @@ describe('SQLite-specific behavior', () => {
     )
     expect(await store.getCursor('did:plc:idempotent')).toBe(1)
     await store.close()
+  })
+
+  it('persists only membership snapshots when the record store resets', async () => {
+    const recordPath = await makeTempDbPath()
+    const membershipPath = await makeTempDbPath()
+    const firstStore = await createFeedgenStore(
+      sqliteConfig(recordPath, membershipPath),
+    )
+    const did = 'did:plc:spikespiegel'
+    const spaceUri = `at://${did}/zone.stratos.space/bebop`
+    const indexedAt = '2024-01-01T00:00:00.000Z'
+
+    await firstStore.upsertPost({
+      uri: `at://${did}/zone.stratos.feed.post/1`,
+      did,
+      cid: 'bafyrecord',
+      sortAt: indexedAt,
+      indexedAt,
+      record: { text: 'See you, space cowboy.' },
+      blobRefs: [],
+      boundaries: ['bounty-hunters'],
+    })
+    await firstStore.upsertCursor(did, 42, indexedAt)
+    await firstStore.upsertSpaceCursor(spaceUri, did, 'cursor-42', indexedAt)
+    await firstStore.upsertEnrolledActor({
+      did,
+      boundaries: ['bounty-hunters'],
+      enrolledAt: indexedAt,
+      lastSeenAt: indexedAt,
+    })
+    await firstStore.replaceSpaceMembers('bounty-hunters', [
+      { did, custody: 'pds', host: 'https://bebop.example' },
+    ])
+    await firstStore.close()
+
+    await Promise.all([
+      rm(recordPath, { force: true }),
+      rm(`${recordPath}-shm`, { force: true }),
+      rm(`${recordPath}-wal`, { force: true }),
+    ])
+    const restartedStore = await createFeedgenStore(
+      sqliteConfig(recordPath, membershipPath),
+    )
+
+    expect(
+      await restartedStore.getPost(`at://${did}/zone.stratos.feed.post/1`),
+    ).toBeNull()
+    expect(await restartedStore.getCursor(did)).toBeNull()
+    expect(await restartedStore.getSpaceCursor(spaceUri, did)).toBeNull()
+    expect(await restartedStore.getEnrolledActor(did)).toEqual({
+      did,
+      boundaries: ['bounty-hunters'],
+      enrolledAt: indexedAt,
+      lastSeenAt: indexedAt,
+    })
+    expect(await restartedStore.listSpaceMembers('bounty-hunters')).toEqual([
+      { did, custody: 'pds', host: 'https://bebop.example' },
+    ])
+    await restartedStore.close()
+  })
+
+  it('imports legacy membership snapshots once without moving cursors', async () => {
+    const legacyPath = await makeTempDbPath()
+    const membershipPath = await makeTempDbPath()
+    const legacyDb = createSqliteDb(legacyPath)
+    await migrateSqliteDb(legacyDb)
+    const legacyStore = new SqliteFeedgenStore(legacyDb)
+    const did = 'did:plc:fayevalentine'
+    const spaceUri = `at://${did}/zone.stratos.space/bebop`
+    const indexedAt = '2024-01-01T00:00:00.000Z'
+
+    await legacyStore.upsertCursor(did, 99, indexedAt)
+    await legacyStore.upsertSpaceCursor(spaceUri, did, 'cursor-99', indexedAt)
+    await legacyStore.upsertEnrolledActor({
+      did,
+      boundaries: ['red-tail'],
+      enrolledAt: indexedAt,
+      lastSeenAt: indexedAt,
+    })
+    await legacyStore.replaceSpaceMembers('red-tail', [
+      { did, custody: 'pds', host: 'https://red-tail.example' },
+    ])
+
+    await legacyStore.close()
+    const firstSplitStore = await createFeedgenStore(
+      sqliteConfig(legacyPath, membershipPath),
+    )
+    expect(await firstSplitStore.getEnrolledActor(did)).toEqual({
+      did,
+      boundaries: ['red-tail'],
+      enrolledAt: indexedAt,
+      lastSeenAt: indexedAt,
+    })
+    await firstSplitStore.close()
+
+    const changedLegacyDb = createSqliteDb(legacyPath)
+    const changedLegacyStore = new SqliteFeedgenStore(changedLegacyDb)
+    await changedLegacyStore.upsertEnrolledActor({
+      did,
+      boundaries: ['changed-after-import'],
+      enrolledAt: indexedAt,
+      lastSeenAt: '2024-01-02T00:00:00.000Z',
+    })
+    await changedLegacyStore.close()
+
+    const restartedSplitStore = await createFeedgenStore(
+      sqliteConfig(legacyPath, membershipPath),
+    )
+    expect(await restartedSplitStore.getEnrolledActor(did)).toEqual({
+      did,
+      boundaries: ['red-tail'],
+      enrolledAt: indexedAt,
+      lastSeenAt: indexedAt,
+    })
+    expect(await restartedSplitStore.listSpaceMembers('red-tail')).toEqual([
+      { did, custody: 'pds', host: 'https://red-tail.example' },
+    ])
+    await restartedSplitStore.close()
+
+    const membershipDb = createSqliteDb(membershipPath)
+    expect(
+      await membershipDb.all<{ name: string }>(sql`
+        SELECT name
+        FROM sqlite_master
+        WHERE type = 'table' AND name = 'sync_cursor'
+      `),
+    ).toEqual([])
+    expect(
+      await membershipDb.all<{ name: string }>(sql`
+        SELECT name
+        FROM sqlite_master
+        WHERE type = 'table' AND name = 'space_sync_cursor'
+      `),
+    ).toEqual([])
+    membershipDb._client.close()
   })
 })

--- a/stratos-feedgen/tests/db/sqlite.test.ts
+++ b/stratos-feedgen/tests/db/sqlite.test.ts
@@ -192,18 +192,18 @@ describe('SQLite-specific behavior', () => {
     await restartedSplitStore.close()
 
     const membershipDb = createSqliteDb(membershipPath)
+    await membershipDb._initialized
     expect(
       await membershipDb.all<{ name: string }>(sql`
         SELECT name
         FROM sqlite_master
-        WHERE type = 'table' AND name = 'sync_cursor'
-      `),
-    ).toEqual([])
-    expect(
-      await membershipDb.all<{ name: string }>(sql`
-        SELECT name
-        FROM sqlite_master
-        WHERE type = 'table' AND name = 'space_sync_cursor'
+        WHERE type = 'table'
+          AND name IN (
+            'sync_cursor',
+            'space_sync_cursor',
+            'space_sync_pending_verification',
+            'space_sync_stage'
+          )
       `),
     ).toEqual([])
     membershipDb._client.close()

--- a/stratos-feedgen/tests/readiness.test.ts
+++ b/stratos-feedgen/tests/readiness.test.ts
@@ -57,4 +57,17 @@ describe('FeedReadinessGate', () => {
     ).toBe(false)
     expect(gate.isReady()).toBe(false)
   })
+
+  it('requires a new session after becoming unavailable', () => {
+    const gate = new FeedReadinessGate()
+    gate.markSessionEstablished()
+    gate.markUnavailable()
+
+    const generation = gate.beginReconciliation()
+
+    expect(
+      gate.completeReconciliation(generation, { errors: 0, truncated: false }),
+    ).toBe(false)
+    expect(gate.isReady()).toBe(false)
+  })
 })

--- a/stratos-feedgen/tests/readiness.test.ts
+++ b/stratos-feedgen/tests/readiness.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+
+import { FeedReadinessGate } from '../src/readiness.js'
+
+describe('FeedReadinessGate', () => {
+  it('starts unavailable until a stream session completes reconciliation', () => {
+    const gate = new FeedReadinessGate()
+
+    expect(gate.isReady()).toBe(false)
+
+    const beforeSession = gate.beginReconciliation()
+    expect(
+      gate.completeReconciliation(beforeSession, {
+        errors: 0,
+        truncated: false,
+      }),
+    ).toBe(false)
+    expect(gate.isReady()).toBe(false)
+
+    gate.markSessionEstablished()
+    const afterSession = gate.beginReconciliation()
+    expect(
+      gate.completeReconciliation(afterSession, {
+        errors: 0,
+        truncated: false,
+      }),
+    ).toBe(true)
+    expect(gate.isReady()).toBe(true)
+
+    gate.markUnavailable()
+    expect(gate.isReady()).toBe(false)
+  })
+
+  it('does not release after incomplete or superseded reconciliation', () => {
+    const gate = new FeedReadinessGate()
+    gate.markSessionEstablished()
+
+    const failed = gate.beginReconciliation()
+    expect(
+      gate.completeReconciliation(failed, { errors: 1, truncated: false }),
+    ).toBe(false)
+    expect(gate.isReady()).toBe(false)
+
+    const partial = gate.beginReconciliation()
+    expect(
+      gate.completeReconciliation(partial, { errors: 0, truncated: true }),
+    ).toBe(false)
+    expect(gate.isReady()).toBe(false)
+
+    const olderGeneration = gate.beginReconciliation()
+    gate.markUnavailable()
+    expect(
+      gate.completeReconciliation(olderGeneration, {
+        errors: 0,
+        truncated: false,
+      }),
+    ).toBe(false)
+    expect(gate.isReady()).toBe(false)
+  })
+})

--- a/stratos-feedgen/tests/reconcile.test.ts
+++ b/stratos-feedgen/tests/reconcile.test.ts
@@ -133,6 +133,8 @@ describe('reconcileEnrollments', () => {
       await store.getPost(`at://${VASH}/zone.stratos.feed.post/1`),
     ).not.toBeNull()
 
+    expect(summary.total).toBe(3)
+    expect(summary.truncated).toBe(false)
     expect(summary.examined).toBe(3)
     expect(summary.unenrolled).toBe(1)
     expect(summary.shrunk).toBe(1)
@@ -161,6 +163,8 @@ describe('reconcileEnrollments', () => {
       { maxActors: 4, batchSize: 2 },
     )
     expect(summary.examined).toBe(4)
+    expect(summary.total).toBe(10)
+    expect(summary.truncated).toBe(true)
     expect(client.resolveEnrollments).toHaveBeenCalledTimes(4)
   })
 

--- a/stratos-feedgen/tests/replay-authorizer.test.ts
+++ b/stratos-feedgen/tests/replay-authorizer.test.ts
@@ -66,7 +66,6 @@ function makeIndexer(
 } {
   const resolver = vi.fn(resolveEnrollments)
   const authorizer = new CurrentMembershipReplayAuthorizer({
-    store,
     client: { resolveEnrollments: resolver },
     configuredBoundaries: [ALPHA, BETA],
   })
@@ -123,21 +122,24 @@ afterEach(async () => {
 })
 
 describe('CurrentMembershipReplayAuthorizer', () => {
-  it('uses a matching local snapshot after its first authoritative resolve', async () => {
+  it('re-resolves every admission even when a local snapshot stays unchanged', async () => {
     await store.upsertEnrolledActor(enrollment([ALPHA]))
-    const { indexer, resolveEnrollments } = makeIndexer(async () =>
-      resolution([ALPHA]),
-    )
+    const resolutions = [resolution([ALPHA]), resolution([BETA])]
+    const { indexer, resolveEnrollments } = makeIndexer(async () => {
+      const next = resolutions.shift()
+      if (!next) throw new Error('unexpected authority resolve')
+      return next
+    })
 
     await applyPost(indexer, 1, [ALPHA, UNCONFIGURED])
-    await applyPost(indexer, 2, [ALPHA], 'update')
+    await applyPost(indexer, 2, [BETA], 'update')
 
-    expect(resolveEnrollments).toHaveBeenCalledOnce()
-    expect((await store.getPost(URI))?.boundaries).toEqual([ALPHA])
+    expect(resolveEnrollments).toHaveBeenCalledTimes(2)
+    expect((await store.getPost(URI))?.boundaries).toEqual([BETA])
     expect(await store.getCursor(FAYE)).toBe(2)
   })
 
-  it('resolves directly when no local snapshot exists', async () => {
+  it('resolves directly when no persisted snapshot exists', async () => {
     const { indexer, resolveEnrollments } = makeIndexer(async () =>
       resolution([ALPHA]),
     )
@@ -149,7 +151,7 @@ describe('CurrentMembershipReplayAuthorizer', () => {
     expect((await store.getPost(URI))?.boundaries).toEqual([ALPHA])
   })
 
-  it('resolves directly when the local snapshot is empty', async () => {
+  it('resolves directly despite an empty persisted snapshot', async () => {
     await store.upsertEnrolledActor(enrollment([]))
     const { indexer, resolveEnrollments } = makeIndexer(async () =>
       resolution([ALPHA]),
@@ -161,7 +163,19 @@ describe('CurrentMembershipReplayAuthorizer', () => {
     expect((await store.getPost(URI))?.boundaries).toEqual([ALPHA])
   })
 
-  it('denies a historical alpha post after membership changed to beta', async () => {
+  it('checks authority before denying a record with no configured boundary', async () => {
+    const { indexer, resolveEnrollments } = makeIndexer(async () =>
+      resolution([ALPHA]),
+    )
+
+    await applyPost(indexer, 1, [UNCONFIGURED])
+
+    expect(resolveEnrollments).toHaveBeenCalledOnce()
+    expect(await store.getPost(URI)).toBeNull()
+    expect(await store.getCursor(FAYE)).toBe(1)
+  })
+
+  it('denies a historical alpha post when current authority grants beta', async () => {
     await seedPost([ALPHA])
     await store.upsertCursor(FAYE, 7, '2024-01-01T00:00:00.000Z')
     await store.upsertEnrolledActor(enrollment([BETA]))
@@ -176,7 +190,7 @@ describe('CurrentMembershipReplayAuthorizer', () => {
     expect(await store.getCursor(FAYE)).toBe(8)
   })
 
-  it('does not trust a matching stale snapshot and retains its direct denial', async () => {
+  it('does not trust a matching stale snapshot on later admissions', async () => {
     await seedPost([ALPHA])
     await store.upsertEnrolledActor(enrollment([ALPHA]))
     const { indexer, resolveEnrollments } = makeIndexer(async () =>
@@ -186,12 +200,12 @@ describe('CurrentMembershipReplayAuthorizer', () => {
     await applyPost(indexer, 8, [ALPHA], 'update')
     await applyPost(indexer, 9, [BETA])
 
-    expect(resolveEnrollments).toHaveBeenCalledOnce()
+    expect(resolveEnrollments).toHaveBeenCalledTimes(2)
     expect((await store.getPost(URI))?.boundaries).toEqual([BETA])
     expect(await store.getCursor(FAYE)).toBe(9)
   })
 
-  it('admits a newly granted beta post after an alpha to alpha-plus-beta change', async () => {
+  it('admits a newly granted beta post from current authority', async () => {
     await store.upsertEnrolledActor(enrollment([ALPHA]))
     const { indexer, resolveEnrollments } = makeIndexer(async () =>
       resolution([ALPHA, BETA]),
@@ -204,7 +218,7 @@ describe('CurrentMembershipReplayAuthorizer', () => {
     expect(await store.getCursor(FAYE)).toBe(1)
   })
 
-  it('resolves again when a later local snapshot disagrees with authority', async () => {
+  it('takes fresh authority over a later persisted snapshot change', async () => {
     await store.upsertEnrolledActor(enrollment([ALPHA]))
     const resolutions = [resolution([ALPHA]), resolution([BETA])]
     const { indexer, resolveEnrollments } = makeIndexer(async () => {
@@ -221,7 +235,7 @@ describe('CurrentMembershipReplayAuthorizer', () => {
     expect((await store.getPost(URI))?.boundaries).toEqual([BETA])
   })
 
-  it('re-resolves when an absent snapshot becomes an enrolled empty snapshot', async () => {
+  it('takes fresh authority when persisted enrollment changes', async () => {
     const resolutions = [resolution([ALPHA]), resolution([])]
     const { indexer, resolveEnrollments } = makeIndexer(async () => {
       const next = resolutions.shift()

--- a/stratos-feedgen/tests/replay-authorizer.test.ts
+++ b/stratos-feedgen/tests/replay-authorizer.test.ts
@@ -1,0 +1,303 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  createSqliteDb,
+  type FeedgenStore,
+  migrateSqliteDb,
+  SqliteFeedgenStore,
+} from '../src/db/index.js'
+import {
+  CurrentMembershipReplayAuthorizer,
+  SubscriptionIndexer,
+} from '../src/subscription/index.js'
+import type { ResolveEnrollmentsResult } from '../src/upstream/index.js'
+
+const FAYE = 'did:plc:fayevalentine'
+const STRATOS_DID = 'did:web:stratos.test'
+const ALPHA = `${STRATOS_DID}/alpha`
+const BETA = `${STRATOS_DID}/beta`
+const UNCONFIGURED = `${STRATOS_DID}/unconfigured`
+const POST_PATH = 'zone.stratos.feed.post/replay-test'
+const URI = `at://${FAYE}/${POST_PATH}`
+
+let store: FeedgenStore
+const tmpDirs: string[] = []
+
+async function makeStore(): Promise<FeedgenStore> {
+  const dir = await mkdtemp(join(tmpdir(), 'feedgen-replay-auth-'))
+  tmpDirs.push(dir)
+  const db = createSqliteDb(join(dir, 'feedgen.sqlite'))
+  await migrateSqliteDb(db)
+  return new SqliteFeedgenStore(db)
+}
+
+function record(boundaries: string[]): Record<string, unknown> {
+  return {
+    $type: 'zone.stratos.feed.post',
+    text: 'see you space cowboy',
+    createdAt: '2024-01-01T00:00:00.000Z',
+    boundary: { values: boundaries.map((value) => ({ value })) },
+  }
+}
+
+function enrollment(boundaries: string[]) {
+  return {
+    did: FAYE,
+    boundaries,
+    enrolledAt: '2024-01-01T00:00:00.000Z',
+    lastSeenAt: '2024-01-01T00:00:00.000Z',
+  }
+}
+
+function resolution(
+  boundaries: string[],
+  enrolled = true,
+): ResolveEnrollmentsResult {
+  return { did: FAYE, enrolled, boundaries }
+}
+
+function makeIndexer(
+  resolveEnrollments: (did: string) => Promise<ResolveEnrollmentsResult>,
+): {
+  indexer: SubscriptionIndexer
+  resolveEnrollments: ReturnType<typeof vi.fn>
+} {
+  const resolver = vi.fn(resolveEnrollments)
+  const authorizer = new CurrentMembershipReplayAuthorizer({
+    store,
+    client: { resolveEnrollments: resolver },
+    configuredBoundaries: [ALPHA, BETA],
+  })
+  return {
+    indexer: new SubscriptionIndexer(store, { replayAuthorizer: authorizer }),
+    resolveEnrollments: resolver,
+  }
+}
+
+async function applyPost(
+  indexer: SubscriptionIndexer,
+  seq: number,
+  boundaries: string[],
+  action: 'create' | 'update' = 'create',
+): Promise<void> {
+  await indexer.applyCommit({
+    did: FAYE,
+    seq,
+    time: '2024-01-02T00:00:00.000Z',
+    ops: [
+      {
+        action,
+        path: POST_PATH,
+        cid: `bafy${seq}`,
+        record: record(boundaries),
+      },
+    ],
+  })
+}
+
+async function seedPost(boundaries: string[]): Promise<void> {
+  await store.upsertPost({
+    uri: URI,
+    did: FAYE,
+    cid: 'bafy-existing',
+    sortAt: '2024-01-01T00:00:00.000Z',
+    indexedAt: '2024-01-01T00:00:00.000Z',
+    record: record(boundaries),
+    blobRefs: [],
+    boundaries,
+  })
+}
+
+beforeEach(async () => {
+  store = await makeStore()
+})
+
+afterEach(async () => {
+  await store.close()
+  for (const dir of tmpDirs) {
+    await rm(dir, { recursive: true, force: true })
+  }
+  tmpDirs.length = 0
+})
+
+describe('CurrentMembershipReplayAuthorizer', () => {
+  it('uses a matching local snapshot after its first authoritative resolve', async () => {
+    await store.upsertEnrolledActor(enrollment([ALPHA]))
+    const { indexer, resolveEnrollments } = makeIndexer(async () =>
+      resolution([ALPHA]),
+    )
+
+    await applyPost(indexer, 1, [ALPHA, UNCONFIGURED])
+    await applyPost(indexer, 2, [ALPHA], 'update')
+
+    expect(resolveEnrollments).toHaveBeenCalledOnce()
+    expect((await store.getPost(URI))?.boundaries).toEqual([ALPHA])
+    expect(await store.getCursor(FAYE)).toBe(2)
+  })
+
+  it('resolves directly when no local snapshot exists', async () => {
+    const { indexer, resolveEnrollments } = makeIndexer(async () =>
+      resolution([ALPHA]),
+    )
+
+    await applyPost(indexer, 1, [ALPHA])
+
+    expect(resolveEnrollments).toHaveBeenCalledOnce()
+    expect(resolveEnrollments).toHaveBeenCalledWith(FAYE)
+    expect((await store.getPost(URI))?.boundaries).toEqual([ALPHA])
+  })
+
+  it('resolves directly when the local snapshot is empty', async () => {
+    await store.upsertEnrolledActor(enrollment([]))
+    const { indexer, resolveEnrollments } = makeIndexer(async () =>
+      resolution([ALPHA]),
+    )
+
+    await applyPost(indexer, 1, [ALPHA])
+
+    expect(resolveEnrollments).toHaveBeenCalledOnce()
+    expect((await store.getPost(URI))?.boundaries).toEqual([ALPHA])
+  })
+
+  it('denies a historical alpha post after membership changed to beta', async () => {
+    await seedPost([ALPHA])
+    await store.upsertCursor(FAYE, 7, '2024-01-01T00:00:00.000Z')
+    await store.upsertEnrolledActor(enrollment([BETA]))
+    const { indexer, resolveEnrollments } = makeIndexer(async () =>
+      resolution([BETA]),
+    )
+
+    await applyPost(indexer, 8, [ALPHA], 'update')
+
+    expect(resolveEnrollments).toHaveBeenCalledOnce()
+    expect(await store.getPost(URI)).toBeNull()
+    expect(await store.getCursor(FAYE)).toBe(8)
+  })
+
+  it('does not trust a matching stale snapshot and retains its direct denial', async () => {
+    await seedPost([ALPHA])
+    await store.upsertEnrolledActor(enrollment([ALPHA]))
+    const { indexer, resolveEnrollments } = makeIndexer(async () =>
+      resolution([BETA]),
+    )
+
+    await applyPost(indexer, 8, [ALPHA], 'update')
+    await applyPost(indexer, 9, [BETA])
+
+    expect(resolveEnrollments).toHaveBeenCalledOnce()
+    expect((await store.getPost(URI))?.boundaries).toEqual([BETA])
+    expect(await store.getCursor(FAYE)).toBe(9)
+  })
+
+  it('admits a newly granted beta post after an alpha to alpha-plus-beta change', async () => {
+    await store.upsertEnrolledActor(enrollment([ALPHA]))
+    const { indexer, resolveEnrollments } = makeIndexer(async () =>
+      resolution([ALPHA, BETA]),
+    )
+
+    await applyPost(indexer, 1, [BETA])
+
+    expect(resolveEnrollments).toHaveBeenCalledOnce()
+    expect((await store.getPost(URI))?.boundaries).toEqual([BETA])
+    expect(await store.getCursor(FAYE)).toBe(1)
+  })
+
+  it('resolves again when a later local snapshot disagrees with authority', async () => {
+    await store.upsertEnrolledActor(enrollment([ALPHA]))
+    const resolutions = [resolution([ALPHA]), resolution([BETA])]
+    const { indexer, resolveEnrollments } = makeIndexer(async () => {
+      const next = resolutions.shift()
+      if (!next) throw new Error('unexpected authority resolve')
+      return next
+    })
+
+    await applyPost(indexer, 1, [ALPHA])
+    await store.upsertEnrolledActor(enrollment([BETA]))
+    await applyPost(indexer, 2, [BETA], 'update')
+
+    expect(resolveEnrollments).toHaveBeenCalledTimes(2)
+    expect((await store.getPost(URI))?.boundaries).toEqual([BETA])
+  })
+
+  it('re-resolves when an absent snapshot becomes an enrolled empty snapshot', async () => {
+    const resolutions = [resolution([ALPHA]), resolution([])]
+    const { indexer, resolveEnrollments } = makeIndexer(async () => {
+      const next = resolutions.shift()
+      if (!next) throw new Error('unexpected authority resolve')
+      return next
+    })
+
+    await applyPost(indexer, 1, [ALPHA])
+    await store.upsertEnrolledActor(enrollment([]))
+    await applyPost(indexer, 2, [ALPHA], 'update')
+
+    expect(resolveEnrollments).toHaveBeenCalledTimes(2)
+    expect(await store.getPost(URI)).toBeNull()
+    expect(await store.getCursor(FAYE)).toBe(2)
+  })
+
+  it('denies a valid unenrolled response and removes a historical post', async () => {
+    await seedPost([ALPHA])
+    await store.upsertEnrolledActor(enrollment([BETA]))
+    const { indexer } = makeIndexer(async () => resolution([], false))
+
+    await applyPost(indexer, 8, [ALPHA], 'update')
+
+    expect(await store.getPost(URI)).toBeNull()
+    expect(await store.getCursor(FAYE)).toBe(8)
+  })
+
+  it('throws and leaves the cursor unchanged when authority resolution fails', async () => {
+    await store.upsertEnrolledActor(enrollment([BETA]))
+    const { indexer } = makeIndexer(async () => {
+      throw new Error('authority unavailable')
+    })
+
+    await expect(applyPost(indexer, 1, [ALPHA])).rejects.toThrow(
+      'authority unavailable',
+    )
+
+    expect(await store.getPost(URI)).toBeNull()
+    expect(await store.getCursor(FAYE)).toBeNull()
+  })
+
+  it('throws and leaves the cursor unchanged for a malformed authority response', async () => {
+    await store.upsertEnrolledActor(enrollment([BETA]))
+    const { indexer } = makeIndexer(
+      async () =>
+        ({
+          did: FAYE,
+          enrolled: true,
+          boundaries: [ALPHA, 42],
+        }) as unknown as ResolveEnrollmentsResult,
+    )
+
+    await expect(applyPost(indexer, 1, [ALPHA])).rejects.toMatchObject({
+      code: 'ACTOR_REPLAY_AUTHORITY_INVALID',
+    })
+
+    expect(await store.getPost(URI)).toBeNull()
+    expect(await store.getCursor(FAYE)).toBeNull()
+  })
+
+  it('always applies a delete op without resolving authority', async () => {
+    await seedPost([ALPHA])
+    await store.upsertEnrolledActor(enrollment([BETA]))
+    const { indexer, resolveEnrollments } = makeIndexer(async () => {
+      throw new Error('delete must not resolve authority')
+    })
+
+    await indexer.applyCommit({
+      did: FAYE,
+      seq: 8,
+      time: '2024-01-02T00:00:00.000Z',
+      ops: [{ action: 'delete', path: POST_PATH }],
+    })
+
+    expect(resolveEnrollments).not.toHaveBeenCalled()
+    expect(await store.getPost(URI)).toBeNull()
+    expect(await store.getCursor(FAYE)).toBe(8)
+  })
+})

--- a/stratos-feedgen/tests/upstream.test.ts
+++ b/stratos-feedgen/tests/upstream.test.ts
@@ -169,17 +169,19 @@ describe('UpstreamStratosClient', () => {
     })
 
     it('bounds the authority request with the configured timeout', async () => {
-      const fetchImpl = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
-        expect(init?.signal).toBeInstanceOf(AbortSignal)
-        return new Response(
-          JSON.stringify({
-            did: 'did:plc:user',
-            enrolled: true,
-            boundaries: ['engineering'],
-          }),
-          { headers: { 'content-type': 'application/json' } },
-        )
-      })
+      const fetchImpl = vi.fn(
+        async (_input: RequestInfo | URL, init?: RequestInit) => {
+          expect(init?.signal).toBeInstanceOf(AbortSignal)
+          return new Response(
+            JSON.stringify({
+              did: 'did:plc:user',
+              enrolled: true,
+              boundaries: ['engineering'],
+            }),
+            { headers: { 'content-type': 'application/json' } },
+          )
+        },
+      )
       const timedClient = new UpstreamStratosClient({
         serviceUrl: mock.baseUrl,
         serviceDid: STRATOS_DID,

--- a/stratos-feedgen/tests/upstream.test.ts
+++ b/stratos-feedgen/tests/upstream.test.ts
@@ -5,7 +5,7 @@ import {
   Server,
   ServerResponse,
 } from 'node:http'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { Secp256k1Keypair } from '@atproto/crypto'
 import { StratosError } from '@northskysocial/stratos-core'
 
@@ -166,6 +166,31 @@ describe('UpstreamStratosClient', () => {
         body: 'upstream down',
         lxm: 'zone.stratos.identity.resolveEnrollments',
       })
+    })
+
+    it('bounds the authority request with the configured timeout', async () => {
+      const fetchImpl = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+        expect(init?.signal).toBeInstanceOf(AbortSignal)
+        return new Response(
+          JSON.stringify({
+            did: 'did:plc:user',
+            enrolled: true,
+            boundaries: ['engineering'],
+          }),
+          { headers: { 'content-type': 'application/json' } },
+        )
+      })
+      const timedClient = new UpstreamStratosClient({
+        serviceUrl: mock.baseUrl,
+        serviceDid: STRATOS_DID,
+        feedgenDid: FEEDGEN_DID,
+        keypair,
+        fetch: fetchImpl as typeof fetch,
+        requestTimeoutMs: 1_000,
+      })
+
+      await timedClient.resolveEnrollments('did:plc:user')
+      expect(fetchImpl).toHaveBeenCalledOnce()
     })
   })
 


### PR DESCRIPTION
## Summary
- split durable enrollment and space-member snapshots from the ephemeral record and cursor projection, without migrating cursors
- authorize replayed actor records against current upstream membership on every replay
- fail closed with `FeedNotReady` until a live subscription session completes an authoritative, uncapped reconciliation

## Validation
- `pnpm --filter @northskysocial/stratos-feedgen test`
- `pnpm --filter @northskysocial/stratos-feedgen typecheck`
- `pnpm --filter @northskysocial/stratos-feedgen build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Feed serving now waits for enrollment state to be established and reconciled before becoming available.
  - Historical posts are rechecked against current membership, preventing unauthorized content from being replayed.
  - Membership data remains available independently from feed records during record-store resets.

- **Bug Fixes**
  - Requests made while the feed is not ready now return a clear `503 FeedNotReady` response.
  - Enrollment lookups now respect the configured request timeout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->